### PR TITLE
Update swagger version

### DIFF
--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -59,13 +59,13 @@
     <dependency>
       <groupId>io.springfox</groupId>
       <artifactId>springfox-swagger2</artifactId>
-      <version>2.3.1</version>
+      <version>2.7.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.springfox</groupId>
       <artifactId>springfox-swagger-ui</artifactId>
-      <version>2.3.1</version>
+      <version>2.7.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
For generation of typescript client in cbioportal/cbioportal-frontend it is
essential to have a newer version of Swagger, otherwise all objects returned by
the API have `any` type.