### PR TITLE
Added name and description info for PFAM domains

### DIFF
--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/PfamA.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/PfamA.java
@@ -1,0 +1,46 @@
+package org.cbioportal.genome_nexus.annotation.domain;
+
+import com.univocity.parsers.annotations.Parsed;
+import com.univocity.parsers.annotations.Trim;
+
+/**
+ * @author Selcuk Onur Sumer
+ */
+public class PfamA
+{
+    @Trim
+    @Parsed(field = "pfamA_acc")
+    private String pfamAccession;
+
+    @Trim
+    @Parsed(field = "pfamA_id")
+    private String pfamId;
+
+    @Trim
+    @Parsed(field = "description")
+    private String pfamDescription;
+
+    public String getPfamAccession() {
+        return pfamAccession;
+    }
+
+    public void setPfamAccession(String pfamAccession) {
+        this.pfamAccession = pfamAccession;
+    }
+
+    public String getPfamId() {
+        return pfamId;
+    }
+
+    public void setPfamId(String pfamId) {
+        this.pfamId = pfamId;
+    }
+
+    public String getPfamDescription() {
+        return pfamDescription;
+    }
+
+    public void setPfamDescription(String pfamDescription) {
+        this.pfamDescription = pfamDescription;
+    }
+}

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/PfamDomain.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/PfamDomain.java
@@ -46,6 +46,12 @@ public class PfamDomain
     @ApiModelProperty(value = "PFAM domain end")
     private String getPfamDomainEnd;
 
+    @ApiModelProperty(value = "PFAM domain name")
+    private String pfamDomainName;
+
+    @ApiModelProperty(value = "PFAM domain description")
+    private String pfamDomainDescription;
+
     public String getGeneId() {
         return geneId;
     }
@@ -100,5 +106,21 @@ public class PfamDomain
 
     public void setGetPfamDomainEnd(String getPfamDomainEnd) {
         this.getPfamDomainEnd = getPfamDomainEnd;
+    }
+
+    public String getPfamDomainName() {
+        return pfamDomainName;
+    }
+
+    public void setPfamDomainName(String pfamDomainName) {
+        this.pfamDomainName = pfamDomainName;
+    }
+
+    public String getPfamDomainDescription() {
+        return pfamDomainDescription;
+    }
+
+    public void setPfamDomainDescription(String pfamDomainDescription) {
+        this.pfamDomainDescription = pfamDomainDescription;
     }
 }

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/web/PfamController.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/web/PfamController.java
@@ -30,7 +30,7 @@ public class PfamController
 
     @ApiOperation(value = "Retrieves all PFAM domains",
         nickname = "fetchAllPfamDomainsGET")
-    @RequestMapping(value = "/pfam/allDomains",
+    @RequestMapping(value = "/pfam/domain",
         method = RequestMethod.GET,
         produces = "application/json")
     public List<PfamDomain> fetchAllPfamDomainsGET()
@@ -40,7 +40,7 @@ public class PfamController
 
     @ApiOperation(value = "Retrieves PFAM domains by Ensembl transcript IDs",
         nickname = "fetchPfamDomainsByTranscriptIdsPOST")
-    @RequestMapping(value = "/pfam/byTranscript",
+    @RequestMapping(value = "/pfam/domain/transcript",
         method = RequestMethod.POST,
         produces = "application/json")
     public List<PfamDomain> fetchPfamDomainsByTranscriptIdsPOST(
@@ -61,7 +61,7 @@ public class PfamController
 
     @ApiOperation(value = "Retrieves PFAM domains by an Ensembl transcript ID",
         nickname = "fetchPfamDomainsByTranscriptIdGET")
-    @RequestMapping(value = "/pfam/byTranscript/{transcriptId}",
+    @RequestMapping(value = "/pfam/domain/transcript/{transcriptId}",
         method = RequestMethod.GET,
         produces = "application/json")
     public List<PfamDomain> fetchPfamDomainsByTranscriptIdsGET(
@@ -75,7 +75,7 @@ public class PfamController
 
     @ApiOperation(value = "Retrieves PFAM domains by Ensembl protein IDs",
         nickname = "fetchPfamDomainsByProteinIdsPOST")
-    @RequestMapping(value = "/pfam/byProtein",
+    @RequestMapping(value = "/pfam/domain/protein",
         method = RequestMethod.POST,
         produces = "application/json")
     public List<PfamDomain> fetchPfamDomainsByProteinIdsPOST(
@@ -96,7 +96,7 @@ public class PfamController
 
     @ApiOperation(value = "Retrieves PFAM domains by an Ensembl protein ID",
         nickname = "fetchPfamDomainsByProteinIdGET")
-    @RequestMapping(value = "/pfam/byProtein/{proteinId}",
+    @RequestMapping(value = "/pfam/domain/protein/{proteinId}",
         method = RequestMethod.GET,
         produces = "application/json")
     public List<PfamDomain> fetchPfamDomainsByProteinIdGET(
@@ -110,7 +110,7 @@ public class PfamController
 
     @ApiOperation(value = "Retrieves PFAM domains by Ensembl gene IDs",
         nickname = "fetchPfamDomainsByGeneIdsPOST")
-    @RequestMapping(value = "/pfam/byGene",
+    @RequestMapping(value = "/pfam/domain/gene",
         method = RequestMethod.POST,
         produces = "application/json")
     public List<PfamDomain> fetchPfamDomainsByGeneIdsPOST(
@@ -131,7 +131,7 @@ public class PfamController
 
     @ApiOperation(value = "Retrieves PFAM domains by an Ensembl gene ID",
         nickname = "fetchPfamDomainsByGeneIdGET")
-    @RequestMapping(value = "/pfam/byGene/{geneId}",
+    @RequestMapping(value = "/pfam/domain/gene/{geneId}",
         method = RequestMethod.GET,
         produces = "application/json")
     public List<PfamDomain> fetchPfamDomainsByGeneIdGET(
@@ -145,7 +145,7 @@ public class PfamController
 
     @ApiOperation(value = "Retrieves PFAM domains by PFAM domain IDs",
         nickname = "fetchPfamDomainsByPfamIdsPOST")
-    @RequestMapping(value = "/pfam/byPfamDomain",
+    @RequestMapping(value = "/pfam/domain/pfam",
         method = RequestMethod.POST,
         produces = "application/json")
     public List<PfamDomain> fetchPfamDomainsByPfamIdsPOST(
@@ -166,7 +166,7 @@ public class PfamController
 
     @ApiOperation(value = "Retrieves PFAM domains by a PFAM domain ID",
         nickname = "fetchPfamDomainsByPfamIdGET")
-    @RequestMapping(value = "/pfam/byPfamDomain/{pfamDomainId}",
+    @RequestMapping(value = "/pfam/domain/pfam/{pfamDomainId}",
         method = RequestMethod.GET,
         produces = "application/json")
     public List<PfamDomain> fetchPfamDomainsByPfamIdGET(

--- a/annotation/src/main/resources/application.properties.EXAMPLE
+++ b/annotation/src/main/resources/application.properties.EXAMPLE
@@ -18,6 +18,9 @@ vep.isoform.overrides=uniprot:isoform_overrides_uniprot.txt,mskcc:isoform_overri
 # Ensemble biomart PFAM filename
 ensembl.biomart.pfam=ensembl_biomart_pfam.txt
 
+# PFAM_A filename
+pfam.pfamA=pfamA.txt
+
 # MongoDB URI in the form of mongodb://<USERNAME>:<PASSWORD>@<HOST>:<PORT>/<DB>
 spring.data.mongodb.uri=mongodb://127.0.0.1:27017/annotator
 

--- a/annotation/src/main/resources/pfamA.txt
+++ b/annotation/src/main/resources/pfamA.txt
@@ -1,0 +1,16713 @@
+pfamA_acc	pfamA_id	description
+PF00001	7tm_1	7 transmembrane receptor (rhodopsin family)
+PF00002	7tm_2	7 transmembrane receptor (Secretin family)
+PF00003	7tm_3	7 transmembrane sweet-taste receptor of 3 GCPR
+PF00004	AAA	ATPase family associated with various cellular activities (AAA)
+PF00005	ABC_tran	ABC transporter
+PF00006	ATP-synt_ab	ATP synthase alpha/beta family, nucleotide-binding domain
+PF00007	Cys_knot	Cystine-knot domain
+PF00008	EGF	EGF-like domain
+PF00009	GTP_EFTU	Elongation factor Tu GTP binding domain
+PF00010	HLH	Helix-loop-helix DNA-binding domain
+PF00011	HSP20	Hsp20/alpha crystallin family
+PF00012	HSP70	Hsp70 protein
+PF00013	KH_1	KH domain
+PF00014	Kunitz_BPTI	Kunitz/Bovine pancreatic trypsin inhibitor domain
+PF00015	MCPsignal	Methyl-accepting chemotaxis protein (MCP) signalling domain
+PF00016	RuBisCO_large	Ribulose bisphosphate carboxylase large chain, catalytic domain
+PF00017	SH2	SH2 domain
+PF00018	SH3_1	SH3 domain
+PF00019	TGF_beta	Transforming growth factor beta like domain
+PF00020	TNFR_c6	TNFR/NGFR cysteine-rich region
+PF00021	UPAR_LY6	u-PAR/Ly-6 domain
+PF00022	Actin	Actin
+PF00023	Ank	Ankyrin repeat
+PF00024	PAN_1	PAN domain
+PF00025	Arf	ADP-ribosylation factor family
+PF00026	Asp	Eukaryotic aspartyl protease
+PF00027	cNMP_binding	Cyclic nucleotide-binding domain
+PF00028	Cadherin	Cadherin domain
+PF00029	Connexin	Connexin
+PF00030	Crystall	Beta/Gamma crystallin
+PF00031	Cystatin	Cystatin domain
+PF00032	Cytochrom_B_C	Cytochrome b(C-terminal)/b6/petD
+PF00033	Cytochrome_B	Cytochrome b/b6/petB
+PF00034	Cytochrom_C	Cytochrome c
+PF00035	dsrm	Double-stranded RNA binding motif
+PF00036	EF-hand_1	EF hand
+PF00037	Fer4	4Fe-4S binding domain
+PF00038	Filament	Intermediate filament protein
+PF00039	fn1	Fibronectin type I domain
+PF00040	fn2	Fibronectin type II domain
+PF00041	fn3	Fibronectin type III domain
+PF00042	Globin	Globin
+PF00043	GST_C	Glutathione S-transferase, C-terminal domain
+PF00044	Gp_dh_N	Glyceraldehyde 3-phosphate dehydrogenase, NAD binding domain
+PF00045	Hemopexin	Hemopexin
+PF00046	Homeobox	Homeobox domain
+PF00047	ig	Immunoglobulin domain
+PF00048	IL8	Small cytokines (intecrine/chemokine), interleukin-8 like
+PF00049	Insulin	Insulin/IGF/Relaxin family
+PF00050	Kazal_1	Kazal-type serine protease inhibitor domain
+PF00051	Kringle	Kringle domain
+PF00052	Laminin_B	Laminin B (Domain IV)
+PF00053	Laminin_EGF	Laminin EGF domain
+PF00054	Laminin_G_1	Laminin G domain
+PF00055	Laminin_N	Laminin N-terminal (Domain VI)
+PF00056	Ldh_1_N	lactate/malate dehydrogenase, NAD binding domain
+PF00057	Ldl_recept_a	Low-density lipoprotein receptor domain class A
+PF00058	Ldl_recept_b	Low-density lipoprotein receptor repeat class B
+PF00059	Lectin_C	Lectin C-type domain
+PF00060	Lig_chan	Ligand-gated ion channel
+PF00061	Lipocalin	Lipocalin / cytosolic fatty-acid binding protein family
+PF00062	Lys	C-type lysozyme/alpha-lactalbumin family
+PF00063	Myosin_head	Myosin head (motor domain)
+PF00064	Neur	Neuraminidase
+PF00066	Notch	LNR domain
+PF00067	p450	Cytochrome P450
+PF00068	Phospholip_A2_1	Phospholipase A2
+PF00069	Pkinase	Protein kinase domain
+PF00070	Pyr_redox	Pyridine nucleotide-disulphide oxidoreductase
+PF00071	Ras	Ras family
+PF00072	Response_reg	Response regulator receiver domain
+PF00073	Rhv	picornavirus capsid protein
+PF00074	RnaseA	Pancreatic ribonuclease
+PF00075	RNase_H	RNase H
+PF00076	RRM_1	RNA recognition motif. (a.k.a. RRM, RBD, or RNP domain)
+PF00077	RVP	Retroviral aspartyl protease
+PF00078	RVT_1	Reverse transcriptase (RNA-dependent DNA polymerase)
+PF00079	Serpin	Serpin (serine protease inhibitor)
+PF00080	Sod_Cu	Copper/zinc superoxide dismutase (SODC)
+PF00081	Sod_Fe_N	Iron/manganese superoxide dismutases, alpha-hairpin domain
+PF00082	Peptidase_S8	Subtilase family
+PF00083	Sugar_tr	Sugar (and other) transporter
+PF00084	Sushi	Sushi repeat (SCR repeat)
+PF00085	Thioredoxin	Thioredoxin
+PF00086	Thyroglobulin_1	Thyroglobulin type-1 repeat
+PF00087	Toxin_TOLIP	Snake toxin and toxin-like protein
+PF00088	Trefoil	Trefoil (P-type) domain
+PF00089	Trypsin	Trypsin
+PF00090	TSP_1	Thrombospondin type 1 domain
+PF00091	Tubulin	Tubulin/FtsZ family, GTPase domain
+PF00092	VWA	von Willebrand factor type A domain
+PF00093	VWC	von Willebrand factor type C domain
+PF00094	VWD	von Willebrand factor type D domain
+PF00095	WAP	WAP-type (Whey Acidic Protein) 'four-disulfide core'
+PF00096	zf-C2H2	Zinc finger, C2H2 type
+PF00097	zf-C3HC4	Zinc finger, C3HC4 type (RING finger)
+PF00098	zf-CCHC	Zinc knuckle
+PF00100	Zona_pellucida	Zona pellucida-like domain
+PF00101	RuBisCO_small	Ribulose bisphosphate carboxylase, small chain
+PF00102	Y_phosphatase	Protein-tyrosine phosphatase
+PF00103	Hormone_1	Somatotropin hormone family
+PF00104	Hormone_recep	Ligand-binding domain of nuclear hormone receptor
+PF00105	zf-C4	Zinc finger, C4 type (two domains)
+PF00106	adh_short	short chain dehydrogenase
+PF00107	ADH_zinc_N	Zinc-binding dehydrogenase
+PF00108	Thiolase_N	Thiolase, N-terminal domain
+PF00109	ketoacyl-synt	Beta-ketoacyl synthase, N-terminal domain
+PF00110	wnt	wnt family
+PF00111	Fer2	2Fe-2S iron-sulfur cluster binding domain
+PF00112	Peptidase_C1	Papain family cysteine protease
+PF00113	Enolase_C	Enolase, C-terminal TIM barrel domain
+PF00114	Pilin	Pilin (bacterial filament)
+PF00115	COX1	Cytochrome C and Quinol oxidase polypeptide I
+PF00116	COX2	Cytochrome C oxidase subunit II, periplasmic domain
+PF00117	GATase	Glutamine amidotransferase class-I
+PF00118	Cpn60_TCP1	TCP-1/cpn60 chaperonin family
+PF00119	ATP-synt_A	ATP synthase A chain
+PF00120	Gln-synt_C	Glutamine synthetase, catalytic domain
+PF00121	TIM	Triosephosphate isomerase
+PF00122	E1-E2_ATPase	E1-E2 ATPase
+PF00123	Hormone_2	Peptide hormone
+PF00124	Photo_RC	Photosynthetic reaction centre protein
+PF00125	Histone	Core histone H2A/H2B/H3/H4
+PF00126	HTH_1	Bacterial regulatory helix-turn-helix protein, lysR family
+PF00127	Copper-bind	Copper binding proteins, plastocyanin/azurin family
+PF00128	Alpha-amylase	Alpha amylase, catalytic domain
+PF00129	MHC_I	Class I Histocompatibility antigen, domains alpha 1 and 2
+PF00130	C1_1	Phorbol esters/diacylglycerol binding domain (C1 domain)
+PF00131	Metallothio	Metallothionein
+PF00132	Hexapep	Bacterial transferase hexapeptide (six repeats)
+PF00133	tRNA-synt_1	tRNA synthetases class I (I, L, M and V)
+PF00134	Cyclin_N	Cyclin, N-terminal domain
+PF00135	COesterase	Carboxylesterase family
+PF00136	DNA_pol_B	DNA polymerase family B
+PF00137	ATP-synt_C	ATP synthase subunit C
+PF00139	Lectin_legB	Legume lectin domain
+PF00140	Sigma70_r1_2	Sigma-70 factor, region 1.2
+PF00141	peroxidase	Peroxidase
+PF00142	Fer4_NifH	4Fe-4S iron sulfur cluster binding proteins, NifH/frxC family
+PF00143	Interferon	Interferon alpha/beta domain
+PF00144	Beta-lactamase	Beta-lactamase
+PF00145	DNA_methylase	C-5 cytosine-specific DNA methylase
+PF00146	NADHdh	NADH dehydrogenase
+PF00147	Fibrinogen_C	Fibrinogen beta and gamma chains, C-terminal globular domain
+PF00148	Oxidored_nitro	Nitrogenase component 1 type Oxidoreductase
+PF00149	Metallophos	Calcineurin-like phosphoesterase
+PF00150	Cellulase	Cellulase (glycosyl hydrolase family 5)
+PF00151	Lipase	Lipase
+PF00152	tRNA-synt_2	tRNA synthetases class II (D, K and N) 
+PF00153	Mito_carr	Mitochondrial carrier protein
+PF00154	RecA	recA bacterial DNA recombination protein
+PF00155	Aminotran_1_2	Aminotransferase class I and II
+PF00156	Pribosyltran	Phosphoribosyl transferase domain
+PF00157	Pou	Pou domain - N-terminal to homeobox domain
+PF00158	Sigma54_activat	Sigma-54 interaction domain
+PF00159	Hormone_3	Pancreatic hormone peptide
+PF00160	Pro_isomerase	Cyclophilin type peptidyl-prolyl cis-trans isomerase/CLD
+PF00161	RIP	Ribosome inactivating protein
+PF00162	PGK	Phosphoglycerate kinase
+PF00163	Ribosomal_S4	Ribosomal protein S4/S9 N-terminal domain
+PF00164	Ribosom_S12_S23	Ribosomal protein S12/S23
+PF00165	HTH_AraC	Bacterial regulatory helix-turn-helix proteins, AraC family
+PF00166	Cpn10	Chaperonin 10 Kd subunit
+PF00167	FGF	Fibroblast growth factor
+PF00168	C2	C2 domain
+PF00169	PH	PH domain
+PF00170	bZIP_1	bZIP transcription factor
+PF00171	Aldedh	Aldehyde dehydrogenase family
+PF00172	Zn_clus	Fungal Zn(2)-Cys(6) binuclear cluster domain
+PF00173	Cyt-b5	Cytochrome b5-like Heme/Steroid binding domain
+PF00174	Oxidored_molyb	Oxidoreductase molybdopterin binding domain
+PF00175	NAD_binding_1	Oxidoreductase NAD-binding domain 
+PF00176	SNF2_N	SNF2 family N-terminal domain
+PF00177	Ribosomal_S7	Ribosomal protein S7p/S5e
+PF00178	Ets	Ets-domain
+PF00179	UQ_con	Ubiquitin-conjugating enzyme
+PF00180	Iso_dh	Isocitrate/isopropylmalate dehydrogenase
+PF00181	Ribosomal_L2	Ribosomal Proteins L2, RNA binding domain
+PF00182	Glyco_hydro_19	Chitinase class I
+PF00183	HSP90	Hsp90 protein
+PF00184	Hormone_5	Neurohypophysial hormones, C-terminal Domain
+PF00185	OTCace	Aspartate/ornithine carbamoyltransferase, Asp/Orn binding domain
+PF00186	DHFR_1	Dihydrofolate reductase
+PF00187	Chitin_bind_1	Chitin recognition protein
+PF00188	CAP	Cysteine-rich secretory protein family
+PF00189	Ribosomal_S3_C	Ribosomal protein S3, C-terminal domain
+PF00190	Cupin_1	Cupin
+PF00191	Annexin	Annexin
+PF00193	Xlink	Extracellular link domain
+PF00194	Carb_anhydrase	Eukaryotic-type carbonic anhydrase
+PF00195	Chal_sti_synt_N	Chalcone and stilbene synthases, N-terminal domain
+PF00196	GerE	Bacterial regulatory proteins, luxR family
+PF00197	Kunitz_legume	Trypsin and protease inhibitor
+PF00198	2-oxoacid_dh	2-oxoacid dehydrogenases acyltransferase (catalytic domain)
+PF00199	Catalase	Catalase
+PF00200	Disintegrin	Disintegrin
+PF00201	UDPGT	UDP-glucoronosyl and UDP-glucosyl transferase
+PF00202	Aminotran_3	Aminotransferase class-III
+PF00203	Ribosomal_S19	Ribosomal protein S19
+PF00204	DNA_gyraseB	DNA gyrase B
+PF00205	TPP_enzyme_M	Thiamine pyrophosphate enzyme, central domain
+PF00206	Lyase_1	Lyase
+PF00207	A2M	Alpha-2-macroglobulin family
+PF00208	ELFV_dehydrog	Glutamate/Leucine/Phenylalanine/Valine dehydrogenase
+PF00209	SNF	Sodium:neurotransmitter symporter family
+PF00210	Ferritin	Ferritin-like domain
+PF00211	Guanylate_cyc	Adenylate and Guanylate cyclase catalytic domain
+PF00212	ANP	Atrial natriuretic peptide
+PF00213	OSCP	ATP synthase delta (OSCP) subunit
+PF00214	Calc_CGRP_IAPP	Calcitonin / CGRP / IAPP family
+PF00215	OMPdecase	Orotidine 5'-phosphate decarboxylase / HUMPS family
+PF00216	Bac_DNA_binding	Bacterial DNA-binding protein
+PF00217	ATP-gua_Ptrans	ATP:guanido phosphotransferase, C-terminal catalytic domain
+PF00218	IGPS	Indole-3-glycerol phosphate synthase
+PF00219	IGFBP	Insulin-like growth factor binding protein
+PF00220	Hormone_4	Neurohypophysial hormones, N-terminal Domain
+PF00221	Lyase_aromatic	Aromatic amino acid lyase
+PF00223	PsaA_PsaB	Photosystem I psaA/psaB protein
+PF00224	PK	Pyruvate kinase, barrel domain
+PF00225	Kinesin	Kinesin motor domain
+PF00226	DnaJ	DnaJ domain
+PF00227	Proteasome	Proteasome subunit
+PF00228	Bowman-Birk_leg	Bowman-Birk serine protease inhibitor family
+PF00229	TNF	TNF(Tumour Necrosis Factor) family 
+PF00230	MIP	Major intrinsic protein
+PF00231	ATP-synt	ATP synthase
+PF00232	Glyco_hydro_1	Glycosyl hydrolase family 1
+PF00233	PDEase_I	3'5'-cyclic nucleotide phosphodiesterase
+PF00234	Tryp_alpha_amyl	Protease inhibitor/seed storage/LTP family
+PF00235	Profilin	Profilin
+PF00236	Hormone_6	Glycoprotein hormone
+PF00237	Ribosomal_L22	Ribosomal protein L22p/L17e
+PF00238	Ribosomal_L14	Ribosomal protein L14p/L23e
+PF00239	Resolvase	Resolvase, N terminal domain
+PF00240	ubiquitin	Ubiquitin family
+PF00241	Cofilin_ADF	Cofilin/tropomyosin-type actin-binding protein
+PF00242	DNA_pol_viral_N	DNA polymerase (viral) N-terminal domain
+PF00243	NGF	Nerve growth factor family
+PF00244	14-3-3	14-3-3 protein
+PF00245	Alk_phosphatase	Alkaline phosphatase
+PF00246	Peptidase_M14	Zinc carboxypeptidase
+PF00248	Aldo_ket_red	Aldo/keto reductase family
+PF00249	Myb_DNA-binding	Myb-like DNA-binding domain
+PF00250	Forkhead	Forkhead domain
+PF00251	Glyco_hydro_32N	Glycosyl hydrolases family 32 N-terminal domain
+PF00252	Ribosomal_L16	Ribosomal protein L16p/L10e
+PF00253	Ribosomal_S14	Ribosomal protein S14p/S29e
+PF00254	FKBP_C	FKBP-type peptidyl-prolyl cis-trans isomerase
+PF00255	GSHPx	Glutathione peroxidase
+PF00257	Dehydrin	Dehydrin
+PF00258	Flavodoxin_1	Flavodoxin
+PF00260	Protamine_P1	Protamine P1
+PF00261	Tropomyosin	Tropomyosin
+PF00262	Calreticulin	Calreticulin family
+PF00263	Secretin	Bacterial type II and III secretion system protein
+PF00264	Tyrosinase	Common central domain of tyrosinase
+PF00265	TK	Thymidine kinase
+PF00266	Aminotran_5	Aminotransferase class-V
+PF00267	Porin_1	Gram-negative porin
+PF00268	Ribonuc_red_sm	Ribonucleotide reductase, small chain
+PF00269	SASP	Small, acid-soluble spore proteins, alpha/beta type
+PF00270	DEAD	DEAD/DEAH box helicase
+PF00271	Helicase_C	Helicase conserved C-terminal domain
+PF00272	Cecropin	Cecropin family
+PF00273	Serum_albumin	Serum albumin family
+PF00274	Glycolytic	Fructose-bisphosphate aldolase class-I
+PF00275	EPSP_synthase	EPSP synthase (3-phosphoshikimate 1-carboxyvinyltransferase)
+PF00276	Ribosomal_L23	Ribosomal protein L23
+PF00277	SAA	Serum amyloid A protein
+PF00278	Orn_DAP_Arg_deC	Pyridoxal-dependent decarboxylase, C-terminal sheet domain
+PF00280	potato_inhibit	Potato inhibitor I family
+PF00281	Ribosomal_L5	Ribosomal protein L5
+PF00282	Pyridoxal_deC	Pyridoxal-dependent decarboxylase conserved domain
+PF00283	Cytochrom_B559	Cytochrome b559, alpha (gene psbE) and beta (gene psbF)subunits
+PF00284	Cytochrom_B559a	Lumenal portion of Cytochrome b559, alpha (gene psbE) subunit
+PF00285	Citrate_synt	Citrate synthase, C-terminal domain
+PF00286	Flexi_CP	Viral coat protein
+PF00287	Na_K-ATPase	Sodium / potassium ATPase beta chain
+PF00288	GHMP_kinases_N	GHMP kinases N terminal domain
+PF00289	Biotin_carb_N	Biotin carboxylase, N-terminal domain
+PF00290	Trp_syntA	Tryptophan synthase alpha chain
+PF00291	PALP	Pyridoxal-phosphate dependent enzyme
+PF00292	PAX	'Paired box' domain
+PF00293	NUDIX	NUDIX domain
+PF00294	PfkB	pfkB family carbohydrate kinase
+PF00295	Glyco_hydro_28	Glycosyl hydrolases family 28
+PF00296	Bac_luciferase	Luciferase-like monooxygenase
+PF00297	Ribosomal_L3	Ribosomal protein L3
+PF00298	Ribosomal_L11	Ribosomal protein L11, RNA binding domain
+PF00299	Squash	Squash family serine protease inhibitor
+PF00300	His_Phos_1	Histidine phosphatase superfamily (branch 1)
+PF00301	Rubredoxin	Rubredoxin
+PF00302	CAT	Chloramphenicol acetyltransferase
+PF00303	Thymidylat_synt	Thymidylate synthase
+PF00304	Gamma-thionin	Gamma-thionin family
+PF00305	Lipoxygenase	Lipoxygenase
+PF00306	ATP-synt_ab_C	ATP synthase alpha/beta chain, C terminal domain
+PF00307	CH	Calponin homology (CH) domain
+PF00308	Bac_DnaA	Bacterial dnaA  protein
+PF00309	Sigma54_AID	Sigma-54 factor, Activator interacting domain (AID) 
+PF00310	GATase_2	Glutamine amidotransferases class-II
+PF00311	PEPcase	Phosphoenolpyruvate carboxylase
+PF00312	Ribosomal_S15	Ribosomal protein S15
+PF00313	CSD	'Cold-shock' DNA-binding domain
+PF00314	Thaumatin	Thaumatin family
+PF00316	FBPase	Fructose-1-6-bisphosphatase, N-terminal domain
+PF00317	Ribonuc_red_lgN	Ribonucleotide reductase, all-alpha domain
+PF00318	Ribosomal_S2	Ribosomal protein S2
+PF00319	SRF-TF	SRF-type transcription factor (DNA-binding and dimerisation domain)
+PF00320	GATA	GATA zinc finger
+PF00321	Thionin	Plant thionin
+PF00322	Endothelin	Endothelin family
+PF00323	Defensin_1	Mammalian defensin
+PF00324	AA_permease	Amino acid permease
+PF00325	Crp	Bacterial regulatory proteins, crp family
+PF00326	Peptidase_S9	Prolyl oligopeptidase family
+PF00327	Ribosomal_L30	Ribosomal protein L30p/L7e
+PF00328	His_Phos_2	Histidine phosphatase superfamily (branch 2)
+PF00329	Complex1_30kDa	Respiratory-chain NADH dehydrogenase, 30 Kd subunit
+PF00330	Aconitase	Aconitase family (aconitate hydratase)
+PF00331	Glyco_hydro_10	Glycosyl hydrolase family 10
+PF00332	Glyco_hydro_17	Glycosyl hydrolases family 17
+PF00333	Ribosomal_S5	Ribosomal protein S5, N-terminal domain
+PF00334	NDK	Nucleoside diphosphate kinase
+PF00335	Tetraspannin	Tetraspanin family
+PF00336	DNA_pol_viral_C	DNA polymerase (viral) C-terminal domain
+PF00337	Gal-bind_lectin	Galactoside-binding lectin
+PF00338	Ribosomal_S10	Ribosomal protein S10p/S20e
+PF00339	Arrestin_N	Arrestin (or S-antigen), N-terminal domain
+PF00340	IL1	Interleukin-1 / 18
+PF00341	PDGF	PDGF/VEGF domain
+PF00342	PGI	Phosphoglucose isomerase
+PF00343	Phosphorylase	Carbohydrate phosphorylase
+PF00344	SecY	SecY translocase
+PF00345	PapD_N	Pili and flagellar-assembly chaperone, PapD N-terminal domain
+PF00346	Complex1_49kDa	Respiratory-chain NADH dehydrogenase, 49 Kd subunit
+PF00347	Ribosomal_L6	Ribosomal protein L6
+PF00348	polyprenyl_synt	Polyprenyl synthetase
+PF00349	Hexokinase_1	Hexokinase
+PF00350	Dynamin_N	Dynamin family
+PF00351	Biopterin_H	Biopterin-dependent aromatic amino acid hydroxylase
+PF00352	TBP	Transcription factor TFIID (or TATA-binding protein, TBP)
+PF00353	HemolysinCabind	Haemolysin-type calcium-binding repeat (2 copies)
+PF00354	Pentaxin	Pentaxin family
+PF00355	Rieske	Rieske [2Fe-2S] domain
+PF00356	LacI	Bacterial regulatory proteins, lacI family
+PF00357	Integrin_alpha	Integrin alpha cytoplasmic region
+PF00358	PTS_EIIA_1	phosphoenolpyruvate-dependent sugar phosphotransferase system, EIIA 1
+PF00359	PTS_EIIA_2	Phosphoenolpyruvate-dependent sugar phosphotransferase system, EIIA 2
+PF00360	PHY	Phytochrome region
+PF00361	Proton_antipo_M	Proton-conducting membrane transporter
+PF00362	Integrin_beta	Integrin beta chain VWA domain
+PF00363	Casein	Casein
+PF00364	Biotin_lipoyl	Biotin-requiring enzyme
+PF00365	PFK	Phosphofructokinase
+PF00366	Ribosomal_S17	Ribosomal protein S17
+PF00367	PTS_EIIB	phosphotransferase system, EIIB
+PF00368	HMG-CoA_red	Hydroxymethylglutaryl-coenzyme A reductase
+PF00370	FGGY_N	FGGY family of carbohydrate kinases, N-terminal domain
+PF00372	Hemocyanin_M	Hemocyanin, copper containing domain
+PF00373	FERM_M	FERM central domain
+PF00374	NiFeSe_Hases	Nickel-dependent hydrogenase
+PF00375	SDF	Sodium:dicarboxylate symporter family
+PF00376	MerR	MerR family regulatory protein
+PF00377	Prion	Prion/Doppel alpha-helical domain
+PF00378	ECH_1	Enoyl-CoA hydratase/isomerase
+PF00379	Chitin_bind_4	Insect cuticle protein
+PF00380	Ribosomal_S9	Ribosomal protein S9/S16
+PF00381	PTS-HPr	PTS HPr component phosphorylation site
+PF00382	TFIIB	Transcription factor TFIIB repeat
+PF00383	dCMP_cyt_deam_1	Cytidine and deoxycytidylate deaminase zinc-binding region
+PF00384	Molybdopterin	Molybdopterin oxidoreductase
+PF00385	Chromo	Chromo (CHRromatin Organisation MOdifier) domain
+PF00386	C1q	C1q domain
+PF00387	PI-PLC-Y	Phosphatidylinositol-specific phospholipase C, Y domain
+PF00388	PI-PLC-X	Phosphatidylinositol-specific phospholipase C, X domain
+PF00389	2-Hacid_dh	D-isomer specific 2-hydroxyacid dehydrogenase, catalytic domain
+PF00390	malic	Malic enzyme, N-terminal domain
+PF00391	PEP-utilizers	PEP-utilising enzyme, mobile domain
+PF00392	GntR	Bacterial regulatory proteins, gntR family
+PF00393	6PGD	6-phosphogluconate dehydrogenase, C-terminal domain
+PF00394	Cu-oxidase	Multicopper oxidase
+PF00395	SLH	S-layer homology domain
+PF00396	Granulin	Granulin
+PF00397	WW	WW domain
+PF00398	RrnaAD	Ribosomal RNA adenine dimethylase
+PF00399	PIR	Yeast PIR protein repeat
+PF00400	WD40	WD domain, G-beta repeat
+PF00401	ATP-synt_DE	ATP synthase, Delta/Epsilon chain, long alpha-helix domain
+PF00402	Calponin	Calponin family repeat
+PF00403	HMA	Heavy-metal-associated domain
+PF00404	Dockerin_1	Dockerin type I repeat
+PF00405	Transferrin	Transferrin
+PF00406	ADK	Adenylate kinase
+PF00407	Bet_v_1	Pathogenesis-related protein Bet v I family
+PF00408	PGM_PMM_IV	Phosphoglucomutase/phosphomannomutase, C-terminal domain
+PF00410	Ribosomal_S8	Ribosomal protein S8
+PF00411	Ribosomal_S11	Ribosomal protein S11
+PF00412	LIM	LIM domain
+PF00413	Peptidase_M10	Matrixin
+PF00414	MAP1B_neuraxin	Neuraxin and MAP1B repeat
+PF00415	RCC1	Regulator of chromosome condensation (RCC1) repeat
+PF00416	Ribosomal_S13	Ribosomal protein S13/S18
+PF00418	Tubulin-binding	Tau and MAP protein, tubulin-binding repeat
+PF00419	Fimbrial	Fimbrial protein
+PF00420	Oxidored_q2	NADH-ubiquinone/plastoquinone oxidoreductase chain 4L
+PF00421	PSII	Photosystem II protein
+PF00423	HN	Haemagglutinin-neuraminidase
+PF00424	REV	REV protein (anti-repression trans-activator protein)
+PF00425	Chorismate_bind	chorismate binding enzyme
+PF00426	VP4_haemagglut	Outer Capsid protein VP4 (Hemagglutinin) Concanavalin-like domain
+PF00427	PBS_linker_poly	Phycobilisome Linker polypeptide
+PF00428	Ribosomal_60s	60s Acidic ribosomal protein
+PF00429	TLV_coat	ENV polyprotein (coat polyprotein)
+PF00430	ATP-synt_B	ATP synthase B/B' CF(0)
+PF00431	CUB	CUB domain
+PF00432	Prenyltrans	Prenyltransferase and squalene oxidase repeat
+PF00433	Pkinase_C	Protein kinase C terminal domain
+PF00434	VP7	Glycoprotein VP7
+PF00435	Spectrin	Spectrin repeat
+PF00436	SSB	Single-strand binding protein family
+PF00437	T2SSE	Type II/IV secretion system protein
+PF00438	S-AdoMet_synt_N	S-adenosylmethionine synthetase, N-terminal domain
+PF00439	Bromodomain	Bromodomain
+PF00440	TetR_N	Bacterial regulatory proteins, tetR family
+PF00441	Acyl-CoA_dh_1	Acyl-CoA dehydrogenase, C-terminal domain
+PF00443	UCH	Ubiquitin carboxyl-terminal hydrolase
+PF00444	Ribosomal_L36	Ribosomal protein L36
+PF00445	Ribonuclease_T2	Ribonuclease T2 family
+PF00446	GnRH	Gonadotropin-releasing hormone
+PF00447	HSF_DNA-bind	HSF-type DNA-binding
+PF00448	SRP54	SRP54-type protein, GTPase domain
+PF00449	Urease_alpha	Urease alpha-subunit, N-terminal domain
+PF00450	Peptidase_S10	Serine carboxypeptidase
+PF00451	Toxin_2	Scorpion short toxin, BmKK2
+PF00452	Bcl-2	Apoptosis regulator proteins, Bcl-2 family
+PF00453	Ribosomal_L20	Ribosomal protein L20
+PF00454	PI3_PI4_kinase	Phosphatidylinositol 3- and 4-kinase
+PF00455	DeoRC	DeoR C terminal sensor domain
+PF00456	Transketolase_N	Transketolase, thiamine diphosphate binding domain
+PF00457	Glyco_hydro_11	Glycosyl hydrolases family 11
+PF00458	WHEP-TRS	WHEP-TRS domain
+PF00459	Inositol_P	Inositol monophosphatase family
+PF00460	Flg_bb_rod	Flagella basal body rod protein
+PF00462	Glutaredoxin	Glutaredoxin
+PF00463	ICL	Isocitrate lyase family
+PF00464	SHMT	Serine hydroxymethyltransferase
+PF00465	Fe-ADH	Iron-containing alcohol dehydrogenase 
+PF00466	Ribosomal_L10	Ribosomal protein L10
+PF00467	KOW	KOW motif
+PF00468	Ribosomal_L34	Ribosomal protein L34
+PF00469	F-protein	Negative factor, (F-Protein) or Nef
+PF00471	Ribosomal_L33	Ribosomal protein L33
+PF00472	RF-1	RF-1 domain
+PF00473	CRF	Corticotropin-releasing factor family
+PF00474	SSF	Sodium:solute symporter family
+PF00475	IGPD	Imidazoleglycerol-phosphate dehydratase
+PF00476	DNA_pol_A	DNA polymerase family A
+PF00477	LEA_5	Small hydrophilic plant seed protein
+PF00478	IMPDH	IMP dehydrogenase / GMP reductase domain
+PF00479	G6PD_N	Glucose-6-phosphate dehydrogenase, NAD binding domain
+PF00480	ROK	ROK family
+PF00481	PP2C	Protein phosphatase 2C
+PF00482	T2SSF	Type II secretion system (T2SS), protein F
+PF00483	NTP_transferase	Nucleotidyl transferase
+PF00484	Pro_CA	Carbonic anhydrase
+PF00485	PRK	Phosphoribulokinase / Uridine kinase family
+PF00486	Trans_reg_C	Transcriptional regulatory protein, C terminal
+PF00487	FA_desaturase	Fatty acid desaturase
+PF00488	MutS_V	MutS domain V
+PF00489	IL6	Interleukin-6/G-CSF/MGF family
+PF00490	ALAD	Delta-aminolevulinic acid dehydratase
+PF00491	Arginase	Arginase family
+PF00493	MCM	MCM2/3/5 family
+PF00494	SQS_PSY	Squalene/phytoene synthase
+PF00496	SBP_bac_5	Bacterial extracellular solute-binding proteins, family 5 Middle
+PF00497	SBP_bac_3	Bacterial extracellular solute-binding proteins, family 3
+PF00498	FHA	FHA domain
+PF00499	Oxidored_q3	NADH-ubiquinone/plastoquinone oxidoreductase chain 6
+PF00500	Late_protein_L1	L1 (late) protein
+PF00501	AMP-binding	AMP-binding enzyme
+PF00502	Phycobilisome	Phycobilisome protein
+PF00503	G-alpha	G-protein alpha subunit
+PF00504	Chloroa_b-bind	Chlorophyll A-B binding protein
+PF00505	HMG_box	HMG (high mobility group) box
+PF00506	Flu_NP	Influenza virus nucleoprotein
+PF00507	Oxidored_q4	NADH-ubiquinone/plastoquinone oxidoreductase, chain 3
+PF00508	PPV_E2_N	E2 (early) protein, N terminal
+PF00509	Hemagglutinin	Haemagglutinin
+PF00510	COX3	Cytochrome c oxidase subunit III
+PF00511	PPV_E2_C	E2 (early) protein, C terminal
+PF00512	HisKA	His Kinase A (phospho-acceptor) domain
+PF00513	Late_protein_L2	Late Protein L2
+PF00514	Arm	Armadillo/beta-catenin-like repeat
+PF00515	TPR_1	Tetratricopeptide repeat
+PF00516	GP120	Envelope glycoprotein GP120
+PF00517	GP41	Retroviral envelope protein
+PF00518	E6	Early Protein (E6)
+PF00519	PPV_E1_C	Papillomavirus helicase
+PF00520	Ion_trans	Ion transport protein
+PF00521	DNA_topoisoIV	DNA gyrase/topoisomerase IV, subunit A
+PF00522	VPR	VPR/VPX protein
+PF00523	Fusion_gly	Fusion glycoprotein F0
+PF00524	PPV_E1_N	E1 Protein, N terminal domain
+PF00525	Crystallin	Alpha crystallin A chain, N terminal
+PF00526	Dicty_CTDC	Dictyostelium (slime mold) repeat
+PF00527	E7	E7 protein, Early protein
+PF00528	BPD_transp_1	Binding-protein-dependent transport system inner membrane component
+PF00529	HlyD	HlyD membrane-fusion protein of T1SS
+PF00530	SRCR	Scavenger receptor cysteine-rich domain
+PF00531	Death	Death domain
+PF00532	Peripla_BP_1	Periplasmic binding proteins and sugar binding domain of LacI family
+PF00533	BRCT	BRCA1 C Terminus (BRCT) domain
+PF00534	Glycos_transf_1	Glycosyl transferases group 1
+PF00535	Glycos_transf_2	Glycosyl transferase family 2
+PF00536	SAM_1	SAM domain (Sterile alpha motif)
+PF00537	Toxin_3	Scorpion toxin-like domain 
+PF00538	Linker_histone	linker histone H1 and H5 family
+PF00539	Tat	Transactivating regulatory protein (Tat)
+PF00540	Gag_p17	gag gene protein p17 (matrix protein)
+PF00541	Adeno_knob	Adenoviral fibre protein (knob domain)
+PF00542	Ribosomal_L12	Ribosomal protein L7/L12 C-terminal domain
+PF00543	P-II	Nitrogen regulatory protein P-II
+PF00544	Pec_lyase_C	Pectate lyase
+PF00545	Ribonuclease	ribonuclease
+PF00547	Urease_gamma	Urease, gamma subunit
+PF00548	Peptidase_C3	3C cysteine protease (picornain 3C)
+PF00549	Ligase_CoA	CoA-ligase
+PF00550	PP-binding	Phosphopantetheine attachment site
+PF00551	Formyl_trans_N	Formyl transferase
+PF00552	IN_DBD_C	Integrase DNA binding domain
+PF00553	CBM_2	Cellulose binding domain
+PF00554	RHD_DNA_bind	Rel homology DNA-binding domain
+PF00555	Endotoxin_M	delta endotoxin
+PF00556	LHC	Antenna complex alpha/beta subunit
+PF00557	Peptidase_M24	Metallopeptidase family M24
+PF00558	Vpu	Vpu protein
+PF00559	Vif	Retroviral Vif (Viral infectivity) protein
+PF00560	LRR_1	Leucine Rich Repeat
+PF00561	Abhydrolase_1	alpha/beta hydrolase fold
+PF00562	RNA_pol_Rpb2_6	RNA polymerase Rpb2, domain 6
+PF00563	EAL	EAL domain
+PF00564	PB1	PB1 domain
+PF00565	SNase	Staphylococcal nuclease homologue
+PF00566	RabGAP-TBC	Rab-GTPase-TBC domain
+PF00567	TUDOR	Tudor domain
+PF00568	WH1	WH1 domain
+PF00569	ZZ	Zinc finger, ZZ type
+PF00570	HRDC	HRDC domain
+PF00571	CBS	CBS domain
+PF00572	Ribosomal_L13	Ribosomal protein L13
+PF00573	Ribosomal_L4	Ribosomal protein L4/L1 family
+PF00574	CLP_protease	Clp protease
+PF00575	S1	S1 RNA binding domain
+PF00576	Transthyretin	HIUase/Transthyretin family
+PF00577	Usher	Outer membrane usher protein
+PF00578	AhpC-TSA	AhpC/TSA family
+PF00579	tRNA-synt_1b	tRNA synthetases class I (W and Y)
+PF00580	UvrD-helicase	UvrD/REP helicase N-terminal domain
+PF00581	Rhodanese	Rhodanese-like domain
+PF00582	Usp	Universal stress protein family
+PF00583	Acetyltransf_1	Acetyltransferase (GNAT) family
+PF00584	SecE	SecE/Sec61-gamma subunits of protein translocation complex
+PF00585	Thr_dehydrat_C	C-terminal regulatory domain of Threonine dehydratase
+PF00586	AIRS	AIR synthase related protein, N-terminal domain
+PF00587	tRNA-synt_2b	tRNA synthetase class II core domain (G, H, P, S and T)
+PF00588	SpoU_methylase	SpoU rRNA Methylase family
+PF00589	Phage_integrase	Phage integrase family
+PF00590	TP_methylase	Tetrapyrrole (Corrin/Porphyrin) Methylases
+PF00591	Glycos_transf_3	Glycosyl transferase family, a/b domain
+PF00593	TonB_dep_Rec	TonB dependent receptor
+PF00594	Gla	Vitamin K-dependent carboxylation/gamma-carboxyglutamic (GLA) domain
+PF00595	PDZ	PDZ domain (Also known as DHR or GLGF)
+PF00596	Aldolase_II	Class II Aldolase and Adducin N-terminal domain
+PF00598	Flu_M1	Influenza Matrix protein (M1)
+PF00599	Flu_M2	Influenza Matrix protein (M2)
+PF00600	Flu_NS1	Influenza non-structural protein (NS1)
+PF00601	Flu_NS2	Influenza non-structural protein (NS2)
+PF00602	Flu_PB1	Influenza RNA-dependent RNA polymerase subunit PB1
+PF00603	Flu_PA	Influenza RNA-dependent RNA polymerase subunit PA
+PF00604	Flu_PB2	Influenza RNA-dependent RNA polymerase subunit PB2
+PF00605	IRF	Interferon regulatory factor transcription factor
+PF00606	Glycoprotein_B	Herpesvirus Glycoprotein B ectodomain
+PF00607	Gag_p24	gag gene protein p24 (core nucleocapsid protein)
+PF00608	Adeno_shaft	Adenoviral fibre protein (repeat/shaft region)
+PF00609	DAGK_acc	Diacylglycerol kinase accessory domain
+PF00610	DEP	Domain found in Dishevelled, Egl-10, and Pleckstrin (DEP)
+PF00611	FCH	Fes/CIP4, and EFC/F-BAR homology domain
+PF00612	IQ	IQ calmodulin-binding motif
+PF00613	PI3Ka	Phosphoinositide 3-kinase family, accessory domain (PIK domain)
+PF00614	PLDc	Phospholipase D Active site motif
+PF00615	RGS	Regulator of G protein signaling domain
+PF00616	RasGAP	GTPase-activator protein for Ras-like GTPase
+PF00617	RasGEF	RasGEF domain
+PF00618	RasGEF_N	RasGEF N-terminal motif
+PF00619	CARD	Caspase recruitment domain
+PF00620	RhoGAP	RhoGAP domain
+PF00621	RhoGEF	RhoGEF domain
+PF00622	SPRY	SPRY domain
+PF00623	RNA_pol_Rpb1_2	RNA polymerase Rpb1, domain 2
+PF00624	Flocculin	Flocculin repeat
+PF00625	Guanylate_kin	Guanylate kinase
+PF00626	Gelsolin	Gelsolin repeat
+PF00627	UBA	UBA/TS-N domain
+PF00628	PHD	PHD-finger
+PF00629	MAM	MAM domain, meprin/A5/mu
+PF00630	Filamin	Filamin/ABP280 repeat
+PF00631	G-gamma	GGL domain
+PF00632	HECT	HECT-domain (ubiquitin-transferase)
+PF00633	HHH	Helix-hairpin-helix motif
+PF00634	BRCA2	BRCA2 repeat
+PF00635	Motile_Sperm	MSP (Major sperm protein) domain
+PF00636	Ribonuclease_3	Ribonuclease III domain
+PF00637	Clathrin	Region in Clathrin and VPS
+PF00638	Ran_BP1	RanBP1 domain
+PF00639	Rotamase	PPIC-type PPIASE domain
+PF00640	PID	Phosphotyrosine interaction domain (PTB/PID)
+PF00641	zf-RanBP	Zn-finger in Ran binding protein and others
+PF00642	zf-CCCH	Zinc finger C-x8-C-x5-C-x3-H type (and similar)
+PF00643	zf-B_box	B-box zinc finger
+PF00644	PARP	Poly(ADP-ribose) polymerase catalytic domain
+PF00645	zf-PARP	Poly(ADP-ribose) polymerase and DNA-Ligase Zn-finger region
+PF00646	F-box	F-box domain
+PF00647	EF1G	Elongation factor 1 gamma, conserved domain
+PF00648	Peptidase_C2	Calpain family cysteine protease
+PF00649	Copper-fist	Copper fist DNA binding domain
+PF00650	CRAL_TRIO	CRAL/TRIO domain
+PF00651	BTB	BTB/POZ domain
+PF00652	Ricin_B_lectin	Ricin-type beta-trefoil lectin domain
+PF00653	BIR	Inhibitor of Apoptosis domain
+PF00654	Voltage_CLC	Voltage gated chloride channel
+PF00656	Peptidase_C14	Caspase domain
+PF00657	Lipase_GDSL	GDSL-like Lipase/Acylhydrolase
+PF00658	PABP	Poly-adenylate binding protein, unique domain
+PF00659	POLO_box	POLO box duplicated region
+PF00660	SRP1_TIP1	Seripauperin and TIP1 family
+PF00661	Matrix	Viral matrix protein
+PF00662	Proton_antipo_N	NADH-Ubiquinone oxidoreductase (complex I), chain 5 N-terminus
+PF00664	ABC_membrane	ABC transporter transmembrane region
+PF00665	rve	Integrase core domain
+PF00666	Cathelicidins	Cathelicidin
+PF00667	FAD_binding_1	FAD binding domain
+PF00668	Condensation	Condensation domain
+PF00669	Flagellin_N	Bacterial flagellin N-terminal helical region
+PF00670	AdoHcyase_NAD	S-adenosyl-L-homocysteine hydrolase, NAD binding domain
+PF00672	HAMP	HAMP domain
+PF00673	Ribosomal_L5_C	ribosomal L5P family C-terminus
+PF00674	DUP	DUP family
+PF00675	Peptidase_M16	Insulinase (Peptidase family M16)
+PF00676	E1_dh	Dehydrogenase E1 component
+PF00677	Lum_binding	Lumazine binding domain
+PF00679	EFG_C	Elongation factor G C-terminus
+PF00680	RdRP_1	RNA dependent RNA polymerase
+PF00681	Plectin	Plectin repeat
+PF00682	HMGL-like	HMGL-like
+PF00683	TB	TB domain
+PF00684	DnaJ_CXXCXGXG	DnaJ central domain
+PF00685	Sulfotransfer_1	Sulfotransferase domain
+PF00686	CBM_20	Starch binding domain
+PF00687	Ribosomal_L1	Ribosomal protein L1p/L10e family
+PF00688	TGFb_propeptide	TGF-beta propeptide
+PF00689	Cation_ATPase_C	Cation transporting ATPase, C-terminus
+PF00690	Cation_ATPase_N	Cation transporter/ATPase, N-terminus
+PF00691	OmpA	OmpA family
+PF00692	dUTPase	dUTPase
+PF00693	Herpes_TK	Thymidine kinase from herpesvirus
+PF00694	Aconitase_C	Aconitase C-terminal domain
+PF00695	vMSA	Major surface antigen from hepadnavirus
+PF00696	AA_kinase	Amino acid kinase family
+PF00697	PRAI	N-(5'phosphoribosyl)anthranilate (PRA) isomerase
+PF00698	Acyl_transf_1	Acyl transferase domain
+PF00699	Urease_beta	Urease beta subunit
+PF00700	Flagellin_C	Bacterial flagellin C-terminal helical region
+PF00701	DHDPS	Dihydrodipicolinate synthetase family
+PF00702	Hydrolase	haloacid dehalogenase-like hydrolase
+PF00703	Glyco_hydro_2	Glycosyl hydrolases family 2
+PF00704	Glyco_hydro_18	Glycosyl hydrolases family 18
+PF00705	PCNA_N	Proliferating cell nuclear antigen, N-terminal domain
+PF00706	Toxin_4	Anenome neurotoxin
+PF00707	IF3_C	Translation initiation factor IF-3, C-terminal domain
+PF00708	Acylphosphatase	Acylphosphatase
+PF00709	Adenylsucc_synt	Adenylosuccinate synthetase
+PF00710	Asparaginase	Asparaginase, N-terminal
+PF00711	Defensin_beta	Beta defensin
+PF00712	DNA_pol3_beta	DNA polymerase III beta subunit, N-terminal domain
+PF00713	Hirudin	Hirudin
+PF00714	IFN-gamma	Interferon gamma
+PF00715	IL2	Interleukin 2
+PF00716	Peptidase_S21	Assemblin (Peptidase family S21)
+PF00717	Peptidase_S24	Peptidase S24-like
+PF00718	Polyoma_coat	Polyomavirus coat protein
+PF00719	Pyrophosphatase	Inorganic pyrophosphatase
+PF00720	SSI	Subtilisin inhibitor-like
+PF00721	TMV_coat	Virus coat protein (TMV like)
+PF00722	Glyco_hydro_16	Glycosyl hydrolases family 16
+PF00723	Glyco_hydro_15	Glycosyl hydrolases family 15
+PF00724	Oxidored_FMN	NADH:flavin oxidoreductase / NADH oxidase family
+PF00725	3HCDH	3-hydroxyacyl-CoA dehydrogenase, C-terminal domain
+PF00726	IL10	Interleukin 10
+PF00727	IL4	Interleukin 4
+PF00728	Glyco_hydro_20	Glycosyl hydrolase family 20, catalytic domain
+PF00729	Viral_coat	Viral coat protein (S domain)
+PF00730	HhH-GPD	HhH-GPD superfamily base excision DNA repair protein
+PF00731	AIRC	AIR carboxylase
+PF00732	GMC_oxred_N	GMC oxidoreductase
+PF00733	Asn_synthase	Asparagine synthase
+PF00734	CBM_1	Fungal cellulose binding domain
+PF00735	Septin	Septin
+PF00736	EF1_GNE	EF-1 guanine nucleotide exchange domain
+PF00737	PsbH	Photosystem II 10 kDa phosphoprotein
+PF00738	Polyhedrin	Polyhedrin
+PF00739	X	Trans-activation protein X
+PF00740	Parvo_coat	Parvovirus coat protein VP2
+PF00741	Gas_vesicle	Gas vesicle protein
+PF00742	Homoserine_dh	Homoserine dehydrogenase
+PF00743	FMO-like	Flavin-binding monooxygenase-like
+PF00745	GlutR_dimer	Glutamyl-tRNAGlu reductase, dimerisation domain
+PF00746	Gram_pos_anchor	LPXTG cell wall anchor motif
+PF00747	Viral_DNA_bp	ssDNA binding protein
+PF00748	Calpain_inhib	Calpain inhibitor
+PF00749	tRNA-synt_1c	tRNA synthetases class I (E and Q), catalytic domain
+PF00750	tRNA-synt_1d	tRNA synthetases class I (R)
+PF00751	DM	DM DNA binding domain
+PF00752	XPG_N	XPG N-terminal domain
+PF00753	Lactamase_B	Metallo-beta-lactamase superfamily
+PF00754	F5_F8_type_C	F5/8 type C domain
+PF00755	Carn_acyltransf	Choline/Carnitine o-acyltransferase
+PF00756	Esterase	Putative esterase
+PF00757	Furin-like	Furin-like cysteine rich region
+PF00758	EPO_TPO	Erythropoietin/thrombopoietin
+PF00759	Glyco_hydro_9	Glycosyl hydrolase family 9
+PF00760	Cucumo_coat	Cucumovirus coat protein
+PF00761	Polyoma_coat2	Polyomavirus coat protein
+PF00762	Ferrochelatase	Ferrochelatase
+PF00763	THF_DHG_CYH	Tetrahydrofolate dehydrogenase/cyclohydrolase, catalytic domain
+PF00764	Arginosuc_synth	Arginosuccinate synthase
+PF00765	Autoind_synth	Autoinducer synthase
+PF00766	ETF_alpha	Electron transfer flavoprotein FAD-binding domain
+PF00767	Poty_coat	Potyvirus coat protein
+PF00768	Peptidase_S11	D-alanyl-D-alanine carboxypeptidase
+PF00769	ERM	Ezrin/radixin/moesin family
+PF00770	Peptidase_C5	Adenovirus endoprotease
+PF00771	FHIPEP	FHIPEP family
+PF00772	DnaB	DnaB-like helicase N terminal domain
+PF00773	RNB	RNB domain
+PF00775	Dioxygenase_C	Dioxygenase
+PF00777	Glyco_transf_29	Glycosyltransferase family 29 (sialyltransferase)
+PF00778	DIX	DIX domain
+PF00779	BTK	BTK motif
+PF00780	CNH	CNH domain
+PF00781	DAGK_cat	Diacylglycerol kinase catalytic domain
+PF00782	DSPc	Dual specificity phosphatase, catalytic domain
+PF00784	MyTH4	MyTH4 domain
+PF00786	PBD	P21-Rho-binding domain
+PF00787	PX	PX domain
+PF00788	RA	Ras association (RalGDS/AF-6) domain
+PF00789	UBX	UBX domain
+PF00790	VHS	VHS domain
+PF00791	ZU5	ZU5 domain
+PF00792	PI3K_C2	Phosphoinositide 3-kinase C2
+PF00793	DAHP_synth_1	DAHP synthetase I family
+PF00794	PI3K_rbd	PI3-kinase family, ras-binding domain
+PF00795	CN_hydrolase	Carbon-nitrogen hydrolase
+PF00796	PSI_8	Photosystem I reaction centre subunit VIII
+PF00797	Acetyltransf_2	N-acetyltransferase
+PF00798	Arena_glycoprot	Arenavirus glycoprotein
+PF00799	Gemini_AL1	Geminivirus Rep catalytic domain
+PF00800	PDT	Prephenate dehydratase
+PF00801	PKD	PKD domain
+PF00802	Glycoprotein_G	Pneumovirus attachment glycoprotein G
+PF00803	3A	3A/RNA2 movement protein family
+PF00804	Syntaxin	Syntaxin
+PF00805	Pentapeptide	Pentapeptide repeats (8 copies)
+PF00806	PUF	Pumilio-family RNA binding repeat
+PF00807	Apidaecin	Apidaecin
+PF00808	CBFD_NFYB_HMF	Histone-like transcription factor (CBF/NF-Y) and archaeal histone
+PF00809	Pterin_bind	Pterin binding enzyme
+PF00810	ER_lumen_recept	ER lumen protein retaining receptor
+PF00811	Ependymin	Ependymin
+PF00812	Ephrin	Ephrin
+PF00813	FliP	FliP family
+PF00814	Peptidase_M22	Glycoprotease family
+PF00815	Histidinol_dh	Histidinol dehydrogenase
+PF00816	Histone_HNS	H-NS histone family
+PF00817	IMS	impB/mucB/samB family
+PF00818	Ice_nucleation	Ice nucleation protein repeat
+PF00819	Myotoxins	Myotoxin, crotamine 
+PF00820	Lipoprotein_1	Borrelia lipoprotein
+PF00821	PEPCK_C	Phosphoenolpyruvate carboxykinase C-terminal P-loop domain
+PF00822	PMP22_Claudin	PMP-22/EMP/MP20/Claudin family
+PF00823	PPE	PPE family
+PF00825	Ribonuclease_P	Ribonuclease P
+PF00827	Ribosomal_L15e	Ribosomal L15
+PF00828	Ribosomal_L27A	Ribosomal proteins 50S-L15, 50S-L18e, 60S-L27A
+PF00829	Ribosomal_L21p	Ribosomal prokaryotic L21 protein
+PF00830	Ribosomal_L28	Ribosomal L28 family
+PF00831	Ribosomal_L29	Ribosomal L29 protein
+PF00832	Ribosomal_L39	Ribosomal L39 protein
+PF00833	Ribosomal_S17e	Ribosomal S17
+PF00834	Ribul_P_3_epim	Ribulose-phosphate 3 epimerase family
+PF00835	SNAP-25	SNAP-25 family
+PF00836	Stathmin	Stathmin family
+PF00837	T4_deiodinase	Iodothyronine deiodinase
+PF00838	TCTP	Translationally controlled tumour protein
+PF00839	Cys_rich_FGFR	Cysteine rich repeat
+PF00840	Glyco_hydro_7	Glycosyl hydrolase family 7
+PF00841	Protamine_P2	Sperm histone P2
+PF00842	Ala_racemase_C	Alanine racemase, C-terminal domain
+PF00843	Arena_nucleocap	Arenavirus nucleocapsid N-terminal domain
+PF00844	Gemini_coat	Geminivirus coat protein/nuclear export factor BR1 family
+PF00845	Gemini_BL1	Geminivirus BL1 movement protein
+PF00846	Hanta_nucleocap	Hantavirus nucleocapsid protein
+PF00847	AP2	AP2 domain
+PF00848	Ring_hydroxyl_A	Ring hydroxylating alpha subunit (catalytic domain)
+PF00849	PseudoU_synth_2	RNA pseudouridylate synthase
+PF00850	Hist_deacetyl	Histone deacetylase domain
+PF00851	Peptidase_C6	Helper component proteinase
+PF00852	Glyco_transf_10	Glycosyltransferase family 10 (fucosyltransferase) C-term
+PF00853	Runt	Runt domain
+PF00854	PTR2	POT family
+PF00855	PWWP	PWWP domain
+PF00856	SET	SET domain
+PF00857	Isochorismatase	Isochorismatase family
+PF00858	ASC	Amiloride-sensitive sodium channel
+PF00859	CTF_NFI	CTF/NF-I family transcription modulation region
+PF00860	Xan_ur_permease	Permease family
+PF00861	Ribosomal_L18p	Ribosomal L18 of archaea, bacteria, mitoch. and chloroplast
+PF00862	Sucrose_synth	Sucrose synthase
+PF00863	Peptidase_C4	Peptidase family C4
+PF00864	P2X_receptor	ATP P2X receptor
+PF00865	Osteopontin	Osteopontin
+PF00866	Ring_hydroxyl_B	Ring hydroxylating beta subunit
+PF00867	XPG_I	XPG I-region
+PF00868	Transglut_N	Transglutaminase family
+PF00869	Flavi_glycoprot	Flavivirus glycoprotein, central and dimerisation domains
+PF00870	P53	P53 DNA-binding domain
+PF00871	Acetate_kinase	Acetokinase family
+PF00872	Transposase_mut	Transposase, Mutator family
+PF00873	ACR_tran	AcrB/AcrD/AcrF family
+PF00874	PRD	PRD domain
+PF00875	DNA_photolyase	DNA photolyase
+PF00876	Innexin	Innexin
+PF00877	NLPC_P60	NlpC/P60 family
+PF00878	CIMR	Cation-independent mannose-6-phosphate receptor repeat
+PF00879	Defensin_propep	Defensin propeptide
+PF00880	Nebulin	Nebulin repeat
+PF00881	Nitroreductase	Nitroreductase family
+PF00882	Zn_dep_PLPC	Zinc dependent phospholipase C
+PF00883	Peptidase_M17	Cytosol aminopeptidase family, catalytic domain
+PF00884	Sulfatase	Sulfatase
+PF00885	DMRL_synthase	6,7-dimethyl-8-ribityllumazine synthase
+PF00886	Ribosomal_S16	Ribosomal protein S16
+PF00887	ACBP	Acyl CoA binding protein
+PF00888	Cullin	Cullin family
+PF00889	EF_TS	Elongation factor TS
+PF00890	FAD_binding_2	FAD binding domain
+PF00891	Methyltransf_2	O-methyltransferase
+PF00892	EamA	EamA-like transporter family
+PF00893	Multi_Drug_Res	Small Multidrug Resistance protein
+PF00894	Luteo_coat	Luteovirus coat protein
+PF00895	ATP-synt_8	ATP synthase protein 8
+PF00897	Orbi_VP7	Orbivirus inner capsid protein VP7
+PF00898	Orbi_VP2	Orbivirus outer capsid protein VP2
+PF00899	ThiF	ThiF family
+PF00900	Ribosomal_S4e	Ribosomal family S4e
+PF00901	Orbi_VP5	Orbivirus outer capsid protein VP5
+PF00902	TatC	Sec-independent protein translocase protein (TatC)
+PF00903	Glyoxalase	Glyoxalase/Bleomycin resistance protein/Dioxygenase superfamily
+PF00904	Involucrin	Involucrin repeat
+PF00905	Transpeptidase	Penicillin binding protein transpeptidase domain
+PF00906	Hepatitis_core	Hepatitis core antigen
+PF00907	T-box	T-box
+PF00908	dTDP_sugar_isom	dTDP-4-dehydrorhamnose 3,5-epimerase
+PF00909	Ammonium_transp	Ammonium Transporter Family
+PF00910	RNA_helicase	RNA helicase
+PF00912	Transgly	Transglycosylase
+PF00913	Trypan_glycop	Trypanosome variant surface glycoprotein (A-type)
+PF00915	Calici_coat	Calicivirus coat protein
+PF00916	Sulfate_transp	Sulfate permease family
+PF00917	MATH	MATH domain
+PF00918	Gastrin	Gastrin/cholecystokinin family
+PF00919	UPF0004	Uncharacterized protein family UPF0004
+PF00920	ILVD_EDD	Dehydratase family
+PF00921	Lipoprotein_2	Borrelia lipoprotein
+PF00922	Phosphoprotein	Vesiculovirus phosphoprotein
+PF00923	TAL_FSA	Transaldolase/Fructose-6-phosphate aldolase
+PF00924	MS_channel	Mechanosensitive ion channel
+PF00925	GTP_cyclohydro2	GTP cyclohydrolase II
+PF00926	DHBP_synthase	3,4-dihydroxy-2-butanone 4-phosphate synthase
+PF00927	Transglut_C	Transglutaminase family, C-terminal ig like domain
+PF00928	Adap_comp_sub	Adaptor complexes medium subunit family
+PF00929	RNase_T	Exonuclease
+PF00930	DPPIV_N	Dipeptidyl peptidase IV (DPP IV) N-terminal region
+PF00931	NB-ARC	NB-ARC domain
+PF00932	LTD	Lamin Tail Domain
+PF00933	Glyco_hydro_3	Glycosyl hydrolase family 3 N terminal domain
+PF00934	PE	PE family
+PF00935	Ribosomal_L44	Ribosomal protein L44
+PF00936	BMC	BMC domain
+PF00937	Corona_nucleoca	Coronavirus nucleocapsid protein
+PF00938	Lipoprotein_3	Lipoprotein
+PF00939	Na_sulph_symp	Sodium:sulfate symporter transmembrane region
+PF00940	RNA_pol	DNA-dependent RNA polymerase
+PF00941	FAD_binding_5	FAD binding domain in molybdopterin dehydrogenase
+PF00942	CBM_3	Cellulose binding domain
+PF00943	Alpha_E2_glycop	Alphavirus E2 glycoprotein
+PF00944	Peptidase_S3	Alphavirus core protein 
+PF00945	Rhabdo_ncap	Rhabdovirus nucleocapsid protein
+PF00946	Mononeg_RNA_pol	Mononegavirales RNA dependent RNA polymerase 
+PF00947	Pico_P2A	Picornavirus core protein 2A
+PF00948	Flavi_NS1	Flavivirus non-structural Protein NS1 
+PF00949	Peptidase_S7	Peptidase S7, Flavivirus NS3 serine protease 
+PF00950	ABC-3	ABC 3 transport family
+PF00951	Arteri_Gl	Arterivirus GL envelope glycoprotein
+PF00952	Bunya_nucleocap	Bunyavirus nucleocapsid (N) protein
+PF00953	Glycos_transf_4	Glycosyl transferase family 4
+PF00954	S_locus_glycop	S-locus glycoprotein domain
+PF00955	HCO3_cotransp	HCO3- transporter family
+PF00956	NAP	Nucleosome assembly protein (NAP)
+PF00957	Synaptobrevin	Synaptobrevin
+PF00958	GMP_synt_C	GMP synthase C terminal domain
+PF00959	Phage_lysozyme	Phage lysozyme
+PF00960	Neocarzinostat	Neocarzinostatin family
+PF00961	LAGLIDADG_1	LAGLIDADG endonuclease
+PF00962	A_deaminase	Adenosine/AMP deaminase
+PF00963	Cohesin	Cohesin domain
+PF00964	Elicitin	Elicitin
+PF00965	TIMP	Tissue inhibitor of metalloproteinase
+PF00967	Barwin	Barwin family
+PF00969	MHC_II_beta	Class II histocompatibility antigen, beta domain
+PF00970	FAD_binding_6	Oxidoreductase FAD-binding domain
+PF00971	EIAV_GP90	EIAV coat protein, gp90
+PF00972	Flavi_NS5	Flavivirus RNA-directed RNA polymerase
+PF00973	Paramyxo_ncap	Paramyxovirus nucleocapsid protein
+PF00974	Rhabdo_glycop	Rhabdovirus spike glycoprotein
+PF00975	Thioesterase	Thioesterase domain
+PF00976	ACTH_domain	Corticotropin ACTH domain
+PF00977	His_biosynth	Histidine biosynthesis protein
+PF00978	RdRP_2	RNA dependent RNA polymerase
+PF00979	Reovirus_cap	Reovirus outer capsid protein, Sigma 3
+PF00980	Rota_Capsid_VP6	Rotavirus major capsid protein VP6
+PF00981	Rota_NS53	Rotavirus RNA-binding Protein 53 (NS53)
+PF00982	Glyco_transf_20	Glycosyltransferase family 20
+PF00983	Tymo_coat	Tymovirus coat protein
+PF00984	UDPG_MGDP_dh	UDP-glucose/GDP-mannose dehydrogenase family, central domain
+PF00985	MSA_2	Merozoite Surface Antigen 2 (MSA-2) family
+PF00986	DNA_gyraseB_C	DNA gyrase B subunit, carboxyl terminus
+PF00988	CPSase_sm_chain	Carbamoyl-phosphate synthase small chain, CPSase domain
+PF00989	PAS	PAS fold
+PF00990	GGDEF	Diguanylate cyclase, GGDEF domain
+PF00992	Troponin	Troponin
+PF00993	MHC_II_alpha	Class II histocompatibility antigen, alpha domain
+PF00994	MoCF_biosynth	Probable molybdopterin binding domain
+PF00995	Sec1	Sec1 family
+PF00996	GDI	GDP dissociation inhibitor
+PF00997	Casein_kappa	Kappa casein
+PF00998	RdRP_3	Viral RNA dependent RNA polymerase
+PF00999	Na_H_Exchanger	Sodium/hydrogen exchanger family
+PF01000	RNA_pol_A_bac	RNA polymerase Rpb3/RpoA insert domain
+PF01001	HCV_NS4b	Hepatitis C virus non-structural protein NS4b
+PF01002	Flavi_NS2B	Flavivirus non-structural protein NS2B
+PF01003	Flavi_capsid	Flavivirus capsid protein C
+PF01004	Flavi_M	Flavivirus envelope glycoprotein M
+PF01005	Flavi_NS2A	Flavivirus non-structural protein NS2A
+PF01006	HCV_NS4a	Hepatitis C virus non-structural protein NS4a
+PF01007	IRK	Inward rectifier potassium channel
+PF01008	IF-2B	Initiation factor 2 subunit family
+PF01010	Proton_antipo_C	NADH-dehyrogenase subunit F, TMs, (complex I) C-terminus
+PF01011	PQQ	PQQ enzyme repeat
+PF01012	ETF	Electron transfer flavoprotein domain
+PF01014	Uricase	Uricase
+PF01015	Ribosomal_S3Ae	Ribosomal S3Ae family
+PF01016	Ribosomal_L27	Ribosomal L27 protein
+PF01017	STAT_alpha	STAT protein, all-alpha domain
+PF01018	GTP1_OBG	GTP1/OBG
+PF01019	G_glu_transpept	Gamma-glutamyltranspeptidase
+PF01020	Ribosomal_L40e	Ribosomal L40e family
+PF01021	TYA	TYA transposon protein
+PF01022	HTH_5	Bacterial regulatory protein, arsR family
+PF01023	S_100	S-100/ICaBP type calcium binding domain
+PF01024	Colicin	Colicin pore forming domain
+PF01025	GrpE	GrpE
+PF01026	TatD_DNase	TatD related DNase
+PF01027	Bax1-I	Inhibitor of apoptosis-promoting Bax1
+PF01028	Topoisom_I	Eukaryotic DNA topoisomerase I, catalytic core
+PF01029	NusB	NusB family
+PF01030	Recep_L_domain	Receptor L domain
+PF01031	Dynamin_M	Dynamin central region
+PF01032	FecCD	FecCD transport family
+PF01033	Somatomedin_B	Somatomedin B domain
+PF01034	Syndecan	Syndecan domain
+PF01035	DNA_binding_1	6-O-methylguanine DNA methyltransferase, DNA binding domain
+PF01036	Bac_rhodopsin	Bacteriorhodopsin-like protein
+PF01037	AsnC_trans_reg	Lrp/AsnC ligand binding domain
+PF01039	Carboxyl_trans	Carboxyl transferase domain
+PF01040	UbiA	UbiA prenyltransferase family
+PF01041	DegT_DnrJ_EryC1	DegT/DnrJ/EryC1/StrS aminotransferase family
+PF01042	Ribonuc_L-PSP	Endoribonuclease L-PSP
+PF01043	SecA_PP_bind	SecA preprotein cross-linking domain
+PF01044	Vinculin	Vinculin family
+PF01047	MarR	MarR family
+PF01048	PNP_UDP_1	Phosphorylase superfamily
+PF01049	Cadherin_C	Cadherin cytoplasmic region
+PF01050	MannoseP_isomer	Mannose-6-phosphate isomerase
+PF01051	Rep_3	Initiator Replication protein
+PF01052	FliMN_C	Type III flagellar switch regulator (C-ring) FliN C-term
+PF01053	Cys_Met_Meta_PP	Cys/Met metabolism PLP-dependent enzyme
+PF01054	MMTV_SAg	Mouse mammary tumour virus superantigen
+PF01055	Glyco_hydro_31	Glycosyl hydrolases family 31 
+PF01056	Myc_N	Myc amino-terminal region
+PF01057	Parvo_NS1	Parvovirus non-structural protein NS1
+PF01058	Oxidored_q6	NADH ubiquinone oxidoreductase, 20 Kd subunit
+PF01059	Oxidored_q5_N	NADH-ubiquinone oxidoreductase chain 4, amino terminus
+PF01060	TTR-52	Transthyretin-like family
+PF01061	ABC2_membrane	ABC-2 type transporter
+PF01062	Bestrophin	Bestrophin, RFP-TM, chloride channel
+PF01063	Aminotran_4	Amino-transferase class IV
+PF01064	Activin_recp	Activin types I and II receptor domain
+PF01065	Adeno_hexon	Hexon, adenovirus major coat protein, N-terminal domain
+PF01066	CDP-OH_P_transf	CDP-alcohol phosphatidyltransferase
+PF01067	Calpain_III	Calpain large subunit, domain III
+PF01068	DNA_ligase_A_M	ATP dependent DNA ligase domain
+PF01070	FMN_dh	FMN-dependent dehydrogenase
+PF01071	GARS_A	Phosphoribosylglycinamide synthetase, ATP-grasp (A) domain
+PF01073	3Beta_HSD	3-beta hydroxysteroid dehydrogenase/isomerase family
+PF01074	Glyco_hydro_38	Glycosyl hydrolases family 38 N-terminal domain
+PF01075	Glyco_transf_9	Glycosyltransferase family 9 (heptosyltransferase)
+PF01076	Mob_Pre	Plasmid recombination enzyme
+PF01077	NIR_SIR	Nitrite and sulphite reductase 4Fe-4S domain
+PF01078	Mg_chelatase	Magnesium chelatase, subunit ChlI
+PF01079	Hint	Hint module
+PF01080	Presenilin	Presenilin
+PF01081	Aldolase	KDPG and KHG aldolase
+PF01082	Cu2_monooxygen	Copper type II ascorbate-dependent monooxygenase, N-terminal domain
+PF01083	Cutinase	Cutinase
+PF01084	Ribosomal_S18	Ribosomal protein S18
+PF01085	HH_signal	Hedgehog amino-terminal signalling domain
+PF01086	Clathrin_lg_ch	Clathrin light chain
+PF01087	GalP_UDP_transf	Galactose-1-phosphate uridyl transferase, N-terminal domain
+PF01088	Peptidase_C12	Ubiquitin carboxyl-terminal hydrolase, family 1
+PF01090	Ribosomal_S19e	Ribosomal protein S19e
+PF01091	PTN_MK_C	PTN/MK heparin-binding protein family, C-terminal domain
+PF01092	Ribosomal_S6e	Ribosomal protein S6e
+PF01093	Clusterin	Clusterin
+PF01094	ANF_receptor	Receptor family ligand binding region
+PF01095	Pectinesterase	Pectinesterase
+PF01096	TFIIS_C	Transcription factor S-II (TFIIS)
+PF01097	Defensin_2	Arthropod defensin
+PF01098	FTSW_RODA_SPOVE	Cell cycle protein
+PF01099	Uteroglobin	Uteroglobin family
+PF01101	HMG14_17	HMG14 and HMG17
+PF01102	Glycophorin_A	Glycophorin A
+PF01103	Bac_surface_Ag	Surface antigen
+PF01104	Bunya_NS-S	Bunyavirus non-structural protein NS-s
+PF01105	EMP24_GP25L	emp24/gp25L/p24 family/GOLD
+PF01106	NifU	NifU-like domain
+PF01107	MP	Viral movement protein (MP)
+PF01108	Tissue_fac	Tissue factor
+PF01109	GM_CSF	Granulocyte-macrophage colony-stimulating factor
+PF01110	CNTF	Ciliary neurotrophic factor
+PF01111	CKS	Cyclin-dependent kinase regulatory subunit
+PF01112	Asparaginase_2	Asparaginase
+PF01113	DapB_N	Dihydrodipicolinate reductase, N-terminus
+PF01114	Colipase	Colipase, N-terminal domain
+PF01115	F_actin_cap_B	F-actin capping protein, beta subunit
+PF01116	F_bP_aldolase	Fructose-bisphosphate aldolase class-II
+PF01117	Aerolysin	Aerolysin toxin
+PF01118	Semialdhyde_dh	Semialdehyde dehydrogenase, NAD binding domain
+PF01119	DNA_mis_repair	DNA mismatch repair protein, C-terminal domain
+PF01120	Alpha_L_fucos	Alpha-L-fucosidase
+PF01121	CoaE	Dephospho-CoA kinase
+PF01122	Cobalamin_bind	Eukaryotic cobalamin-binding protein
+PF01123	Stap_Strp_toxin	Staphylococcal/Streptococcal toxin, OB-fold domain
+PF01124	MAPEG	MAPEG family
+PF01125	G10	G10 protein
+PF01126	Heme_oxygenase	Heme oxygenase
+PF01127	Sdh_cyt	Succinate dehydrogenase/Fumarate reductase transmembrane subunit
+PF01128	IspD	2-C-methyl-D-erythritol 4-phosphate cytidylyltransferase
+PF01129	ART	NAD:arginine ADP-ribosyltransferase
+PF01130	CD36	CD36 family
+PF01131	Topoisom_bac	DNA topoisomerase
+PF01132	EFP	Elongation factor P (EF-P) OB domain
+PF01133	ER	Enhancer of rudimentary
+PF01134	GIDA	Glucose inhibited division protein A
+PF01135	PCMT	Protein-L-isoaspartate(D-aspartate) O-methyltransferase (PCMT)
+PF01136	Peptidase_U32	Peptidase family U32
+PF01137	RTC	RNA 3'-terminal phosphate cyclase
+PF01138	RNase_PH	3' exoribonuclease family, domain 1
+PF01139	RtcB	tRNA-splicing ligase RtcB
+PF01140	Gag_MA	Matrix protein (MA), p15
+PF01141	Gag_p12	Gag polyprotein, inner coat protein p12
+PF01142	TruD	tRNA pseudouridine synthase D (TruD)
+PF01144	CoA_trans	Coenzyme A transferase
+PF01145	Band_7	SPFH domain / Band 7 family
+PF01146	Caveolin	Caveolin
+PF01147	Crust_neurohorm	Crustacean CHH/MIH/GIH neurohormone family
+PF01148	CTP_transf_1	Cytidylyltransferase family
+PF01149	Fapy_DNA_glyco	Formamidopyrimidine-DNA glycosylase N-terminal domain
+PF01150	GDA1_CD39	GDA1/CD39 (nucleoside phosphatase) family
+PF01151	ELO	GNS1/SUR4 family
+PF01152	Bac_globin	Bacterial-like globin
+PF01153	Glypican	Glypican
+PF01154	HMG_CoA_synt_N	Hydroxymethylglutaryl-coenzyme A synthase N terminal
+PF01155	HypA	Hydrogenase/urease nickel incorporation, metallochaperone, hypA
+PF01156	IU_nuc_hydro	Inosine-uridine preferring nucleoside hydrolase
+PF01157	Ribosomal_L21e	Ribosomal protein L21e
+PF01158	Ribosomal_L36e	Ribosomal protein L36e
+PF01159	Ribosomal_L6e	Ribosomal protein L6e 
+PF01160	Opiods_neuropep	Vertebrate endogenous opioids neuropeptide
+PF01161	PBP	Phosphatidylethanolamine-binding protein
+PF01163	RIO1	RIO1 family
+PF01165	Ribosomal_S21	Ribosomal protein S21
+PF01166	TSC22	TSC-22/dip/bun family
+PF01167	Tub	Tub family
+PF01168	Ala_racemase_N	Alanine racemase, N-terminal domain
+PF01169	UPF0016	Uncharacterized protein family UPF0016
+PF01170	UPF0020	Putative RNA methylase family UPF0020
+PF01171	ATP_bind_3	PP-loop family
+PF01172	SBDS	Shwachman-Bodian-Diamond syndrome (SBDS) protein 
+PF01174	SNO	SNO glutamine amidotransferase family
+PF01175	Urocanase	Urocanase Rossmann-like domain
+PF01176	eIF-1a	Translation initiation factor 1A / IF-1
+PF01177	Asp_Glu_race	Asp/Glu/Hydantoin racemase
+PF01179	Cu_amine_oxid	Copper amine oxidase, enzyme domain
+PF01180	DHO_dh	Dihydroorotate dehydrogenase
+PF01182	Glucosamine_iso	Glucosamine-6-phosphate isomerases/6-phosphogluconolactonase
+PF01183	Glyco_hydro_25	Glycosyl hydrolases family 25
+PF01184	Grp1_Fun34_YaaH	GPR1/FUN34/yaaH family
+PF01185	Hydrophobin	Fungal hydrophobin
+PF01186	Lysyl_oxidase	Lysyl oxidase 
+PF01187	MIF	Macrophage migration inhibitory factor (MIF)
+PF01189	Methyltr_RsmB-F	16S rRNA methyltransferase RsmB/F
+PF01190	Pollen_Ole_e_I	Pollen proteins Ole e I like
+PF01191	RNA_pol_Rpb5_C	RNA polymerase Rpb5, C-terminal domain
+PF01192	RNA_pol_Rpb6	RNA polymerase Rpb6 
+PF01193	RNA_pol_L	RNA polymerase Rpb3/Rpb11 dimerisation domain
+PF01194	RNA_pol_N	RNA polymerases N / 8 kDa subunit
+PF01195	Pept_tRNA_hydro	Peptidyl-tRNA hydrolase
+PF01196	Ribosomal_L17	Ribosomal protein L17
+PF01197	Ribosomal_L31	Ribosomal protein L31
+PF01198	Ribosomal_L31e	Ribosomal protein L31e
+PF01199	Ribosomal_L34e	Ribosomal protein L34e
+PF01200	Ribosomal_S28e	Ribosomal protein S28e
+PF01201	Ribosomal_S8e	Ribosomal protein S8e
+PF01202	SKI	Shikimate kinase
+PF01203	T2SSN	Type II secretion system (T2SS), protein N
+PF01204	Trehalase	Trehalase
+PF01205	UPF0029	Uncharacterized protein family UPF0029
+PF01206	TusA	Sulfurtransferase TusA
+PF01207	Dus	Dihydrouridine synthase (Dus)
+PF01208	URO-D	Uroporphyrinogen decarboxylase (URO-D)
+PF01209	Ubie_methyltran	ubiE/COQ5 methyltransferase family
+PF01210	NAD_Gly3P_dh_N	NAD-dependent glycerol-3-phosphate dehydrogenase N-terminus
+PF01212	Beta_elim_lyase	Beta-eliminating lyase
+PF01213	CAP_N	Adenylate cyclase associated (CAP) N terminal
+PF01214	CK_II_beta	Casein kinase II regulatory subunit
+PF01215	COX5B	Cytochrome c oxidase subunit Vb
+PF01216	Calsequestrin	Calsequestrin
+PF01217	Clat_adaptor_s	Clathrin adaptor complex small chain
+PF01218	Coprogen_oxidas	Coproporphyrinogen III oxidase
+PF01219	DAGK_prokar	Prokaryotic diacylglycerol kinase
+PF01220	DHquinase_II	Dehydroquinase class II
+PF01221	Dynein_light	Dynein light chain type 1 
+PF01222	ERG4_ERG24	Ergosterol biosynthesis ERG4/ERG24 family
+PF01223	Endonuclease_NS	DNA/RNA non-specific endonuclease
+PF01225	Mur_ligase	Mur ligase family, catalytic domain
+PF01226	Form_Nir_trans	Formate/nitrite transporter
+PF01227	GTP_cyclohydroI	GTP cyclohydrolase I
+PF01228	Gly_radical	Glycine radical
+PF01229	Glyco_hydro_39	Glycosyl hydrolases family 39
+PF01230	HIT	HIT domain
+PF01231	IDO	Indoleamine 2,3-dioxygenase
+PF01232	Mannitol_dh	Mannitol dehydrogenase Rossmann domain
+PF01233	NMT	Myristoyl-CoA:protein N-myristoyltransferase, N-terminal domain
+PF01234	NNMT_PNMT_TEMT	NNMT/PNMT/TEMT family
+PF01235	Na_Ala_symp	Sodium:alanine symporter family
+PF01237	Oxysterol_BP	Oxysterol-binding protein 
+PF01238	PMI_typeI	Phosphomannose isomerase type I
+PF01239	PPTA	Protein prenyltransferase alpha subunit repeat
+PF01241	PSI_PSAK	Photosystem I psaG / psaK
+PF01242	PTPS	6-pyruvoyl tetrahydropterin synthase
+PF01243	Putative_PNPOx	Pyridoxamine 5'-phosphate oxidase
+PF01244	Peptidase_M19	Membrane dipeptidase (Peptidase family M19)
+PF01245	Ribosomal_L19	Ribosomal protein L19
+PF01246	Ribosomal_L24e	Ribosomal protein L24e
+PF01247	Ribosomal_L35Ae	Ribosomal protein L35Ae
+PF01248	Ribosomal_L7Ae	Ribosomal protein L7Ae/L30e/S12e/Gadd45 family
+PF01249	Ribosomal_S21e	Ribosomal protein S21e 
+PF01250	Ribosomal_S6	Ribosomal protein S6
+PF01251	Ribosomal_S7e	Ribosomal protein S7e
+PF01252	Peptidase_A8	Signal peptidase (SPase) II
+PF01253	SUI1	Translation initiation factor SUI1
+PF01254	TP2	Nuclear transition protein 2
+PF01255	Prenyltransf	Putative undecaprenyl diphosphate synthase
+PF01256	Carb_kinase	Carbohydrate kinase
+PF01257	2Fe-2S_thioredx	Thioredoxin-like [2Fe-2S] ferredoxin
+PF01258	zf-dskA_traR	Prokaryotic dksA/traR C4-type zinc finger
+PF01259	SAICAR_synt	SAICAR synthetase
+PF01261	AP_endonuc_2	Xylose isomerase-like TIM barrel
+PF01262	AlaDh_PNT_C	Alanine dehydrogenase/PNT, C-terminal domain
+PF01263	Aldose_epim	Aldose 1-epimerase
+PF01264	Chorismate_synt	Chorismate synthase
+PF01265	Cyto_heme_lyase	Cytochrome c/c1 heme lyase
+PF01266	DAO	FAD dependent oxidoreductase
+PF01267	F-actin_cap_A	F-actin capping protein alpha subunit
+PF01268	FTHFS	Formate--tetrahydrofolate ligase
+PF01269	Fibrillarin	Fibrillarin
+PF01270	Glyco_hydro_8	Glycosyl hydrolases family 8
+PF01271	Granin	Granin (chromogranin or secretogranin)
+PF01272	GreA_GreB	Transcription elongation factor, GreA/GreB, C-term
+PF01273	LBP_BPI_CETP	LBP / BPI / CETP family, N-terminal domain
+PF01274	Malate_synthase	Malate synthase
+PF01275	Myelin_PLP	Myelin proteolipid protein (PLP or lipophilin)
+PF01276	OKR_DC_1	Orn/Lys/Arg decarboxylase, major domain
+PF01277	Oleosin	Oleosin
+PF01278	Omptin	Omptin family
+PF01279	Parathyroid	Parathyroid hormone family
+PF01280	Ribosomal_L19e	Ribosomal protein L19e
+PF01281	Ribosomal_L9_N	Ribosomal protein L9, N-terminal domain
+PF01282	Ribosomal_S24e	Ribosomal protein S24e
+PF01283	Ribosomal_S26e	Ribosomal protein S26e
+PF01284	MARVEL	Membrane-associating domain
+PF01285	TEA	TEA/ATTS domain family
+PF01286	XPA_N	XPA protein N-terminal
+PF01287	eIF-5a	Eukaryotic elongation factor 5A hypusine, DNA-binding OB fold
+PF01288	HPPK	7,8-dihydro-6-hydroxymethylpterin-pyrophosphokinase (HPPK)
+PF01289	Thiol_cytolysin	Thiol-activated cytolysin
+PF01290	Thymosin	Thymosin beta-4 family
+PF01291	LIF_OSM	LIF / OSM family
+PF01292	Ni_hydr_CYTB	Prokaryotic cytochrome b561
+PF01293	PEPCK_ATP	Phosphoenolpyruvate carboxykinase
+PF01294	Ribosomal_L13e	Ribosomal protein L13e
+PF01295	Adenylate_cycl	Adenylate cyclase, class-I
+PF01296	Galanin	Galanin
+PF01297	ZnuA	Zinc-uptake complex component A periplasmic
+PF01298	TbpB_B_D	C-lobe and N-lobe beta barrels of Tf-binding protein B
+PF01299	Lamp	Lysosome-associated membrane glycoprotein (Lamp)
+PF01300	Sua5_yciO_yrdC	Telomere recombination
+PF01301	Glyco_hydro_35	Glycosyl hydrolases family 35
+PF01302	CAP_GLY	CAP-Gly domain
+PF01303	Egg_lysin	Egg lysin (Sperm-lysin)
+PF01304	Gas_vesicle_C	Gas vesicles protein GVPc repeated domain
+PF01306	LacY_symp	LacY proton/sugar symporter
+PF01307	Plant_vir_prot	Plant viral movement protein
+PF01308	Chlam_OMP	Chlamydia major outer membrane protein
+PF01309	EAV_GS	Equine arteritis virus small envelope glycoprotein 
+PF01310	Adeno_PVIII	Adenovirus hexon associated protein, protein VIII
+PF01311	Bac_export_1	Bacterial export proteins, family 1
+PF01312	Bac_export_2	FlhB HrpN YscU SpaS Family
+PF01313	Bac_export_3	Bacterial export proteins, family 3
+PF01314	AFOR_C	Aldehyde ferredoxin oxidoreductase, domains 2 & 3
+PF01315	Ald_Xan_dh_C	Aldehyde oxidase and xanthine dehydrogenase, a/b hammerhead domain
+PF01316	Arg_repressor	Arginine repressor, DNA binding domain
+PF01318	Bromo_coat	Bromovirus coat protein
+PF01320	Colicin_Pyocin	Colicin immunity protein / pyocin immunity protein
+PF01321	Creatinase_N	Creatinase/Prolidase N-terminal domain
+PF01322	Cytochrom_C_2	Cytochrome C'
+PF01323	DSBA	DSBA-like thioredoxin domain
+PF01324	Diphtheria_R	Diphtheria toxin, R domain
+PF01325	Fe_dep_repress	Iron dependent repressor, N-terminal DNA binding domain
+PF01326	PPDK_N	Pyruvate phosphate dikinase, PEP/pyruvate binding domain
+PF01327	Pep_deformylase	Polypeptide deformylase
+PF01328	Peroxidase_2	Peroxidase, family 2
+PF01329	Pterin_4a	Pterin 4 alpha carbinolamine dehydratase
+PF01330	RuvA_N	RuvA N terminal domain
+PF01331	mRNA_cap_enzyme	mRNA capping enzyme, catalytic domain
+PF01333	Apocytochr_F_C	Apocytochrome F, C-terminal
+PF01335	DED	Death effector domain
+PF01336	tRNA_anti-codon	OB-fold nucleic acid binding domain
+PF01337	Barstar	Barstar (barnase inhibitor)
+PF01338	Bac_thur_toxin	Bacillus thuringiensis toxin
+PF01339	CheB_methylest	CheB methylesterase
+PF01340	MetJ	Met Apo-repressor, MetJ
+PF01341	Glyco_hydro_6	Glycosyl hydrolases family 6
+PF01342	SAND	SAND domain
+PF01343	Peptidase_S49	Peptidase family S49
+PF01344	Kelch_1	Kelch motif
+PF01345	DUF11	Domain of unknown function DUF11
+PF01346	FKBP_N	Domain amino terminal to FKBP-type peptidyl-prolyl isomerase
+PF01347	Vitellogenin_N	Lipoprotein amino terminal region
+PF01348	Intron_maturas2	Type II intron maturase
+PF01349	Flavi_NS4B	Flavivirus non-structural protein NS4B
+PF01350	Flavi_NS4A	Flavivirus non-structural protein NS4A
+PF01351	RNase_HII	Ribonuclease HII
+PF01352	KRAB	KRAB box
+PF01353	GFP	Green fluorescent protein
+PF01355	HIPIP	High potential iron-sulfur protein
+PF01356	A_amylase_inhib	Alpha amylase inhibitor
+PF01357	Pollen_allerg_1	Pollen allergen
+PF01358	PARP_regulatory	Poly A polymerase regulatory subunit
+PF01359	Transposase_1	Transposase (partial DDE domain)
+PF01361	Tautomerase	Tautomerase enzyme
+PF01363	FYVE	FYVE zinc finger
+PF01364	Peptidase_C25	Peptidase family C25
+PF01365	RYDR_ITPR	RIH domain
+PF01366	PRTP	Herpesvirus processing and transport protein
+PF01367	5_3_exonuc	5'-3' exonuclease, C-terminal SAM fold
+PF01368	DHH	DHH family
+PF01369	Sec7	Sec7 domain
+PF01370	Epimerase	NAD dependent epimerase/dehydratase family
+PF01371	Trp_repressor	Trp repressor protein
+PF01372	Melittin	Melittin
+PF01373	Glyco_hydro_14	Glycosyl hydrolase family 14
+PF01374	Glyco_hydro_46	Glycosyl hydrolase family 46
+PF01375	Enterotoxin_a	Heat-labile enterotoxin alpha chain
+PF01376	Enterotoxin_b	Heat-labile enterotoxin beta chain
+PF01378	IgG_binding_B	B domain
+PF01379	Porphobil_deam	Porphobilinogen deaminase, dipyromethane cofactor binding domain
+PF01380	SIS	SIS domain
+PF01381	HTH_3	Helix-turn-helix
+PF01382	Avidin	Avidin family
+PF01383	CpcD	CpcD/allophycocyanin linker domain
+PF01384	PHO4	Phosphate transporter family
+PF01385	OrfB_IS605	Probable transposase
+PF01386	Ribosomal_L25p	Ribosomal L25p family
+PF01387	Synuclein	Synuclein
+PF01388	ARID	ARID/BRIGHT DNA binding domain
+PF01389	OmpA_membrane	OmpA-like transmembrane domain
+PF01390	SEA	SEA domain
+PF01391	Collagen	Collagen triple helix repeat (20 copies)
+PF01392	Fz	Fz domain
+PF01393	Chromo_shadow	Chromo shadow domain
+PF01394	Clathrin_propel	Clathrin propeller repeat
+PF01395	PBP_GOBP	PBP/GOBP family
+PF01396	zf-C4_Topoisom	Topoisomerase DNA binding C4 zinc finger
+PF01397	Terpene_synth	Terpene synthase, N-terminal domain
+PF01398	JAB	JAB1/Mov34/MPN/PAD-1 ubiquitin protease
+PF01399	PCI	PCI domain
+PF01400	Astacin	Astacin (Peptidase family M12A)
+PF01401	Peptidase_M2	Angiotensin-converting enzyme
+PF01402	RHH_1	Ribbon-helix-helix protein, copG family
+PF01403	Sema	Sema domain
+PF01404	Ephrin_lbd	Ephrin receptor ligand binding domain
+PF01405	PsbT	Photosystem II reaction centre T protein
+PF01406	tRNA-synt_1e	tRNA synthetases class I (C) catalytic domain
+PF01407	Gemini_AL3	Geminivirus AL3 protein
+PF01408	GFO_IDH_MocA	Oxidoreductase family, NAD-binding Rossmann fold
+PF01409	tRNA-synt_2d	tRNA synthetases class II core domain (F)
+PF01410	COLFI	Fibrillar collagen C-terminal domain
+PF01411	tRNA-synt_2c	tRNA synthetases class II (A)
+PF01412	ArfGap	Putative GTPase activating protein for Arf
+PF01413	C4	C-terminal tandem repeated domain in type 4 procollagen
+PF01414	DSL	Delta serrate ligand
+PF01415	IL7	Interleukin 7/9 family
+PF01416	PseudoU_synth_1	tRNA pseudouridine synthase
+PF01417	ENTH	ENTH domain
+PF01418	HTH_6	Helix-turn-helix domain, rpiR family
+PF01419	Jacalin	Jacalin-like lectin domain
+PF01420	Methylase_S	Type I restriction modification DNA specificity domain
+PF01421	Reprolysin	Reprolysin (M12B) family zinc metalloprotease 
+PF01422	zf-NF-X1	NF-X1 type zinc finger
+PF01423	LSM	LSM domain 
+PF01424	R3H	R3H domain
+PF01425	Amidase	Amidase
+PF01426	BAH	BAH domain
+PF01427	Peptidase_M15	D-ala-D-ala dipeptidase
+PF01428	zf-AN1	AN1-like Zinc finger
+PF01429	MBD	Methyl-CpG binding domain
+PF01430	HSP33	Hsp33 protein
+PF01431	Peptidase_M13	Peptidase family M13
+PF01432	Peptidase_M3	Peptidase family M3
+PF01433	Peptidase_M1	Peptidase family M1 domain
+PF01434	Peptidase_M41	Peptidase family M41
+PF01435	Peptidase_M48	Peptidase family M48
+PF01436	NHL	NHL repeat
+PF01437	PSI	Plexin repeat
+PF01439	Metallothio_2	Metallothionein
+PF01440	Gemini_AL2	Geminivirus AL2 protein
+PF01441	Lipoprotein_6	Lipoprotein
+PF01442	Apolipoprotein	Apolipoprotein A1/A4/E domain
+PF01443	Viral_helicase1	Viral (Superfamily 1) RNA helicase
+PF01445	SH	Viral small hydrophobic protein
+PF01446	Rep_1	Replication protein
+PF01447	Peptidase_M4	Thermolysin metallopeptidase, catalytic domain
+PF01448	ELM2	ELM2 domain
+PF01450	IlvC	Acetohydroxy acid isomeroreductase, catalytic domain
+PF01451	LMWPc	Low molecular weight phosphotyrosine protein phosphatase
+PF01452	Rota_NSP4	Rotavirus non structural protein
+PF01453	B_lectin	D-mannose binding lectin
+PF01454	MAGE	MAGE family
+PF01455	HupF_HypC	HupF/HypC family
+PF01456	Mucin	Mucin-like glycoprotein
+PF01457	Peptidase_M8	Leishmanolysin
+PF01458	UPF0051	Uncharacterized protein family (UPF0051)
+PF01459	Porin_3	Eukaryotic porin
+PF01462	LRRNT	Leucine rich repeat N-terminal domain
+PF01463	LRRCT	Leucine rich repeat C-terminal domain
+PF01464	SLT	Transglycosylase SLT domain
+PF01465	GRIP	GRIP domain
+PF01466	Skp1	Skp1 family, dimerisation domain
+PF01467	CTP_transf_like	Cytidylyltransferase-like
+PF01468	GA	GA module
+PF01469	Pentapeptide_2	Pentapeptide repeats (8 copies)
+PF01470	Peptidase_C15	Pyroglutamyl peptidase
+PF01471	PG_binding_1	Putative peptidoglycan binding domain
+PF01472	PUA	PUA domain
+PF01473	CW_binding_1	Putative cell wall binding repeat
+PF01474	DAHP_synth_2	Class-II DAHP synthetase family
+PF01475	FUR	Ferric uptake regulator family
+PF01476	LysM	LysM domain
+PF01477	PLAT	PLAT/LH2 domain
+PF01478	Peptidase_A24	Type IV leader peptidase family
+PF01479	S4	S4 domain
+PF01480	PWI	PWI domain
+PF01481	Arteri_nucleo	Arterivirus nucleocapsid protein
+PF01483	P_proprotein	Proprotein convertase P-domain
+PF01484	Col_cuticle_N	Nematode cuticle collagen N-terminal domain
+PF01485	IBR	IBR domain, a half RING-finger domain
+PF01486	K-box	K-box region
+PF01487	DHquinase_I	Type I 3-dehydroquinase
+PF01488	Shikimate_DH	Shikimate / quinate 5-dehydrogenase
+PF01490	Aa_trans	Transmembrane amino acid transporter protein
+PF01491	Frataxin_Cyay	Frataxin-like domain
+PF01492	Gemini_C4	Geminivirus C4 protein
+PF01493	GXGXG	GXGXG motif
+PF01494	FAD_binding_3	FAD binding domain
+PF01496	V_ATPase_I	V-type ATPase 116kDa subunit family  
+PF01497	Peripla_BP_2	Periplasmic binding protein
+PF01498	HTH_Tnp_Tc3_2	Transposase
+PF01499	Herpes_UL25	Herpesvirus UL25 family
+PF01500	Keratin_B2	Keratin, high sulfur B2 protein
+PF01501	Glyco_transf_8	Glycosyl transferase family 8
+PF01502	PRA-CH	Phosphoribosyl-AMP cyclohydrolase
+PF01503	PRA-PH	Phosphoribosyl-ATP pyrophosphohydrolase
+PF01504	PIP5K	Phosphatidylinositol-4-phosphate 5-Kinase
+PF01505	Vault	Major Vault Protein repeat
+PF01506	HCV_NS5a	Hepatitis C virus non-structural 5a protein membrane anchor
+PF01507	PAPS_reduct	Phosphoadenosine phosphosulfate reductase family
+PF01508	Paramecium_SA	Paramecium surface antigen domain
+PF01509	TruB_N	TruB family pseudouridylate synthase (N terminal domain)
+PF01510	Amidase_2	N-acetylmuramoyl-L-alanine amidase
+PF01512	Complex1_51K	Respiratory-chain NADH dehydrogenase 51 Kd subunit
+PF01513	NAD_kinase	ATP-NAD kinase
+PF01514	YscJ_FliF	Secretory protein of YscJ/FliF family
+PF01515	PTA_PTB	Phosphate acetyl/butaryl transferase
+PF01516	Orbi_VP6	Orbivirus helicase VP6
+PF01517	HDV_ag	Hepatitis delta virus delta antigen
+PF01518	PolyG_pol	Sigma NS protein
+PF01519	DUF16	Protein of unknown function DUF16
+PF01520	Amidase_3	N-acetylmuramoyl-L-alanine amidase
+PF01521	Fe-S_biosyn	Iron-sulphur cluster biosynthesis
+PF01522	Polysacc_deac_1	Polysaccharide deacetylase
+PF01523	PmbA_TldD	Putative modulator of DNA gyrase
+PF01524	Gemini_V2	Geminivirus V2 protein
+PF01525	Rota_NS26	Rotavirus NS26
+PF01526	DDE_Tnp_Tn3	Tn3 transposase DDE domain
+PF01527	HTH_Tnp_1	Transposase
+PF01528	Herpes_glycop	Herpesvirus glycoprotein M
+PF01529	DHHC	DHHC palmitoyltransferase
+PF01530	zf-C2HC	Zinc finger, C2HC type
+PF01531	Glyco_transf_11	Glycosyl transferase family 11
+PF01532	Glyco_hydro_47	Glycosyl hydrolase family 47
+PF01533	Tospo_nucleocap	Tospovirus nucleocapsid protein
+PF01534	Frizzled	Frizzled/Smoothened family membrane region
+PF01535	PPR	PPR repeat
+PF01536	SAM_decarbox	Adenosylmethionine decarboxylase
+PF01537	Herpes_glycop_D	Herpesvirus glycoprotein D/GG/GX domain
+PF01538	HCV_NS2	Hepatitis C virus non-structural protein NS2
+PF01539	HCV_env	Hepatitis C virus envelope glycoprotein E1
+PF01540	Lipoprotein_7	Adhesin lipoprotein
+PF01541	GIY-YIG	GIY-YIG catalytic domain
+PF01542	HCV_core	Hepatitis C virus core protein
+PF01543	HCV_capsid	Hepatitis C virus capsid protein
+PF01544	CorA	CorA-like Mg2+ transporter protein
+PF01545	Cation_efflux	Cation efflux family
+PF01546	Peptidase_M20	Peptidase family M20/M25/M40
+PF01547	SBP_bac_1	Bacterial extracellular solute-binding protein
+PF01548	DEDD_Tnp_IS110	Transposase
+PF01549	ShK	ShK domain-like
+PF01551	Peptidase_M23	Peptidase family M23
+PF01552	Pico_P2B	Picornavirus 2B protein
+PF01553	Acyltransferase	Acyltransferase
+PF01554	MatE	MatE
+PF01555	N6_N4_Mtase	DNA methylase
+PF01556	DnaJ_C	DnaJ C terminal domain
+PF01557	FAA_hydrolase	Fumarylacetoacetate (FAA) hydrolase family
+PF01558	POR	Pyruvate ferredoxin/flavodoxin oxidoreductase
+PF01559	Zein	Zein seed storage protein
+PF01560	HCV_NS1	Hepatitis C virus non-structural protein E2/NS1
+PF01561	Hanta_G2	Hantavirus glycoprotein G2
+PF01562	Pep_M12B_propep	Reprolysin family propeptide
+PF01563	Alpha_E3_glycop	Alphavirus E3 glycoprotein
+PF01564	Spermine_synth	Spermine/spermidine synthase domain
+PF01565	FAD_binding_4	FAD binding domain 
+PF01566	Nramp	Natural resistance-associated macrophage protein
+PF01567	Hanta_G1	Hantavirus glycoprotein G1
+PF01568	Molydop_binding	Molydopterin dinucleotide binding domain
+PF01569	PAP2	PAP2 superfamily
+PF01570	Flavi_propep	Flavivirus polyprotein propeptide
+PF01571	GCV_T	Aminomethyltransferase folate-binding domain
+PF01573	Bromo_MP	Bromovirus movement protein
+PF01575	MaoC_dehydratas	MaoC like domain
+PF01576	Myosin_tail_1	Myosin tail
+PF01577	Peptidase_S30	Potyvirus P1 protease
+PF01578	Cytochrom_C_asm	Cytochrome C assembly protein
+PF01579	DUF19	Domain of unknown function (DUF19)
+PF01580	FtsK_SpoIIIE	FtsK/SpoIIIE family
+PF01581	FARP	FMRFamide related peptide family
+PF01582	TIR	TIR domain
+PF01583	APS_kinase	Adenylylsulphate kinase
+PF01584	CheW	CheW-like domain
+PF01585	G-patch	G-patch domain
+PF01586	Basic	Myogenic Basic domain
+PF01588	tRNA_bind	Putative tRNA binding domain
+PF01589	Alpha_E1_glycop	Alphavirus E1 glycoprotein
+PF01590	GAF	GAF domain
+PF01591	6PF2K	6-phosphofructo-2-kinase
+PF01592	NifU_N	NifU-like N terminal domain
+PF01593	Amino_oxidase	Flavin containing amine oxidoreductase
+PF01594	AI-2E_transport	AI-2E family transporter
+PF01595	DUF21	Domain of unknown function DUF21
+PF01596	Methyltransf_3	O-methyltransferase
+PF01597	GCV_H	Glycine cleavage H-protein
+PF01599	Ribosomal_S27	Ribosomal protein S27a
+PF01600	Corona_S1	Coronavirus S1 glycoprotein
+PF01601	Corona_S2	Coronavirus S2 glycoprotein
+PF01602	Adaptin_N	Adaptin N terminal region
+PF01603	B56	Protein phosphatase 2A regulatory B subunit (B56 family)
+PF01606	Arteri_env	Arterivirus envelope protein
+PF01607	CBM_14	Chitin binding Peritrophin-A domain
+PF01608	I_LWEQ	I/LWEQ domain
+PF01609	DDE_Tnp_1	Transposase DDE domain
+PF01610	DDE_Tnp_ISL3	Transposase
+PF01611	Filo_glycop	Filovirus glycoprotein
+PF01612	DNA_pol_A_exo1	3'-5' exonuclease
+PF01613	Flavin_Reduct	Flavin reductase like domain
+PF01614	IclR	Bacterial transcriptional regulator
+PF01616	Orbi_NS3	Orbivirus NS3
+PF01617	Surface_Ag_2	Surface antigen
+PF01618	MotA_ExbB	MotA/TolQ/ExbB proton channel family
+PF01619	Pro_dh	Proline dehydrogenase
+PF01620	Pollen_allerg_2	Ribonuclease (pollen allergen)
+PF01621	Fusion_gly_K	Cell fusion glycoprotein K
+PF01623	Carla_C4	Carlavirus putative nucleic acid binding protein
+PF01624	MutS_I	MutS domain I
+PF01625	PMSR	Peptide methionine sulfoxide reductase
+PF01627	Hpt	Hpt domain
+PF01628	HrcA	HrcA protein C terminal domain
+PF01629	DUF22	Domain of unknown function DUF22
+PF01630	Glyco_hydro_56	Hyaluronidase
+PF01632	Ribosomal_L35p	Ribosomal protein L35
+PF01633	Choline_kinase	Choline/ethanolamine kinase
+PF01634	HisG	ATP phosphoribosyltransferase
+PF01635	Corona_M	Coronavirus M matrix/glycoprotein
+PF01636	APH	Phosphotransferase enzyme family
+PF01637	ATPase_2	ATPase domain predominantly from Archaea
+PF01638	HxlR	HxlR-like helix-turn-helix
+PF01639	v110	Viral family 110
+PF01640	Peptidase_C10	Peptidase C10 family
+PF01641	SelR	SelR domain
+PF01642	MM_CoA_mutase	Methylmalonyl-CoA mutase
+PF01643	Acyl-ACP_TE	Acyl-ACP thioesterase
+PF01644	Chitin_synth_1	Chitin synthase
+PF01645	Glu_synthase	Conserved region in glutamate synthase
+PF01646	Herpes_UL24	Herpes virus proteins UL24 and UL76
+PF01648	ACPS	4'-phosphopantetheinyl transferase superfamily
+PF01649	Ribosomal_S20p	Ribosomal protein S20
+PF01650	Peptidase_C13	Peptidase C13 family
+PF01652	IF4E	Eukaryotic initiation factor 4E
+PF01653	DNA_ligase_aden	NAD-dependent DNA ligase adenylation domain
+PF01654	Cyt_bd_oxida_I	Cytochrome bd terminal oxidase subunit I
+PF01655	Ribosomal_L32e	Ribosomal protein L32
+PF01656	CbiA	CobQ/CobB/MinD/ParA nucleotide binding domain
+PF01657	Stress-antifung	Salt stress response/antifungal
+PF01658	Inos-1-P_synth	Myo-inositol-1-phosphate synthase
+PF01659	Luteo_Vpg	Luteovirus putative VPg genome linked protein
+PF01660	Vmethyltransf	Viral methyltransferase
+PF01661	Macro	Macro domain
+PF01663	Phosphodiest	Type I phosphodiesterase / nucleotide pyrophosphatase
+PF01664	Reo_sigma1	Reovirus viral attachment protein sigma 1
+PF01665	Rota_NSP3	Rotavirus non-structural protein NSP3
+PF01666	DX	DX module
+PF01667	Ribosomal_S27e	Ribosomal protein S27
+PF01668	SmpB	SmpB protein
+PF01669	Myelin_MBP	Myelin basic protein
+PF01670	Glyco_hydro_12	Glycosyl hydrolase family 12
+PF01671	ASFV_360	African swine fever virus multigene family 360 protein
+PF01672	Plasmid_parti	Putative plasmid partition protein
+PF01673	Herpes_env	Herpesvirus putative major envelope glycoprotein
+PF01674	Lipase_2	Lipase (class 2)
+PF01676	Metalloenzyme	Metalloenzyme superfamily
+PF01677	Herpes_UL7	Herpesvirus UL7 like
+PF01678	DAP_epimerase	Diaminopimelate epimerase
+PF01679	Pmp3	Proteolipid membrane potential modulator
+PF01680	SOR_SNZ	SOR/SNZ family
+PF01681	C6	C6 domain
+PF01682	DB	DB module
+PF01683	EB	EB module
+PF01684	ET	ET module
+PF01686	Adeno_Penton_B	Adenovirus penton base protein
+PF01687	Flavokinase	Riboflavin kinase
+PF01688	Herpes_gI	Alphaherpesvirus glycoprotein I
+PF01690	PLRV_ORF5	Potato leaf roll virus readthrough protein
+PF01691	Adeno_E1B_19K	Adenovirus E1B 19K protein / small t-antigen
+PF01692	Paramyxo_C	Paramyxovirus non-structural protein C
+PF01693	Cauli_VI	Caulimovirus viroplasmin
+PF01694	Rhomboid	Rhomboid family
+PF01695	IstB_IS21	IstB-like ATP binding protein
+PF01696	Adeno_E1B_55K	Adenovirus EB1 55K protein / large t-antigen
+PF01697	Glyco_transf_92	Glycosyltransferase family 92
+PF01698	LFY_SAM	Floricaula / Leafy protein SAM domain
+PF01699	Na_Ca_ex	Sodium/calcium exchanger protein
+PF01700	Orbi_VP3	Orbivirus VP3 (T2) protein
+PF01701	PSI_PsaJ	Photosystem I reaction centre subunit IX / PsaJ
+PF01702	TGT	Queuine tRNA-ribosyltransferase
+PF01704	UDPGP	UTP--glucose-1-phosphate uridylyltransferase
+PF01705	CX	CX module
+PF01706	FliG_C	FliG C-terminal domain
+PF01707	Peptidase_C9	Peptidase family C9
+PF01708	Gemini_mov	Geminivirus putative movement protein 
+PF01709	Transcrip_reg	Transcriptional regulator
+PF01710	HTH_Tnp_IS630	Transposase
+PF01712	dNK	Deoxynucleoside kinase
+PF01713	Smr	Smr domain
+PF01715	IPPT	IPP transferase
+PF01716	MSP	Manganese-stabilising protein / photosystem II polypeptide
+PF01717	Meth_synt_2	Cobalamin-independent synthase, Catalytic domain
+PF01718	Orbi_NS1	Orbivirus non-structural protein NS1, or hydrophobic tubular protein
+PF01719	Rep_2	Plasmid replication protein
+PF01721	Bacteriocin_II	Class II bacteriocin
+PF01722	BolA	BolA-like protein
+PF01723	Chorion_1	Chorion protein
+PF01724	DUF29	Domain of unknown function DUF29
+PF01725	Ham1p_like	Ham1 family
+PF01726	LexA_DNA_bind	LexA DNA binding domain
+PF01728	FtsJ	FtsJ-like methyltransferase
+PF01729	QRPTase_C	Quinolinate phosphoribosyl transferase, C-terminal domain
+PF01730	UreF	UreF
+PF01731	Arylesterase	Arylesterase
+PF01732	DUF31	Putative peptidase (DUF31)
+PF01733	Nucleoside_tran	Nucleoside transporter
+PF01734	Patatin	Patatin-like phospholipase
+PF01735	PLA2_B	Lysophospholipase catalytic domain
+PF01736	Polyoma_agno	Polyomavirus agnoprotein
+PF01737	Ycf9	YCF9
+PF01738	DLH	Dienelactone hydrolase family
+PF01739	CheR	CheR methyltransferase, SAM binding domain
+PF01740	STAS	STAS domain
+PF01741	MscL	Large-conductance mechanosensitive channel, MscL
+PF01742	Peptidase_M27	Clostridial neurotoxin zinc protease
+PF01743	PolyA_pol	Poly A polymerase head domain
+PF01744	GLTT	GLTT repeat (6 copies)
+PF01745	IPT	Isopentenyl transferase
+PF01746	tRNA_m1G_MT	tRNA (Guanine-1)-methyltransferase
+PF01747	ATP-sulfurylase	ATP-sulfurylase
+PF01749	IBB	Importin beta binding domain
+PF01750	HycI	Hydrogenase maturation protease
+PF01751	Toprim	Toprim domain
+PF01752	Peptidase_M9	Collagenase
+PF01753	zf-MYND	MYND finger
+PF01754	zf-A20	A20-like zinc finger
+PF01755	Glyco_transf_25	Glycosyltransferase family 25 (LPS biosynthesis protein)
+PF01756	ACOX	Acyl-CoA oxidase
+PF01757	Acyl_transf_3	Acyltransferase family
+PF01758	SBF	Sodium Bile acid symporter family
+PF01759	NTR	UNC-6/NTR/C345C module
+PF01761	DHQ_synthase	3-dehydroquinate synthase
+PF01762	Galactosyl_T	Galactosyltransferase
+PF01763	Herpes_UL6	Herpesvirus UL6 like
+PF01764	Lipase_3	Lipase (class 3)
+PF01765	RRF	Ribosome recycling factor
+PF01766	Birna_VP2	Birnavirus VP2 protein
+PF01767	Birna_VP3	Birnavirus VP3 protein
+PF01768	Birna_VP4	Birnavirus VP4 protein
+PF01769	MgtE	Divalent cation transporter
+PF01770	Folate_carrier	Reduced folate carrier
+PF01771	Herpes_alk_exo	Herpesvirus alkaline exonuclease
+PF01773	Nucleos_tra2_N	Na+ dependent nucleoside transporter N-terminus
+PF01774	UreD	UreD urease accessory protein
+PF01775	Ribosomal_L18A	Ribosomal proteins 50S-L18Ae/60S-L20/60S-L18A
+PF01776	Ribosomal_L22e	Ribosomal L22e protein family
+PF01777	Ribosomal_L27e	Ribosomal L27e protein family
+PF01778	Ribosomal_L28e	Ribosomal L28e protein family
+PF01779	Ribosomal_L29e	Ribosomal L29e protein family
+PF01780	Ribosomal_L37ae	Ribosomal L37ae protein family
+PF01781	Ribosomal_L38e	Ribosomal L38e protein family
+PF01782	RimM	RimM N-terminal domain
+PF01783	Ribosomal_L32p	Ribosomal L32p protein family
+PF01784	NIF3	NIF3 (NGG1p interacting factor 3)
+PF01785	Closter_coat	Closterovirus coat protein
+PF01786	AOX	Alternative oxidase
+PF01787	Ilar_coat	Ilarvirus coat protein
+PF01788	PsbJ	PsbJ
+PF01789	PsbP	PsbP
+PF01790	LGT	Prolipoprotein diacylglyceryl transferase
+PF01791	DeoC	DeoC/LacD family aldolase
+PF01793	Glyco_transf_15	Glycolipid 2-alpha-mannosyltransferase
+PF01794	Ferric_reduct	Ferric reductase like transmembrane component
+PF01795	Methyltransf_5	MraW methylase family
+PF01796	OB_aCoA_assoc	DUF35 OB-fold domain, acyl-CoA-associated
+PF01797	Y1_Tnp	Transposase IS200 like
+PF01798	Nop	snoRNA binding domain, fibrillarin
+PF01799	Fer2_2	[2Fe-2S] binding domain
+PF01801	Cytomega_gL	Cytomegalovirus glycoprotein L 
+PF01802	Herpes_V23	Herpesvirus VP23 like capsid protein
+PF01803	LIM_bind	LIM-domain binding protein
+PF01804	Penicil_amidase	Penicillin amidase
+PF01805	Surp	Surp module
+PF01806	Paramyxo_P	Paramyxovirinae P phosphoprotein C-terminal region
+PF01807	zf-CHC2	CHC2 zinc finger
+PF01808	AICARFT_IMPCHas	AICARFT/IMPCHase bienzyme
+PF01809	Haemolytic	Haemolytic domain
+PF01810	LysE	LysE type translocator
+PF01812	5-FTHF_cyc-lig	5-formyltetrahydrofolate cyclo-ligase family
+PF01813	ATP-synt_D	ATP synthase subunit D 
+PF01814	Hemerythrin	Hemerythrin HHE cation binding domain
+PF01815	Rop	Rop protein
+PF01816	LRV	Leucine rich repeat variant
+PF01817	CM_2	Chorismate mutase type II
+PF01818	Translat_reg	Bacteriophage translational regulator
+PF01819	Levi_coat	Levivirus coat protein
+PF01820	Dala_Dala_lig_N	D-ala D-ala ligase N-terminus
+PF01821	ANATO	Anaphylotoxin-like domain
+PF01822	WSC	WSC domain
+PF01823	MACPF	MAC/Perforin domain
+PF01824	MatK_N	MatK/TrnK amino terminal region
+PF01825	GPS	GPCR proteolysis site, GPS, motif 
+PF01826	TIL	Trypsin Inhibitor like cysteine rich domain
+PF01827	FTH	FTH domain
+PF01828	Peptidase_A4	Peptidase A4 family
+PF01829	Peptidase_A6	Peptidase A6 family
+PF01830	Peptidase_C7	Peptidase C7 family
+PF01831	Peptidase_C16	Peptidase C16 family
+PF01832	Glucosaminidase	Mannosyl-glycoprotein endo-beta-N-acetylglucosaminidase
+PF01833	TIG	IPT/TIG domain
+PF01834	XRCC1_N	XRCC1 N terminal domain
+PF01835	A2M_N	MG2 domain
+PF01837	HcyBio	Homocysteine biosynthesis enzyme, sulfur-incorporation
+PF01839	FG-GAP	FG-GAP repeat
+PF01840	TCL1_MTCP1	TCL1/MTCP1 family
+PF01841	Transglut_core	Transglutaminase-like superfamily
+PF01842	ACT	ACT domain
+PF01843	DIL	DIL domain
+PF01844	HNH	HNH endonuclease
+PF01845	CcdB	CcdB protein
+PF01846	FF	FF domain
+PF01847	VHL	VHL beta domain
+PF01848	HOK_GEF	Hok/gef family
+PF01849	NAC	NAC domain
+PF01850	PIN	PIN domain
+PF01851	PC_rep	Proteasome/cyclosome repeat
+PF01852	START	START domain
+PF01853	MOZ_SAS	MOZ/SAS family
+PF01855	POR_N	Pyruvate flavodoxin/ferredoxin oxidoreductase, thiamine diP-bdg
+PF01856	HP_OMP	Helicobacter outer membrane protein
+PF01857	RB_B	Retinoblastoma-associated protein B domain
+PF01858	RB_A	Retinoblastoma-associated protein A domain
+PF01861	DUF43	Protein of unknown function DUF43
+PF01862	PvlArgDC	Pyruvoyl-dependent arginine decarboxylase (PvlArgDC)
+PF01863	DUF45	Protein of unknown function DUF45
+PF01864	CarS-like	CDP-archaeol synthase
+PF01865	PhoU_div	Protein of unknown function DUF47
+PF01866	Diphthamide_syn	Putative diphthamide synthesis protein
+PF01867	Cas_Cas1	CRISPR associated protein Cas1
+PF01868	UPF0086	Domain of unknown function UPF0086
+PF01869	BcrAD_BadFG	BadF/BadG/BcrA/BcrD ATPase family
+PF01870	Hjc	Archaeal holliday junction resolvase (hjc)
+PF01871	AMMECR1	AMMECR1
+PF01872	RibD_C	RibD C-terminal domain
+PF01873	eIF-5_eIF-2B	Domain found in IF2B/IF5
+PF01874	CitG	ATP:dephospho-CoA triphosphoribosyl transferase 
+PF01875	Memo	Memo-like protein
+PF01876	RNase_P_p30	RNase P subunit p30
+PF01877	RNA_binding	RNA binding
+PF01878	EVE	EVE domain
+PF01880	Desulfoferrodox	Desulfoferrodoxin
+PF01881	Cas_Cas6	CRISPR associated protein Cas6
+PF01882	DUF58	Protein of unknown function DUF58
+PF01883	FeS_assembly_P	Iron-sulfur cluster assembly protein
+PF01884	PcrB	PcrB family
+PF01885	PTS_2-RNA	RNA 2'-phosphotransferase, Tpt1 / KptA family
+PF01886	DUF61	Protein of unknown function DUF61
+PF01887	SAM_adeno_trans	S-adenosyl-l-methionine hydroxide adenosyltransferase
+PF01888	CbiD	CbiD
+PF01889	DUF63	Membrane protein of unknown function DUF63
+PF01890	CbiG_C	Cobalamin synthesis G C-terminus
+PF01891	CbiM	Cobalt uptake substrate-specific transmembrane region
+PF01893	UPF0058	Uncharacterised protein family UPF0058
+PF01894	UPF0047	Uncharacterised protein family UPF0047
+PF01895	PhoU	PhoU domain
+PF01896	DNA_primase_S	DNA primase small subunit
+PF01899	MNHE	Na+/H+ ion antiporter subunit
+PF01900	RNase_P_Rpp14	Rpp14/Pop5 family
+PF01901	O_anti_polymase	Putative O-antigen polymerase
+PF01902	Diphthami_syn_2	Diphthamide synthase
+PF01903	CbiX	CbiX
+PF01904	DUF72	Protein of unknown function DUF72
+PF01905	DevR	CRISPR-associated negative auto-regulator DevR/Csa2
+PF01906	YbjQ_1	Putative heavy-metal-binding
+PF01907	Ribosomal_L37e	Ribosomal protein L37e
+PF01909	NTP_transf_2	Nucleotidyltransferase domain
+PF01910	Thiamine_BP	Thiamine-binding protein
+PF01912	eIF-6	eIF-6 family
+PF01913	FTR	Formylmethanofuran-tetrahydromethanopterin formyltransferase
+PF01914	MarC	MarC family integral membrane protein
+PF01915	Glyco_hydro_3_C	Glycosyl hydrolase family 3 C-terminal domain
+PF01916	DS	Deoxyhypusine synthase
+PF01917	Arch_flagellin	Archaebacterial flagellin
+PF01918	Alba	Alba
+PF01920	Prefoldin_2	Prefoldin subunit
+PF01921	tRNA-synt_1f	tRNA synthetases class I (K)
+PF01922	SRP19	SRP19 protein
+PF01923	Cob_adeno_trans	Cobalamin adenosyltransferase
+PF01924	HypD	Hydrogenase formation hypA family
+PF01925	TauE	Sulfite exporter TauE/SafE
+PF01926	MMR_HSR1	50S ribosome-binding GTPase
+PF01927	Mut7-C	Mut7-C RNAse domain
+PF01928	CYTH	CYTH domain
+PF01929	Ribosomal_L14e	Ribosomal protein L14
+PF01930	Cas_Cas4	Domain of unknown function DUF83
+PF01931	NTPase_I-T	Protein of unknown function DUF84
+PF01933	UPF0052	Uncharacterised protein family UPF0052
+PF01934	DUF86	Protein of unknown function DUF86
+PF01935	DUF87	Domain of unknown function DUF87
+PF01936	NYN	NYN domain
+PF01937	DUF89	Protein of unknown function DUF89
+PF01938	TRAM	TRAM domain
+PF01939	NucS	Endonuclease NucS
+PF01940	DUF92	Integral membrane protein DUF92
+PF01941	AdoMet_Synthase	S-adenosylmethionine synthetase (AdoMet synthetase)
+PF01943	Polysacc_synt	Polysaccharide biosynthesis protein
+PF01944	SpoIIM	Stage II sporulation protein M
+PF01946	Thi4	Thi4 family
+PF01947	DUF98	Protein of unknown function (DUF98)
+PF01948	PyrI	Aspartate carbamoyltransferase regulatory chain, allosteric domain
+PF01949	DUF99	Protein of unknown function DUF99
+PF01950	FBPase_3	Fructose-1,6-bisphosphatase
+PF01951	Archease	Archease protein family (MTH1598/TM1083)
+PF01954	DUF104	Protein of unknown function DUF104
+PF01955	CbiZ	Adenosylcobinamide amidohydrolase
+PF01956	DUF106	Integral membrane protein DUF106
+PF01957	NfeD	NfeD-like C-terminal, partner-binding
+PF01958	DUF108	Domain of unknown function DUF108
+PF01959	DHQS	3-dehydroquinate synthase (EC 4.6.1.3)
+PF01960	ArgJ	ArgJ family
+PF01963	TraB	TraB family
+PF01964	ThiC_Rad_SAM	Radical SAM ThiC family
+PF01965	DJ-1_PfpI	DJ-1/PfpI family
+PF01966	HD	HD domain
+PF01967	MoaC	MoaC family
+PF01968	Hydantoinase_A	Hydantoinase/oxoprolinase
+PF01969	DUF111	Protein of unknown function DUF111
+PF01970	TctA	Tripartite tricarboxylate transporter TctA family
+PF01972	SDH_sah	Serine dehydrogenase proteinase
+PF01973	MAF_flag10	Protein of unknown function DUF115
+PF01974	tRNA_int_endo	tRNA intron endonuclease, catalytic C-terminal domain
+PF01975	SurE	Survival protein SurE
+PF01976	DUF116	Protein of unknown function DUF116
+PF01977	UbiD	3-octaprenyl-4-hydroxybenzoate carboxy-lyase
+PF01978	TrmB	Sugar-specific transcriptional regulator TrmB
+PF01979	Amidohydro_1	Amidohydrolase family
+PF01980	UPF0066	Uncharacterised protein family UPF0066
+PF01981	PTH2	Peptidyl-tRNA hydrolase PTH2
+PF01982	CTP-dep_RFKase	Domain of unknown function DUF120
+PF01983	CofC	Guanylyl transferase CofC like
+PF01984	dsDNA_bind	Double-stranded DNA-binding domain
+PF01985	CRS1_YhbY	CRS1 / YhbY (CRM) domain
+PF01986	DUF123	Domain of unknown function DUF123
+PF01987	AIM24	Mitochondrial biogenesis AIM24
+PF01988	VIT1	VIT family
+PF01989	DUF126	Protein of unknown function DUF126
+PF01990	ATP-synt_F	ATP synthase (F/14-kDa) subunit
+PF01991	vATP-synt_E	ATP synthase (E/31 kDa) subunit
+PF01992	vATP-synt_AC39	ATP synthase (C/AC39) subunit
+PF01993	MTD	methylene-5,6,7,8-tetrahydromethanopterin dehydrogenase
+PF01994	Trm56	tRNA ribose 2'-O-methyltransferase, aTrm56
+PF01995	DUF128	Domain of unknown function DUF128
+PF01996	F420_ligase	F420-0:Gamma-glutamyl ligase
+PF01997	Translin	Translin family
+PF01998	DUF131	Protein of unknown function DUF131
+PF02001	DUF134	Protein of unknown function  DUF134
+PF02002	TFIIE_alpha	TFIIE alpha subunit
+PF02005	TRM	N2,N2-dimethylguanosine tRNA methyltransferase
+PF02006	PPS_PS	Phosphopantothenate/pantothenate synthetase
+PF02007	MtrH	Tetrahydromethanopterin S-methyltransferase MtrH subunit
+PF02008	zf-CXXC	CXXC zinc finger domain
+PF02009	RIFIN	Rifin
+PF02010	REJ	REJ domain
+PF02011	Glyco_hydro_48	Glycosyl hydrolase family 48
+PF02012	BNR	BNR/Asp-box repeat
+PF02013	CBM_10	Cellulose or protein binding domain
+PF02014	Reeler	Reeler domain
+PF02015	Glyco_hydro_45	Glycosyl hydrolase family 45
+PF02016	Peptidase_S66	LD-carboxypeptidase
+PF02017	CIDE-N	CIDE-N domain
+PF02018	CBM_4_9	Carbohydrate binding domain
+PF02019	WIF	WIF domain
+PF02020	W2	eIF4-gamma/eIF5/eIF2-epsilon
+PF02021	UPF0102	Uncharacterised protein family UPF0102
+PF02022	Integrase_Zn	Integrase Zinc binding domain
+PF02023	SCAN	SCAN domain
+PF02024	Leptin	Leptin
+PF02025	IL5	Interleukin 5
+PF02026	RyR	RyR domain
+PF02027	RolB_RolC	RolB/RolC glucosidase family
+PF02028	BCCT	BCCT, betaine/carnitine/choline family transporter
+PF02029	Caldesmon	Caldesmon
+PF02030	Lipoprotein_8	Hypothetical lipoprotein (MG045 family)
+PF02031	Peptidase_M7	Streptomyces extracellular neutral proteinase (M7) family
+PF02033	RBFA	Ribosome-binding factor A
+PF02035	Coagulin	Coagulin
+PF02036	SCP2	SCP-2 sterol transfer family
+PF02037	SAP	SAP domain
+PF02038	ATP1G1_PLM_MAT8	ATP1G1/PLM/MAT8 family
+PF02040	ArsB	Arsenical pump membrane protein
+PF02041	Auxin_BP	Auxin binding protein
+PF02042	RWP-RK	RWP-RK domain
+PF02043	Bac_chlorC	Bacteriochlorophyll C binding protein
+PF02044	Bombesin	Bombesin-like peptide
+PF02045	CBFB_NFYA	CCAAT-binding transcription factor (CBF-B/NF-YA) subunit B
+PF02046	COX6A	Cytochrome c oxidase subunit VIa
+PF02048	Enterotoxin_ST	Heat-stable enterotoxin ST
+PF02049	FliE	Flagellar hook-basal body complex protein FliE
+PF02050	FliJ	Flagellar FliJ protein
+PF02052	Gallidermin	Gallidermin
+PF02053	Gene66	Gene 66 (IR5) protein
+PF02055	Glyco_hydro_30	Glycosyl hydrolase family 30 TIM-barrel domain
+PF02056	Glyco_hydro_4	Family 4 glycosyl hydrolase
+PF02057	Glyco_hydro_59	Glycosyl hydrolase family 59
+PF02058	Guanylin	Guanylin precursor
+PF02059	IL3	Interleukin-3
+PF02060	ISK_Channel	Slow voltage-gated potassium channel
+PF02061	Lambda_CIII	Lambda Phage CIII
+PF02063	MARCKS	MARCKS family
+PF02064	MAS20	MAS20 protein import receptor
+PF02065	Melibiase	Melibiase
+PF02066	Metallothio_11	Metallothionein family 11
+PF02067	Metallothio_5	Metallothionein family 5
+PF02068	Metallothio_PEC	Plant PEC family metallothionein
+PF02069	Metallothio_Pro	Prokaryotic metallothionein
+PF02070	NMU	Neuromedin U
+PF02071	NSF	Aromatic-di-Alanine (AdAR) repeat 
+PF02072	Orexin	Prepro-orexin
+PF02073	Peptidase_M29	Thermophilic metalloprotease (M29)
+PF02074	Peptidase_M32	Carboxypeptidase Taq (M32) metallopeptidase
+PF02075	RuvC	Crossover junction endodeoxyribonuclease RuvC
+PF02076	STE3	Pheromone A receptor
+PF02077	SURF4	SURF4 family
+PF02078	Synapsin	Synapsin, N-terminal domain
+PF02079	TP1	Nuclear transition protein 1
+PF02080	TrkA_C	TrkA-C domain
+PF02081	TrpBP	Tryptophan RNA-binding attenuator protein
+PF02082	Rrf2	Transcriptional regulator
+PF02083	Urotensin_II	Urotensin II
+PF02084	Bindin	Bindin
+PF02085	Cytochrom_CIII	Class III cytochrome C family
+PF02086	MethyltransfD12	D12 class N6 adenine-specific DNA methyltransferase
+PF02087	Nitrophorin	Nitrophorin
+PF02088	Ornatin	Ornatin
+PF02089	Palm_thioest	Palmitoyl protein thioesterase
+PF02090	SPAM	Salmonella surface presentation of antigen gene type M protein
+PF02091	tRNA-synt_2e	Glycyl-tRNA synthetase alpha subunit
+PF02092	tRNA_synt_2f	Glycyl-tRNA synthetase beta subunit
+PF02093	Gag_p30	Gag P30 core shell protein
+PF02095	Extensin_1	Extensin-like protein repeat
+PF02096	60KD_IMP	60Kd inner membrane protein
+PF02097	Filo_VP35	Filoviridae VP35
+PF02098	His_binding	Tick histamine binding protein
+PF02099	Josephin	Josephin
+PF02100	ODC_AZ	Ornithine decarboxylase antizyme
+PF02101	Ocular_alb	Ocular albinism type 1 protein
+PF02102	Peptidase_M35	Deuterolysin metalloprotease (M35) family
+PF02104	SURF1	SURF1 family
+PF02106	Fanconi_C	Fanconi anaemia group C protein
+PF02107	FlgH	Flagellar L-ring protein
+PF02108	FliH	Flagellar assembly protein FliH
+PF02109	DAD	DAD family
+PF02110	HK	Hydroxyethylthiazole kinase family
+PF02112	PDEase_II	cAMP phosphodiesterases class-II
+PF02113	Peptidase_S13	D-Ala-D-Ala carboxypeptidase 3 (S13) family
+PF02114	Phosducin	Phosducin
+PF02115	Rho_GDI	RHO protein GDP dissociation inhibitor
+PF02116	STE2	Fungal pheromone mating factor STE2 GPCR
+PF02117	7TM_GPCR_Sra	Serpentine type 7TM GPCR chemoreceptor Sra
+PF02118	Srg	Srg family chemoreceptor
+PF02119	FlgI	Flagellar P-ring protein
+PF02120	Flg_hook	Flagellar hook-length control protein FliK
+PF02121	IP_trans	Phosphatidylinositol transfer protein
+PF02122	Peptidase_S39	Peptidase S39
+PF02123	RdRP_4	Viral RNA-directed RNA-polymerase
+PF02124	Marek_A	Marek's disease glycoprotein A
+PF02126	PTE	Phosphotriesterase family
+PF02127	Peptidase_M18	Aminopeptidase I zinc metalloprotease (M18)
+PF02128	Peptidase_M36	Fungalysin metallopeptidase (M36)
+PF02129	Peptidase_S15	X-Pro dipeptidyl-peptidase (S15 family)
+PF02130	UPF0054	Uncharacterized protein family UPF0054
+PF02132	RecR	RecR protein
+PF02133	Transp_cyt_pur	Permease for cytosine/purines, uracil, thiamine, allantoin
+PF02135	zf-TAZ	TAZ zinc finger
+PF02136	NTF2	Nuclear transport factor 2 (NTF2) domain
+PF02137	A_deamin	Adenosine-deaminase (editase) domain
+PF02138	Beach	Beige/BEACH domain
+PF02140	Gal_Lectin	Galactose binding lectin domain
+PF02141	DENN	DENN (AEX-3) domain
+PF02142	MGS	MGS-like domain
+PF02144	Rad1	Repair protein Rad1/Rec1/Rad17
+PF02145	Rap_GAP	Rap/ran-GAP
+PF02146	SIR2	Sir2 family
+PF02148	zf-UBP	Zn-finger in ubiquitin-hydrolases and other protein
+PF02149	KA1	Kinase associated domain 1
+PF02150	RNA_POL_M_15KD	RNA polymerases M/15 Kd subunit
+PF02151	UVR	UvrB/uvrC motif
+PF02152	FolB	Dihydroneopterin aldolase
+PF02153	PDH	Prephenate dehydrogenase
+PF02154	FliM	Flagellar motor switch protein FliM
+PF02155	GCR	Glucocorticoid receptor
+PF02156	Glyco_hydro_26	Glycosyl hydrolase family 26
+PF02157	Man-6-P_recep	Mannose-6-phosphate receptor
+PF02158	Neuregulin	Neuregulin family
+PF02159	Oest_recep	Oestrogen receptor
+PF02160	Peptidase_A3	Cauliflower mosaic virus peptidase (A3)
+PF02161	Prog_receptor	Progesterone receptor
+PF02162	XYPPX	XYPPX repeat (two copies)
+PF02163	Peptidase_M50	Peptidase family M50
+PF02165	WT1	Wilm's tumour protein
+PF02166	Androgen_recep	Androgen receptor
+PF02167	Cytochrom_C1	Cytochrome C1 family
+PF02169	LPP20	LPP20 lipoprotein
+PF02170	PAZ	PAZ domain
+PF02171	Piwi	Piwi domain
+PF02172	KIX	KIX domain
+PF02173	pKID	pKID domain
+PF02174	IRS	PTB domain (IRS-1 type)
+PF02175	7TM_GPCR_Srb	Serpentine type 7TM GPCR chemoreceptor Srb
+PF02176	zf-TRAF	TRAF-type zinc finger
+PF02177	APP_N	Amyloid A4 N-terminal heparin-binding
+PF02178	AT_hook	AT hook motif
+PF02179	BAG	BAG domain
+PF02180	BH4	Bcl-2 homology region 4
+PF02181	FH2	Formin Homology 2 Domain
+PF02182	SAD_SRA	SAD/SRA domain
+PF02183	HALZ	Homeobox associated leucine zipper
+PF02184	HAT	HAT (Half-A-TPR) repeat
+PF02185	HR1	Hr1 repeat
+PF02186	TFIIE_beta	TFIIE beta subunit core domain
+PF02187	GAS2	Growth-Arrest-Specific Protein 2 Domain
+PF02188	GoLoco	GoLoco motif
+PF02189	ITAM	Immunoreceptor tyrosine-based activation motif
+PF02190	LON_substr_bdg	ATP-dependent protease La (LON) substrate-binding domain 
+PF02191	OLF	Olfactomedin-like domain
+PF02192	PI3K_p85B	PI3-kinase family, p85-binding domain
+PF02194	PXA	PXA domain
+PF02195	ParBc	ParB-like nuclease domain
+PF02196	RBD	Raf-like Ras-binding domain
+PF02197	RIIa	Regulatory subunit of type II PKA R-subunit
+PF02198	SAM_PNT	Sterile alpha motif (SAM)/Pointed domain
+PF02199	SapA	Saposin A-type domain
+PF02200	STE	STE like transcription factor
+PF02201	SWIB	SWIB/MDM2 domain
+PF02202	Tachykinin	Tachykinin family
+PF02203	TarH	Tar ligand binding domain homologue
+PF02204	VPS9	Vacuolar sorting protein 9 (VPS9) domain
+PF02205	WH2	WH2 motif
+PF02206	WSN	Domain of unknown function
+PF02207	zf-UBR	Putative zinc finger in N-recognin (UBR box)
+PF02208	Sorb	Sorbin homologous domain
+PF02209	VHP	Villin headpiece domain
+PF02210	Laminin_G_2	Laminin G domain
+PF02211	NHase_beta	Nitrile hydratase beta subunit
+PF02212	GED	Dynamin GTPase effector domain
+PF02213	GYF	GYF domain
+PF02214	BTB_2	BTB/POZ domain
+PF02216	B	B domain
+PF02217	T_Ag_DNA_bind	Origin of replication binding protein
+PF02218	HS1_rep	Repeat in HS1/Cortactin
+PF02219	MTHFR	Methylenetetrahydrofolate reductase
+PF02221	E1_DerP2_DerF2	ML domain
+PF02222	ATP-grasp	ATP-grasp domain
+PF02223	Thymidylate_kin	Thymidylate kinase
+PF02224	Cytidylate_kin	Cytidylate kinase
+PF02225	PA	PA domain
+PF02226	Pico_P1A	Picornavirus coat protein (VP4)
+PF02228	Gag_p19	Major core protein p19
+PF02229	PC4	Transcriptional Coactivator p15 (PC4)
+PF02230	Abhydrolase_2	Phospholipase/Carboxylesterase
+PF02232	Alpha_TIF	Alpha trans-inducing protein (Alpha-TIF) 
+PF02233	PNTB	NAD(P) transhydrogenase beta subunit
+PF02234	CDI	Cyclin-dependent kinase inhibitor
+PF02236	Viral_DNA_bi	Viral DNA-binding protein, all alpha domain
+PF02237	BPL_C	Biotin protein ligase C terminal domain
+PF02238	COX7a	Cytochrome c oxidase subunit VII
+PF02239	Cytochrom_D1	Cytochrome D1 heme domain
+PF02240	MCR_gamma	Methyl-coenzyme M reductase gamma subunit
+PF02241	MCR_beta	Methyl-coenzyme M reductase beta subunit, C-terminal domain
+PF02244	Propep_M14	Carboxypeptidase activation peptide
+PF02245	Pur_DNA_glyco	Methylpurine-DNA glycosylase (MPG)
+PF02246	B1	Protein L b1 domain
+PF02247	Como_LCP	Large coat protein
+PF02248	Como_SCP	Small coat protein
+PF02249	MCR_alpha	Methyl-coenzyme M reductase alpha subunit, C-terminal domain
+PF02250	Orthopox_35kD	35kD major secreted virus protein 
+PF02251	PA28_alpha	Proteasome activator pa28 alpha subunit
+PF02252	PA28_beta	Proteasome activator pa28 beta subunit
+PF02253	PLA1	Phospholipase A1
+PF02254	TrkA_N	TrkA-N domain
+PF02255	PTS_IIA	PTS system, Lactose/Cellobiose specific IIA subunit
+PF02256	Fe_hyd_SSU	Iron hydrogenase small subunit
+PF02257	RFX_DNA_binding	RFX DNA-binding domain
+PF02258	SLT_beta	Shiga-like toxin beta subunit
+PF02259	FAT	FAT domain
+PF02260	FATC	FATC domain
+PF02261	Asp_decarbox	Aspartate decarboxylase
+PF02262	Cbl_N	CBL proto-oncogene N-terminal domain 1
+PF02263	GBP	Guanylate-binding protein, N-terminal domain
+PF02264	LamB	LamB porin
+PF02265	S1-P1_nuclease	S1/P1 Nuclease
+PF02267	Rib_hydrolayse	ADP-ribosyl cyclase
+PF02268	TFIIA_gamma_N	Transcription initiation factor IIA, gamma subunit, helical domain
+PF02269	TFIID-18kDa	Transcription initiation factor IID, 18kD subunit
+PF02270	TFIIF_beta	Transcription initiation factor IIF, beta subunit
+PF02271	UCR_14kD	Ubiquinol-cytochrome C reductase complex 14kD subunit
+PF02272	DHHA1	DHHA1 domain
+PF02273	Acyl_transf_2	Acyl transferase
+PF02274	Amidinotransf	Amidinotransferase
+PF02275	CBAH	Linear amide C-N hydrolases, choloylglycine hydrolase family
+PF02276	CytoC_RC	Photosynthetic reaction centre cytochrome C subunit
+PF02277	DBI_PRT	Phosphoribosyltransferase
+PF02278	Lyase_8	Polysaccharide lyase family 8, super-sandwich domain
+PF02281	Dimer_Tnp_Tn5	Transposase Tn5 dimerisation domain
+PF02282	Herpes_UL42	DNA polymerase processivity factor (UL42)
+PF02283	CobU	Cobinamide kinase / cobinamide phosphate guanyltransferase
+PF02284	COX5A	Cytochrome c oxidase subunit Va
+PF02285	COX8	Cytochrome oxidase c subunit VIII
+PF02286	Dehydratase_LU	Dehydratase large subunit
+PF02287	Dehydratase_SU	Dehydratase small subunit
+PF02288	Dehydratase_MU	Dehydratase medium subunit
+PF02289	MCH	Cyclohydrolase (MCH)
+PF02290	SRP14	Signal recognition particle 14kD protein
+PF02291	TFIID-31kDa	Transcription initiation factor IID, 31kD subunit
+PF02293	AmiS_UreI	AmiS/UreI family transporter
+PF02294	7kD_DNA_binding	7kD DNA-binding domain
+PF02295	z-alpha	Adenosine deaminase z-alpha domain
+PF02296	Alpha_adaptin_C	Alpha adaptin AP2, C-terminal domain
+PF02297	COX6B	Cytochrome oxidase c subunit VIb
+PF02298	Cu_bind_like	Plastocyanin-like domain
+PF02300	Fumarate_red_C	Fumarate reductase subunit C
+PF02301	HORMA	HORMA domain
+PF02302	PTS_IIB	PTS system, Lactose/Cellobiose specific IIB subunit
+PF02303	Phage_DNA_bind	Helix-destabilising protein
+PF02304	Phage_B	Scaffold protein B
+PF02305	Phage_F	Capsid protein (F protein)
+PF02306	Phage_G	Major spike protein (G protein)
+PF02308	MgtC	MgtC family
+PF02309	AUX_IAA	AUX/IAA family
+PF02310	B12-binding	B12 binding domain
+PF02311	AraC_binding	AraC-like ligand binding domain
+PF02312	CBF_beta	Core binding factor beta subunit
+PF02313	Fumarate_red_D	Fumarate reductase subunit D
+PF02315	MDH	Methanol dehydrogenase beta subunit
+PF02316	HTH_Tnp_Mu_1	Mu DNA-binding domain
+PF02317	Octopine_DH	NAD/NADP octopine/nopaline dehydrogenase, alpha-helical domain
+PF02318	FYVE_2	FYVE-type zinc finger
+PF02319	E2F_TDP	E2F/DP family winged-helix DNA-binding domain
+PF02320	UCR_hinge	Ubiquinol-cytochrome C reductase hinge protein
+PF02321	OEP	Outer membrane efflux protein
+PF02322	Cyt_bd_oxida_II	Cytochrome bd terminal oxidase subunit II
+PF02323	ELH	Egg-laying hormone precursor    
+PF02324	Glyco_hydro_70	Glycosyl hydrolase family 70
+PF02325	YGGT	YGGT family
+PF02326	YMF19	Plant ATP synthase F0
+PF02327	BChl_A	Bacteriochlorophyll A protein
+PF02329	HDC	Histidine carboxylase PI chain
+PF02330	MAM33	Mitochondrial glycoprotein
+PF02331	P35	Apoptosis preventing protein
+PF02332	Phenol_Hydrox	Methane/Phenol/Toluene Hydroxylase
+PF02333	Phytase	Phytase
+PF02334	RTP	Replication terminator protein
+PF02335	Cytochrom_C552	Cytochrome c552
+PF02336	Denso_VP4	Capsid protein VP4
+PF02337	Gag_p10	Retroviral GAG p10 protein
+PF02338	OTU	OTU-like cysteine protease
+PF02340	PRRSV_Env	PRRSV putative envelope protein
+PF02341	RcbX	RbcX protein
+PF02342	TerD	TerD domain
+PF02343	TRA-1_regulated	TRA-1 regulated protein R03H10.4
+PF02344	Myc-LZ	Myc leucine zipper domain
+PF02346	Vac_Fusion	Chordopoxvirus multifunctional envelope protein A27
+PF02347	GDC-P	Glycine cleavage system P-protein
+PF02348	CTP_transf_3	Cytidylyltransferase
+PF02349	MSG	Major surface glycoprotein
+PF02350	Epimerase_2	UDP-N-acetylglucosamine 2-epimerase
+PF02351	GDNF	GDNF/GAS1 domain
+PF02352	Decorin_bind	Decorin binding protein
+PF02353	CMAS	Mycolic acid cyclopropane synthetase
+PF02354	Latrophilin	Latrophilin Cytoplasmic C-terminal region
+PF02355	SecD_SecF	Protein export membrane protein
+PF02357	NusG	Transcription termination factor nusG
+PF02358	Trehalose_PPase	Trehalose-phosphatase
+PF02359	CDC48_N	Cell division protein 48 (CDC48), N-terminal domain
+PF02361	CbiQ	Cobalt transport protein
+PF02362	B3	B3 DNA binding domain
+PF02363	C_tripleX	Cysteine rich repeat
+PF02364	Glucan_synthase	1,3-beta-glucan synthase component 
+PF02365	NAM	No apical meristem (NAM) protein
+PF02366	PMT	Dolichyl-phosphate-mannose-protein mannosyltransferase  
+PF02367	TsaE	Threonylcarbamoyl adenosine biosynthesis protein TsaE
+PF02368	Big_2	Bacterial Ig-like domain (group 2)
+PF02369	Big_1	Bacterial Ig-like domain (group 1)
+PF02370	M	M protein repeat
+PF02371	Transposase_20	Transposase IS116/IS110/IS902 family
+PF02372	IL15	Interleukin 15
+PF02373	JmjC	JmjC domain, hydroxylase
+PF02374	ArsA_ATPase	Anion-transporting ATPase
+PF02375	JmjN	jmjN domain
+PF02376	CUT	CUT domain
+PF02377	Dishevelled	Dishevelled specific domain
+PF02378	PTS_EIIC	Phosphotransferase system, EIIC 
+PF02380	Papo_T_antigen	T-antigen specific domain
+PF02381	MraZ	MraZ protein, putative antitoxin-like
+PF02382	RTX	RTX N-terminal domain
+PF02383	Syja_N	SacI homology domain
+PF02384	N6_Mtase	N-6 DNA Methylase
+PF02386	TrkH	Cation transport protein
+PF02387	IncFII_repA	IncFII RepA protein family
+PF02388	FemAB	FemAB family
+PF02389	Cornifin	Cornifin (SPRR) family
+PF02390	Methyltransf_4	Putative methyltransferase 
+PF02391	MoaE	MoaE protein
+PF02392	Ycf4	Ycf4
+PF02393	US22	US22 like
+PF02394	IL1_propep	Interleukin-1 propeptide
+PF02395	Peptidase_S6	Immunoglobulin A1 protease
+PF02397	Bac_transf	Bacterial sugar transferase
+PF02398	Corona_7	Coronavirus protein 7
+PF02399	Herpes_ori_bp	Origin of replication binding protein
+PF02401	LYTB	LytB protein
+PF02402	Lysis_col	Lysis protein
+PF02403	Seryl_tRNA_N	Seryl-tRNA synthetase N-terminal domain
+PF02404	SCF	Stem cell factor
+PF02405	MlaE	Permease MlaE
+PF02406	MmoB_DmpM	MmoB/DmpM family 
+PF02407	Viral_Rep	Putative viral replication protein
+PF02408	CUB_2	CUB-like domain
+PF02410	RsfS	Ribosomal silencing factor during starvation 
+PF02411	MerT	MerT mercuric transport protein
+PF02412	TSP_3	Thrombospondin type 3 repeat
+PF02413	Caudo_TAP	Caudovirales tail fibre assembly protein, lambda gpK
+PF02414	Borrelia_orfA	Borrelia ORF-A
+PF02415	Chlam_PMP	Chlamydia polymorphic membrane protein (Chlamydia_PMP) repeat
+PF02416	MttA_Hcf106	mttA/Hcf106 family
+PF02417	Chromate_transp	Chromate transporter
+PF02419	PsbL	PsbL protein
+PF02420	AFP	Insect antifreeze protein repeat
+PF02421	FeoB_N	Ferrous iron transport protein B
+PF02422	Keratin	Keratin
+PF02423	OCD_Mu_crystall	Ornithine cyclodeaminase/mu-crystallin family
+PF02424	ApbE	ApbE family
+PF02425	GBP_PSP	Paralytic/GBP/PSP peptide
+PF02426	MIase	Muconolactone delta-isomerase
+PF02427	PSI_PsaE	Photosystem I reaction centre subunit IV / PsaE
+PF02428	Prot_inhib_II	Potato type II proteinase inhibitor family
+PF02429	PCP	Peridinin-chlorophyll A binding protein
+PF02430	AMA-1	Apical membrane antigen 1
+PF02431	Chalcone	Chalcone-flavanone isomerase
+PF02432	Fimbrial_K88	Fimbrial, major and minor subunit
+PF02433	FixO	Cytochrome C oxidase, mono-heme subunit/FixO
+PF02434	Fringe	Fringe-like
+PF02435	Glyco_hydro_68	Levansucrase/Invertase
+PF02436	PYC_OADA	Conserved carboxylase domain
+PF02437	Ski_Sno	SKI/SNO/DAC family
+PF02438	Adeno_100	Late 100kD protein
+PF02439	Adeno_E3_CR2	Adenovirus E3 region protein CR2
+PF02440	Adeno_E3_CR1	Adenovirus E3 region protein CR1
+PF02441	Flavoprotein	Flavoprotein
+PF02442	L1R_F9L	Lipid membrane protein of large eukaryotic DNA viruses
+PF02443	Circo_capsid	Circovirus capsid protein
+PF02444	HEV_ORF1	Hepatitis E virus ORF-2 (Putative capsid protein)
+PF02445	NadA	Quinolinate synthetase A protein
+PF02446	Glyco_hydro_77	4-alpha-glucanotransferase
+PF02447	GntP_permease	GntP family permease
+PF02448	L71	L71 family
+PF02449	Glyco_hydro_42	Beta-galactosidase
+PF02450	LCAT	Lecithin:cholesterol acyltransferase
+PF02451	Nodulin	Nodulin
+PF02452	PemK_toxin	PemK-like, MazF-like toxin of type II toxin-antitoxin system
+PF02453	Reticulon	Reticulon
+PF02454	Sigma_1s	Sigma 1s protein
+PF02455	Hex_IIIa	Hexon-associated protein (IIIa)
+PF02456	Adeno_IVa2	Adenovirus IVa2 protein
+PF02457	DisA_N	DisA bacterial checkpoint controller nucleotide-binding
+PF02458	Transferase	Transferase family
+PF02459	Adeno_terminal	Adenoviral DNA terminal protein
+PF02460	Patched	Patched family
+PF02461	AMO	Ammonia monooxygenase
+PF02462	Opacity	Opacity family porin protein
+PF02463	SMC_N	RecF/RecN/SMC N terminal domain
+PF02464	CinA	Competence-damaged protein
+PF02465	FliD_N	Flagellar hook-associated protein 2 N-terminus
+PF02466	Tim17	Tim17/Tim22/Tim23/Pmp24 family
+PF02467	Whib	Transcription factor WhiB
+PF02468	PsbN	Photosystem II reaction centre N protein (psbN)
+PF02469	Fasciclin	Fasciclin domain
+PF02470	MlaD	MlaD protein
+PF02471	OspE	Borrelia outer surface protein E
+PF02472	ExbD	Biopolymer transport protein ExbD/TolR
+PF02474	NodA	Nodulation protein A (NodA)
+PF02475	Met_10	Met-10+ like-protein
+PF02476	US2	US2 family
+PF02477	Nairo_nucleo	Nucleocapsid N protein
+PF02478	Pneumo_phosprot	Pneumovirus phosphoprotein
+PF02479	Herpes_IE68	Herpesvirus immediate early protein
+PF02480	Herpes_gE	Alphaherpesvirus glycoprotein E
+PF02481	DNA_processg_A	DNA recombination-mediator protein A
+PF02482	Ribosomal_S30AE	Sigma 54 modulation protein / S30EA ribosomal protein
+PF02484	Rhabdo_NV	Rhabdovirus Non-virion protein
+PF02485	Branch	Core-2/I-Branching enzyme
+PF02486	Rep_trans	Replication initiation factor
+PF02487	CLN3	CLN3 protein
+PF02488	EMA	Merozoite Antigen
+PF02489	Herpes_glycop_H	Herpesvirus glycoprotein H main domain
+PF02491	SHS2_FTSA	SHS2 domain inserted in FTSA
+PF02492	cobW	CobW/HypB/UreG, nucleotide-binding domain
+PF02493	MORN	MORN repeat
+PF02494	HYR	HYR domain
+PF02495	7kD_coat	7kD viral coat protein
+PF02496	ABA_WDS	ABA/WDS induced protein
+PF02497	Arteri_GP4	Arterivirus glycoprotein
+PF02498	Bro-N	BRO family, N-terminal domain
+PF02499	DNA_pack_C	Probable DNA packing protein, C-terminus
+PF02500	DNA_pack_N	Probable DNA packing protein, N-terminus 
+PF02501	T2SSI	Type II secretion system (T2SS), protein I
+PF02502	LacAB_rpiB	Ribose/Galactose Isomerase
+PF02503	PP_kinase	Polyphosphate kinase middle domain
+PF02504	FA_synthesis	Fatty acid synthesis protein
+PF02505	MCR_D	Methyl-coenzyme M reductase operon protein D
+PF02507	PSI_PsaF	Photosystem I reaction centre subunit III
+PF02508	Rnf-Nqr	Rnf-Nqr subunit, membrane protein
+PF02509	Rota_NS35	Rotavirus non-structural protein 35
+PF02510	SPAN	Surface presentation of antigens protein
+PF02511	Thy1	Thymidylate synthase complementing protein
+PF02512	UK	Virulence determinant
+PF02513	Spin-Ssty	Spin/Ssty Family
+PF02514	CobN-Mg_chel	CobN/Magnesium Chelatase
+PF02515	CoA_transf_3	CoA-transferase family III
+PF02516	STT3	Oligosaccharyl transferase STT3 subunit
+PF02517	Abi	CAAX protease self-immunity
+PF02518	HATPase_c	Histidine kinase-, DNA gyrase B-, and HSP90-like ATPase
+PF02519	Auxin_inducible	Auxin responsive protein
+PF02520	DUF148	Domain of unknown function DUF148
+PF02521	HP_OMP_2	Putative outer membrane protein
+PF02522	Antibiotic_NAT	Aminoglycoside 3-N-acetyltransferase
+PF02524	KID	KID repeat
+PF02525	Flavodoxin_2	Flavodoxin-like fold
+PF02526	GBP_repeat	Glycophorin-binding protein
+PF02527	GidB	rRNA small subunit methyltransferase G
+PF02529	PetG	Cytochrome B6-F complex subunit 5
+PF02530	Porin_2	Porin subfamily
+PF02531	PsaD	PsaD
+PF02532	PsbI	Photosystem II reaction centre I protein (PSII 4.8 kDa protein)
+PF02533	PsbK	Photosystem II 4 kDa reaction centre component
+PF02534	T4SS-DNA_transf	Type IV secretory system Conjugative DNA transfer
+PF02535	Zip	ZIP Zinc transporter
+PF02536	mTERF	mTERF
+PF02537	CRCB	CrcB-like protein, Camphor Resistance (CrcB)
+PF02538	Hydantoinase_B	Hydantoinase B/oxoprolinase
+PF02540	NAD_synthase	NAD synthase
+PF02541	Ppx-GppA	Ppx/GppA phosphatase family
+PF02542	YgbB	YgbB family
+PF02543	Carbam_trans_N	Carbamoyltransferase N-terminus
+PF02544	Steroid_dh	3-oxo-5-alpha-steroid 4-dehydrogenase 
+PF02545	Maf	Maf-like protein
+PF02547	Queuosine_synth	Queuosine biosynthesis protein
+PF02548	Pantoate_transf	Ketopantoate hydroxymethyltransferase
+PF02550	AcetylCoA_hydro	Acetyl-CoA hydrolase/transferase N-terminal domain
+PF02551	Acyl_CoA_thio	Acyl-CoA thioesterase
+PF02552	CO_dh	CO dehydrogenase beta subunit/acetyl-CoA synthase epsilon subunit
+PF02553	CbiN	Cobalt transport protein component CbiN
+PF02554	CstA	Carbon starvation protein CstA
+PF02556	SecB	Preprotein translocase subunit SecB
+PF02557	VanY	D-alanyl-D-alanine carboxypeptidase
+PF02558	ApbA	Ketopantoate reductase PanE/ApbA
+PF02559	CarD_CdnL_TRCF	CarD-like/TRCF domain
+PF02560	Cyanate_lyase	Cyanate lyase C-terminal domain
+PF02561	FliS	Flagellar protein FliS
+PF02562	PhoH	PhoH-like protein
+PF02563	Poly_export	Polysaccharide biosynthesis/export protein
+PF02565	RecO_C	Recombination protein O C terminal
+PF02566	OsmC	OsmC-like protein
+PF02567	PhzC-PhzF	Phenazine biosynthesis-like protein
+PF02568	ThiI	Thiamine biosynthesis protein (ThiI)
+PF02569	Pantoate_ligase	Pantoate-beta-alanine ligase
+PF02570	CbiC	Precorrin-8X methylmutase
+PF02571	CbiJ	Precorrin-6x reductase CbiJ/CobK
+PF02572	CobA_CobO_BtuR	ATP:corrinoid adenosyltransferase BtuR/CobO/CobP
+PF02574	S-methyl_trans	Homocysteine S-methyltransferase
+PF02575	YbaB_DNA_bd	YbaB/EbfC DNA-binding family
+PF02576	DUF150	RimP N-terminal domain
+PF02577	DNase-RNase	Bifunctional nuclease
+PF02578	Cu-oxidase_4	Multi-copper polyphenol oxidoreductase laccase
+PF02579	Nitro_FeMo-Co	Dinitrogenase iron-molybdenum cofactor
+PF02580	Tyr_Deacylase	D-Tyr-tRNA(Tyr) deacylase
+PF02581	TMP-TENI	Thiamine monophosphate synthase
+PF02582	DUF155	Uncharacterised ACR, YagE family COG1723
+PF02583	Trns_repr_metal	Metal-sensitive transcriptional repressor
+PF02585	PIG-L	GlcNAc-PI de-N-acetylase
+PF02586	SRAP	SOS response associated peptidase (SRAP)
+PF02588	YitT_membrane	Uncharacterised 5xTM membrane BCR, YitT family COG1284
+PF02589	LUD_dom	LUD domain
+PF02590	SPOUT_MTase	Predicted SPOUT methyltransferase
+PF02591	zf-RING_7	C4-type zinc ribbon domain
+PF02592	Vut_1	Putative vitamin uptake transporter
+PF02593	DUF166	Domain of unknown function
+PF02594	DUF167	Uncharacterised ACR, YggU family COG1872
+PF02595	Gly_kinase	Glycerate kinase family
+PF02596	DUF169	Uncharacterised ArCR, COG2043
+PF02597	ThiS	ThiS family
+PF02598	Methyltrn_RNA_3	Putative RNA methyltransferase
+PF02599	CsrA	Global regulator protein family
+PF02600	DsbB	Disulfide bond formation protein DsbB
+PF02601	Exonuc_VII_L	Exonuclease VII, large subunit
+PF02602	HEM4	Uroporphyrinogen-III synthase HemD
+PF02603	Hpr_kinase_N	HPr Serine kinase N terminus
+PF02604	PhdYeFM_antitox	Antitoxin Phd_YefM, type II toxin-antitoxin system
+PF02605	PsaL	Photosystem I reaction centre subunit XI
+PF02606	LpxK	Tetraacyldisaccharide-1-P 4'-kinase
+PF02607	B12-binding_2	B12 binding domain
+PF02608	Bmp	ABC transporter substrate-binding protein PnrA-like
+PF02609	Exonuc_VII_S	Exonuclease VII small subunit
+PF02610	Arabinose_Isome	L-arabinose isomerase
+PF02611	CDH	CDP-diacylglycerol pyrophosphatase
+PF02613	Nitrate_red_del	Nitrate reductase delta subunit
+PF02614	UxaC	Glucuronate isomerase
+PF02615	Ldh_2	Malate/L-lactate dehydrogenase
+PF02616	SMC_ScpA	Segregation and condensation protein ScpA
+PF02617	ClpS	ATP-dependent Clp protease adaptor protein ClpS
+PF02618	YceG	YceG-like family
+PF02620	DUF177	Uncharacterized ACR, COG1399
+PF02621	VitK2_biosynth	Menaquinone biosynthesis
+PF02622	DUF179	Uncharacterized ACR, COG1678
+PF02623	FliW	FliW protein
+PF02624	YcaO	YcaO cyclodehydratase, ATP-ad Mg2+-binding
+PF02625	XdhC_CoxI	XdhC and CoxI family
+PF02626	CT_A_B	Carboxyltransferase domain, subdomain A and B 
+PF02627	CMD	Carboxymuconolactone decarboxylase family
+PF02628	COX15-CtaA	Cytochrome oxidase assembly protein
+PF02629	CoA_binding	CoA binding domain
+PF02630	SCO1-SenC	SCO1/SenC
+PF02631	RecX	RecX family
+PF02632	BioY	BioY family
+PF02633	Creatininase	Creatinine amidohydrolase
+PF02634	FdhD-NarQ	FdhD/NarQ family
+PF02635	DrsE	DsrE/DsrF-like family
+PF02636	Methyltransf_28	Putative S-adenosyl-L-methionine-dependent methyltransferase
+PF02637	GatB_Yqey	GatB domain
+PF02638	GHL10	Glycosyl hydrolase-like 10
+PF02639	DUF188	Uncharacterized BCR, YaiI/YqxD family COG1671
+PF02641	DUF190	Uncharacterized ACR, COG1993
+PF02643	DUF192	Uncharacterized ACR, COG1430
+PF02645	DegV	Uncharacterised protein, DegV family COG1307
+PF02646	RmuC	RmuC family
+PF02649	GCHY-1	Type I GTP cyclohydrolase folE2
+PF02650	HTH_WhiA	WhiA C-terminal HTH domain
+PF02652	Lactate_perm	L-lactate permease
+PF02653	BPD_transp_2	Branched-chain amino acid transport system / permease component
+PF02654	CobS	Cobalamin-5-phosphate synthase
+PF02655	ATP-grasp_3	ATP-grasp domain
+PF02656	DUF202	Domain of unknown function (DUF202)
+PF02657	SufE	Fe-S metabolism associated domain
+PF02659	Mntp	Putative manganese efflux pump
+PF02660	G3P_acyltransf	Glycerol-3-phosphate acyltransferase
+PF02661	Fic	Fic/DOC family
+PF02662	FlpD	Methyl-viologen-reducing hydrogenase, delta subunit
+PF02663	FmdE	FmdE, Molybdenum formylmethanofuran dehydrogenase operon 
+PF02664	LuxS	S-Ribosylhomocysteinase (LuxS)
+PF02665	Nitrate_red_gam	Nitrate reductase gamma subunit
+PF02666	PS_Dcarbxylase	Phosphatidylserine decarboxylase
+PF02667	SCFA_trans	Short chain fatty acid transporter
+PF02668	TauD	Taurine catabolism dioxygenase TauD, TfdA family
+PF02669	KdpC	K+-transporting ATPase, c chain
+PF02670	DXP_reductoisom	1-deoxy-D-xylulose 5-phosphate reductoisomerase
+PF02671	PAH	Paired amphipathic helix repeat
+PF02672	CP12	CP12 domain
+PF02673	BacA	Bacitracin resistance protein BacA
+PF02674	Colicin_V	Colicin V production protein
+PF02675	AdoMet_dc	S-adenosylmethionine decarboxylase 
+PF02676	TYW3	Methyltransferase TYW3
+PF02677	DUF208	Uncharacterized BCR, COG1636
+PF02678	Pirin	Pirin
+PF02679	ComA	(2R)-phospho-3-sulfolactate synthase (ComA)
+PF02680	DUF211	Uncharacterized ArCR, COG1888
+PF02681	DUF212	Divergent PAP2 family
+PF02682	CT_C_D	Carboxyltransferase domain, subdomain C and D
+PF02683	DsbD	Cytochrome C biogenesis protein transmembrane region
+PF02684	LpxB	Lipid-A-disaccharide synthetase
+PF02685	Glucokinase	Glucokinase
+PF02686	Glu-tRNAGln	Glu-tRNAGln amidotransferase C subunit
+PF02687	FtsX	FtsX-like permease family
+PF02689	Herpes_Helicase	Helicase
+PF02690	Na_Pi_cotrans	Na+/Pi-cotransporter
+PF02691	VacA	Vacuolating cyotoxin
+PF02694	UPF0060	Uncharacterised BCR, YnfA/UPF0060 family
+PF02696	UPF0061	Uncharacterized ACR, YdiU/UPF0061 family
+PF02697	VAPB_antitox	Putative antitoxin
+PF02698	DUF218	DUF218 domain
+PF02699	YajC	Preprotein translocase subunit
+PF02700	PurS	Phosphoribosylformylglycinamidine (FGAM) synthase
+PF02701	zf-Dof	Dof domain, zinc finger
+PF02702	KdpD	Osmosensitive K+ channel His kinase sensor domain
+PF02703	Adeno_E1A	Early E1A protein
+PF02704	GASA	Gibberellin regulated protein
+PF02705	K_trans	K+ potassium transporter
+PF02706	Wzz	Chain length determinant protein
+PF02707	MOSP_N	Major Outer Sheath Protein N-terminal region
+PF02709	Glyco_transf_7C	N-terminal domain of galactosyltransferase
+PF02710	Hema_HEFG	Hemagglutinin domain of haemagglutinin-esterase-fusion glycoprotein
+PF02711	Pap_E4	E4 protein
+PF02713	DUF220	Domain of unknown function DUF220
+PF02714	RSN1_7TM	Calcium-dependent channel, 7TM region, putative phosphate
+PF02718	Herpes_UL31	Herpesvirus UL31-like protein
+PF02719	Polysacc_synt_2	Polysaccharide biosynthesis protein
+PF02720	DUF222	Domain of unknown function (DUF222)
+PF02721	DUF223	Domain of unknown function DUF223
+PF02722	MOSP_C	Major Outer Sheath Protein C-terminal domain
+PF02723	NS3_envE	Non-structural protein NS3/Small envelope protein E
+PF02724	CDC45	CDC45-like protein
+PF02725	Paramyxo_NS_C	Non-structural protein C
+PF02727	Cu_amine_oxidN2	Copper amine oxidase, N2 domain
+PF02728	Cu_amine_oxidN3	Copper amine oxidase, N3 domain
+PF02729	OTCace_N	Aspartate/ornithine carbamoyltransferase, carbamoyl-P binding domain
+PF02730	AFOR_N	Aldehyde ferredoxin oxidoreductase, N-terminal domain
+PF02731	SKIP_SNW	SKIP/SNW domain
+PF02732	ERCC4	ERCC4 domain
+PF02733	Dak1	Dak1 domain
+PF02734	Dak2	DAK2 domain
+PF02735	Ku	Ku70/Ku80 beta-barrel domain
+PF02736	Myosin_N	Myosin N-terminal SH3-like domain
+PF02737	3HCDH_N	3-hydroxyacyl-CoA dehydrogenase, NAD binding domain
+PF02738	Ald_Xan_dh_C2	Molybdopterin-binding domain of aldehyde dehydrogenase
+PF02739	5_3_exonuc_N	5'-3' exonuclease, N-terminal resolvase-like domain
+PF02740	Colipase_C	Colipase, C-terminal domain
+PF02741	FTR_C	FTR, proximal lobe
+PF02742	Fe_dep_repr_C	Iron dependent repressor, metal binding and dimerisation domain
+PF02743	dCache_1	Cache domain
+PF02744	GalP_UDP_tr_C	Galactose-1-phosphate uridyl transferase, C-terminal domain
+PF02745	MCR_alpha_N	Methyl-coenzyme M reductase alpha subunit, N-terminal domain
+PF02746	MR_MLE_N	Mandelate racemase / muconate lactonizing enzyme, N-terminal domain
+PF02747	PCNA_C	Proliferating cell nuclear antigen, C-terminal domain
+PF02748	PyrI_C	Aspartate carbamoyltransferase regulatory chain, metal binding domain
+PF02749	QRPTase_N	Quinolinate phosphoribosyl transferase, N-terminal domain
+PF02750	Synapsin_C	Synapsin, ATP binding domain
+PF02751	TFIIA_gamma_C	Transcription initiation factor IIA, gamma subunit
+PF02752	Arrestin_C	Arrestin (or S-antigen), C-terminal domain
+PF02753	PapD_C	Pili assembly chaperone PapD, C-terminal domain
+PF02754	CCG	Cysteine-rich domain
+PF02755	RPEL	RPEL repeat
+PF02756	GYR	GYR motif
+PF02757	YLP	YLP motif
+PF02758	PYRIN	PAAD/DAPIN/Pyrin domain
+PF02759	RUN	RUN domain
+PF02760	HIN	HIN-200/IF120x domain
+PF02761	Cbl_N2	CBL proto-oncogene N-terminus, EF hand-like domain
+PF02762	Cbl_N3	CBL proto-oncogene N-terminus, SH2-like domain
+PF02763	Diphtheria_C	Diphtheria toxin, C domain
+PF02764	Diphtheria_T	Diphtheria toxin, T domain
+PF02765	POT1	Telomeric single stranded DNA binding POT1/CDC13
+PF02767	DNA_pol3_beta_2	DNA polymerase III beta subunit, central domain
+PF02768	DNA_pol3_beta_3	DNA polymerase III beta subunit, C-terminal domain
+PF02769	AIRS_C	AIR synthase related protein, C-terminal domain
+PF02770	Acyl-CoA_dh_M	Acyl-CoA dehydrogenase, middle domain
+PF02771	Acyl-CoA_dh_N	Acyl-CoA dehydrogenase, N-terminal domain
+PF02772	S-AdoMet_synt_M	S-adenosylmethionine synthetase, central domain
+PF02773	S-AdoMet_synt_C	S-adenosylmethionine synthetase, C-terminal domain
+PF02774	Semialdhyde_dhC	Semialdehyde dehydrogenase, dimerisation domain
+PF02775	TPP_enzyme_C	Thiamine pyrophosphate enzyme, C-terminal TPP binding domain
+PF02776	TPP_enzyme_N	Thiamine pyrophosphate enzyme, N-terminal TPP binding domain
+PF02777	Sod_Fe_C	Iron/manganese superoxide dismutases, C-terminal domain
+PF02778	tRNA_int_endo_N	tRNA intron endonuclease, N-terminal domain
+PF02779	Transket_pyr	Transketolase, pyrimidine binding domain
+PF02780	Transketolase_C	Transketolase, C-terminal domain
+PF02781	G6PD_C	Glucose-6-phosphate dehydrogenase, C-terminal domain
+PF02782	FGGY_C	FGGY family of carbohydrate kinases, C-terminal domain
+PF02783	MCR_beta_N	Methyl-coenzyme M reductase beta subunit, N-terminal domain
+PF02784	Orn_Arg_deC_N	Pyridoxal-dependent decarboxylase, pyridoxal binding domain
+PF02785	Biotin_carb_C	Biotin carboxylase C-terminal domain
+PF02786	CPSase_L_D2	Carbamoyl-phosphate synthase L chain, ATP binding domain
+PF02787	CPSase_L_D3	Carbamoyl-phosphate synthetase large chain, oligomerisation domain
+PF02788	RuBisCO_large_N	Ribulose bisphosphate carboxylase large chain, N-terminal domain
+PF02789	Peptidase_M17_N	Cytosol aminopeptidase family, N-terminal domain
+PF02790	COX2_TM	Cytochrome C oxidase subunit II, transmembrane domain
+PF02791	DDT	DDT domain
+PF02792	Mago_nashi	Mago nashi protein
+PF02793	HRM	Hormone receptor domain
+PF02794	HlyC	RTX toxin acyltransferase family
+PF02796	HTH_7	Helix-turn-helix domain of resolvase
+PF02797	Chal_sti_synt_C	Chalcone and stilbene synthases, C-terminal domain
+PF02798	GST_N	Glutathione S-transferase, N-terminal domain
+PF02799	NMT_C	Myristoyl-CoA:protein N-myristoyltransferase, C-terminal domain
+PF02800	Gp_dh_C	Glyceraldehyde 3-phosphate dehydrogenase, C-terminal domain
+PF02801	Ketoacyl-synt_C	Beta-ketoacyl synthase, C-terminal domain
+PF02803	Thiolase_C	Thiolase, C-terminal domain
+PF02805	Ada_Zn_binding	Metal binding domain of Ada
+PF02806	Alpha-amylase_C	Alpha amylase, C-terminal all-beta domain
+PF02807	ATP-gua_PtransN	ATP:guanido phosphotransferase, N-terminal domain
+PF02809	UIM	Ubiquitin interaction motif
+PF02810	SEC-C	SEC-C motif
+PF02811	PHP	PHP domain
+PF02812	ELFV_dehydrog_N	Glu/Leu/Phe/Val dehydrogenase, dimerisation domain
+PF02813	Retro_M	Retroviral M domain
+PF02814	UreE_N	UreE urease accessory protein, N-terminal domain
+PF02815	MIR	MIR domain
+PF02816	Alpha_kinase	Alpha-kinase family
+PF02817	E3_binding	e3 binding domain
+PF02818	PPAK	PPAK motif
+PF02819	Toxin_9	Spider toxin
+PF02820	MBT	mbt repeat
+PF02821	Staphylokinase	Staphylokinase/Streptokinase family
+PF02822	Antistasin	Antistasin family
+PF02823	ATP-synt_DE_N	ATP synthase, Delta/Epsilon chain, beta-sandwich domain
+PF02824	TGS	TGS domain
+PF02825	WWE	WWE domain
+PF02826	2-Hacid_dh_C	D-isomer specific 2-hydroxyacid dehydrogenase, NAD binding domain
+PF02827	PKI	cAMP-dependent protein kinase inhibitor
+PF02828	L27	L27 domain
+PF02829	3H	3H domain
+PF02830	V4R	V4R domain
+PF02831	gpW	gpW
+PF02832	Flavi_glycop_C	Flavivirus glycoprotein, immunoglobulin-like domain
+PF02833	DHHA2	DHHA2 domain
+PF02834	LigT_PEase	LigT like Phosphoesterase
+PF02836	Glyco_hydro_2_C	Glycosyl hydrolases family 2, TIM barrel domain
+PF02837	Glyco_hydro_2_N	Glycosyl hydrolases family 2, sugar binding domain
+PF02838	Glyco_hydro_20b	Glycosyl hydrolase family 20, domain 2
+PF02839	CBM_5_12	Carbohydrate binding domain
+PF02840	Prp18	Prp18 domain
+PF02841	GBP_C	Guanylate-binding protein, C-terminal domain
+PF02843	GARS_C	Phosphoribosylglycinamide synthetase, C domain
+PF02844	GARS_N	Phosphoribosylglycinamide synthetase, N domain
+PF02845	CUE	CUE domain
+PF02847	MA3	MA3 domain
+PF02852	Pyr_redox_dim	Pyridine nucleotide-disulphide oxidoreductase, dimerisation domain
+PF02854	MIF4G	MIF4G domain
+PF02861	Clp_N	Clp amino terminal domain, pathogenicity island component
+PF02862	DDHD	DDHD domain
+PF02863	Arg_repressor_C	Arginine repressor, C-terminal domain
+PF02864	STAT_bind	STAT protein, DNA binding domain
+PF02865	STAT_int	STAT protein, protein interaction domain
+PF02866	Ldh_1_C	lactate/malate dehydrogenase, alpha/beta C-terminal domain
+PF02867	Ribonuc_red_lgC	Ribonucleotide reductase, barrel domain
+PF02868	Peptidase_M4_C	Thermolysin metallopeptidase, alpha-helical domain
+PF02870	Methyltransf_1N	6-O-methylguanine DNA methyltransferase, ribonuclease-like domain
+PF02872	5_nucleotid_C	5'-nucleotidase, C-terminal domain
+PF02873	MurB_C	UDP-N-acetylenolpyruvoylglucosamine reductase, C-terminal domain
+PF02874	ATP-synt_ab_N	ATP synthase alpha/beta family, beta-barrel domain
+PF02875	Mur_ligase_C	Mur ligase family, glutamate ligase domain
+PF02876	Stap_Strp_tox_C	Staphylococcal/Streptococcal toxin, beta-grasp domain
+PF02877	PARP_reg	Poly(ADP-ribose) polymerase, regulatory domain
+PF02878	PGM_PMM_I	Phosphoglucomutase/phosphomannomutase, alpha/beta/alpha domain I
+PF02879	PGM_PMM_II	Phosphoglucomutase/phosphomannomutase, alpha/beta/alpha domain II
+PF02880	PGM_PMM_III	Phosphoglucomutase/phosphomannomutase, alpha/beta/alpha domain III
+PF02881	SRP54_N	SRP54-type protein, helical bundle domain
+PF02882	THF_DHG_CYH_C	Tetrahydrofolate dehydrogenase/cyclohydrolase, NAD(P)-binding domain
+PF02883	Alpha_adaptinC2	Adaptin C-terminal domain
+PF02884	Lyase_8_C	Polysaccharide lyase family 8, C-terminal beta-sandwich domain
+PF02885	Glycos_trans_3N	Glycosyl transferase family, helical bundle domain
+PF02886	LBP_BPI_CETP_C	LBP / BPI / CETP family, C-terminal domain
+PF02887	PK_C	Pyruvate kinase, alpha/beta domain
+PF02888	CaMBD	Calmodulin binding domain
+PF02889	Sec63	Sec63 Brl domain
+PF02890	DUF226	Borrelia family of unknown function DUF226
+PF02891	zf-MIZ	MIZ/SP-RING zinc finger
+PF02892	zf-BED	BED zinc finger
+PF02893	GRAM	GRAM domain
+PF02894	GFO_IDH_MocA_C	Oxidoreductase family, C-terminal alpha/beta domain
+PF02895	H-kinase_dim	Signal transducing histidine kinase, homodimeric domain
+PF02896	PEP-utilizers_C	PEP-utilising enzyme, TIM barrel domain
+PF02897	Peptidase_S9_N	Prolyl oligopeptidase, N-terminal beta-propeller domain
+PF02898	NO_synthase	Nitric oxide synthase, oxygenase domain
+PF02899	Phage_int_SAM_1	Phage integrase, N-terminal SAM-like domain
+PF02900	LigB	Catalytic LigB subunit of aromatic ring-opening dioxygenase
+PF02901	PFL-like	Pyruvate formate lyase-like
+PF02902	Peptidase_C48	Ulp1 protease family, C-terminal catalytic domain
+PF02903	Alpha-amylase_N	Alpha amylase, N-terminal ig-like domain
+PF02905	EBV-NA1	Epstein Barr virus nuclear antigen-1, DNA-binding domain
+PF02906	Fe_hyd_lg_C	Iron only hydrogenase large subunit, C-terminal domain
+PF02907	Peptidase_S29	Hepatitis C virus NS3 protease
+PF02909	TetR_C	Tetracyclin repressor, C-terminal all-alpha domain
+PF02910	Succ_DH_flav_C	Fumarate reductase flavoprotein C-term
+PF02911	Formyl_trans_C	Formyl transferase, C-terminal domain
+PF02912	Phe_tRNA-synt_N	Aminoacyl tRNA synthetase class II, N-terminal domain
+PF02913	FAD-oxidase_C	FAD linked oxidases, C-terminal domain
+PF02914	DDE_2	Bacteriophage Mu transposase
+PF02915	Rubrerythrin	Rubrerythrin
+PF02916	DNA_PPF	DNA polymerase processivity factor
+PF02917	Pertussis_S1	Pertussis toxin, subunit 1
+PF02918	Pertussis_S2S3	Pertussis toxin, subunit 2 and 3, C-terminal domain
+PF02919	Topoisom_I_N	Eukaryotic DNA topoisomerase I, DNA binding fragment
+PF02920	Integrase_DNA	DNA binding domain of tn916 integrase
+PF02921	UCR_TM	Ubiquinol cytochrome reductase transmembrane region
+PF02922	CBM_48	Carbohydrate-binding module 48 (Isoamylase N-terminal domain)
+PF02923	BamHI	Restriction endonuclease BamHI
+PF02924	HDPD	Bacteriophage lambda head decoration protein D
+PF02925	gpD	Bacteriophage scaffolding protein D
+PF02926	THUMP	THUMP domain
+PF02927	CelD_N	Cellulase N-terminal ig-like domain
+PF02928	zf-C5HC2	C5HC2 zinc finger
+PF02929	Bgal_small_N	Beta galactosidase small chain
+PF02931	Neur_chan_LBD	Neurotransmitter-gated ion-channel ligand binding domain
+PF02932	Neur_chan_memb	Neurotransmitter-gated ion-channel transmembrane region
+PF02933	CDC48_2	Cell division protein 48 (CDC48), domain 2
+PF02934	GatB_N	GatB/GatE catalytic domain
+PF02935	COX7C	Cytochrome c oxidase subunit VIIc
+PF02936	COX4	Cytochrome c oxidase subunit IV
+PF02937	COX6C	Cytochrome c oxidase subunit VIc
+PF02938	GAD	GAD domain
+PF02939	UcrQ	UcrQ family
+PF02940	mRNA_triPase	mRNA capping enzyme, beta chain
+PF02941	FeThRed_A	Ferredoxin thioredoxin reductase variable alpha chain
+PF02942	Flu_B_NS1	Influenza B non-structural protein (NS1)
+PF02943	FeThRed_B	Ferredoxin thioredoxin reductase catalytic beta chain
+PF02944	BESS	BESS motif
+PF02945	Endonuclease_7	Recombination endonuclease VII
+PF02946	GTF2I	GTF2I-like repeat
+PF02947	Flt3_lig	flt3 ligand 
+PF02948	Amelogenin	Amelogenin
+PF02949	7tm_6	7tm Odorant receptor
+PF02950	Conotoxin	Conotoxin
+PF02951	GSH-S_N	Prokaryotic glutathione synthetase, N-terminal domain
+PF02952	Fucose_iso_C	L-fucose isomerase, C-terminal domain
+PF02953	zf-Tim10_DDP	Tim10/DDP family zinc finger
+PF02954	HTH_8	Bacterial regulatory protein, Fis family
+PF02955	GSH-S_ATP	Prokaryotic glutathione synthetase, ATP-grasp domain
+PF02956	TT_ORF1	TT viral orf 1
+PF02957	TT_ORF2	TT viral ORF2
+PF02958	EcKinase	Ecdysteroid kinase
+PF02959	Tax	HTLV Tax
+PF02960	K1	K1 glycoprotein
+PF02961	BAF	Barrier to autointegration factor
+PF02962	CHMI	5-carboxymethyl-2-hydroxymuconate isomerase
+PF02963	EcoRI	Restriction endonuclease EcoRI
+PF02964	MeMO_Hyd_G	Methane monooxygenase, hydrolase gamma chain
+PF02965	Met_synt_B12	Vitamin B12 dependent methionine synthase, activation domain
+PF02966	DIM1	Mitosis protein DIM1
+PF02969	TAF	TATA box binding protein associated factor (TAF)
+PF02970	TBCA	Tubulin binding cofactor A
+PF02971	FTCD	Formiminotransferase domain
+PF02972	Phycoerythr_ab	Phycoerythrin, alpha/beta chain
+PF02973	Sialidase	Sialidase, N-terminal domain
+PF02974	Inh	Protease inhibitor Inh
+PF02975	Me-amine-dh_L	Methylamine dehydrogenase, L chain
+PF02976	MutH	DNA mismatch repair enzyme MutH
+PF02977	CarbpepA_inh	Carboxypeptidase A inhibitor
+PF02978	SRP_SPB	Signal peptide binding domain
+PF02979	NHase_alpha	Nitrile hydratase, alpha chain
+PF02980	FokI_C	Restriction endonuclease FokI, catalytic domain
+PF02981	FokI_N	Restriction endonuclease FokI, recognition domain
+PF02982	Scytalone_dh	Scytalone dehydratase
+PF02983	Pro_Al_protease	Alpha-lytic protease prodomain
+PF02984	Cyclin_C	Cyclin, C-terminal domain
+PF02985	HEAT	HEAT repeat
+PF02986	Fn_bind	Fibronectin binding repeat
+PF02987	LEA_4	Late embryogenesis abundant protein
+PF02988	PLA2_inh	Phospholipase A2 inhibitor
+PF02989	DUF228	Lyme disease proteins of unknown function
+PF02990	EMP70	Endomembrane protein 70
+PF02991	Atg8	Autophagy protein Atg8 ubiquitin like
+PF02992	Transposase_21	Transposase family tnp2
+PF02993	MCPVI	Minor capsid protein VI
+PF02994	Transposase_22	L1 transposable element RBD-like domain
+PF02995	DUF229	Protein of unknown function (DUF229)
+PF02996	Prefoldin	Prefoldin subunit
+PF02998	Lentiviral_Tat	Lentiviral Tat protein
+PF02999	Borrelia_orfD	Borrelia orf-D family
+PF03000	NPH3	NPH3 family
+PF03002	Somatostatin	Somatostatin/Cortistatin family
+PF03003	Pox_G9-A16	Pox virus entry-fusion-complex G9/A16
+PF03004	Transposase_24	Plant transposase (Ptta/En/Spm family)
+PF03006	HlyIII	Haemolysin-III related
+PF03007	WES_acyltransf	Wax ester synthase-like Acyl-CoA acyltransferase domain
+PF03008	DUF234	Archaea bacterial proteins of unknown function
+PF03009	GDPD	Glycerophosphoryl diester phosphodiesterase family
+PF03010	GP4	GP4
+PF03011	PFEMP	PFEMP DBL domain
+PF03012	PP_M1	Phosphoprotein
+PF03013	Pyr_excise	Pyrimidine dimer DNA glycosylase
+PF03014	SP2	Structural protein 2
+PF03015	Sterile	Male sterility protein
+PF03016	Exostosin	Exostosin family
+PF03017	Transposase_23	TNP1/EN/SPM transposase
+PF03018	Dirigent	Dirigent-like protein
+PF03020	LEM	LEM domain
+PF03021	CM2	Influenza C virus M2 protein
+PF03022	MRJP	Major royal jelly protein
+PF03023	MVIN	MviN-like protein
+PF03024	Folate_rec	Folate receptor family
+PF03025	Papilloma_E5	Papillomavirus E5
+PF03026	CM1	Influenza C virus M1 protein
+PF03028	Dynein_heavy	Dynein heavy chain and region D6 of dynein motor
+PF03029	ATP_bind_1	Conserved hypothetical ATP binding protein
+PF03030	H_PPase	Inorganic H+ pyrophosphatase
+PF03031	NIF	NLI interacting factor-like phosphatase
+PF03032	FSAP_sig_propep	Frog skin active peptide family signal and propeptide
+PF03033	Glyco_transf_28	Glycosyltransferase family 28 N-terminal domain
+PF03034	PSS	Phosphatidyl serine synthase
+PF03035	RNA_capsid	Calicivirus putative RNA polymerase/capsid protein
+PF03036	Perilipin	Perilipin family
+PF03037	KMP11	Kinetoplastid membrane protein 11
+PF03038	Herpes_UL95	UL95 family
+PF03039	IL12	Interleukin-12 alpha subunit
+PF03040	CemA	CemA family
+PF03041	Baculo_LEF-2	lef-2
+PF03042	Birna_VP5	Birnavirus VP5 protein
+PF03043	Herpes_UL87	Herpesvirus UL87 family
+PF03044	Herpes_UL16	Herpesvirus UL16/UL94 family
+PF03045	DAN	DAN domain
+PF03047	ComC	COMC family
+PF03048	Herpes_UL92	UL92 family
+PF03049	Herpes_UL79	UL79 family
+PF03050	DDE_Tnp_IS66	Transposase IS66 family 
+PF03051	Peptidase_C1_2	Peptidase C1-like family
+PF03052	Adeno_52K	Adenoviral protein L1 52/55-kDa
+PF03053	Corona_NS3b	ORF3b coronavirus protein
+PF03054	tRNA_Me_trans	tRNA methyl transferase
+PF03055	RPE65	Retinal pigment epithelial membrane protein
+PF03057	DUF236	DUF236 repeat
+PF03058	Sar8_2	Sar8.2 family
+PF03059	NAS	Nicotianamine synthase protein
+PF03060	NMO	Nitronate monooxygenase
+PF03061	4HBT	Thioesterase superfamily
+PF03062	MBOAT	MBOAT, membrane-bound O-acyltransferase family
+PF03063	Prismane	Prismane/CO dehydrogenase family
+PF03064	U79_P34	HSV U79 / HCMV P34
+PF03065	Glyco_hydro_57	Glycosyl hydrolase family 57
+PF03066	Nucleoplasmin	Nucleoplasmin/nucleophosmin domain
+PF03067	LPMO_10	Lytic polysaccharide mono-oxygenase, cellulose-degrading
+PF03068	PAD	Protein-arginine deiminase (PAD)
+PF03069	FmdA_AmdA	Acetamidase/Formamidase family
+PF03070	TENA_THI-4	TENA/THI-4/PQQC family
+PF03071	GNT-I	GNT-I family
+PF03072	DUF237	MG032/MG096/MG288 family 1
+PF03073	TspO_MBR	TspO/MBR family
+PF03074	GCS	Glutamate-cysteine ligase
+PF03076	GP3	Equine arteritis virus GP3
+PF03077	VacA2	Putative vacuolating cytotoxin
+PF03078	ATHILA	ATHILA ORF-1 family
+PF03079	ARD	ARD/ARD' family
+PF03080	Neprosin	Neprosin
+PF03081	Exo70	Exo70 exocyst complex subunit
+PF03082	MAGSP	Male accessory gland secretory protein
+PF03083	MtN3_slv	Sugar efflux transporter for intercellular exchange
+PF03084	Sigma_1_2	Reoviral Sigma1/Sigma2 family
+PF03085	RAP-1	Rhoptry-associated protein 1 (RAP-1)
+PF03086	DUF240	MG032/MG096/MG288 family 2
+PF03087	DUF241	Arabidopsis protein of unknown function
+PF03088	Str_synth	Strictosidine synthase
+PF03089	RAG2	Recombination activating protein 2
+PF03090	Replicase	Replicase family
+PF03091	CutA1	CutA1 divalent ion tolerance protein
+PF03092	BT1	BT1 family
+PF03094	Mlo	Mlo family
+PF03095	PTPA	Phosphotyrosyl phosphate activator (PTPA) protein
+PF03096	Ndr	Ndr family
+PF03097	BRO1	BRO1-like domain
+PF03098	An_peroxidase	Animal haem peroxidase
+PF03099	BPL_LplA_LipB	Biotin/lipoate A/B protein ligase family
+PF03100	CcmE	CcmE
+PF03101	FAR1	FAR1 DNA-binding domain
+PF03102	NeuB	NeuB family
+PF03103	DUF243	Domain of unknown function (DUF243)
+PF03104	DNA_pol_B_exo1	DNA polymerase family B, exonuclease domain
+PF03105	SPX	SPX domain
+PF03106	WRKY	WRKY DNA -binding domain
+PF03107	C1_2	C1 domain
+PF03108	DBD_Tnp_Mut	MuDR family transposase
+PF03109	ABC1	ABC1 family
+PF03110	SBP	SBP domain
+PF03112	DUF244	Uncharacterized protein family (ORF7) DUF
+PF03113	RSV_NS2	Respiratory synctial virus non-structural protein NS2
+PF03114	BAR	BAR domain
+PF03115	Astro_capsid_N	Astrovirus capsid protein precursor
+PF03116	NQR2_RnfD_RnfE	NQR2, RnfD, RnfE family
+PF03117	Herpes_UL49_1	UL49 family
+PF03118	RNA_pol_A_CTD	Bacterial RNA polymerase, alpha chain C terminal domain
+PF03119	DNA_ligase_ZBD	NAD-dependent DNA ligase C4 zinc finger domain
+PF03120	DNA_ligase_OB	NAD-dependent DNA ligase OB-fold domain
+PF03121	Herpes_UL52	Herpesviridae UL52/UL70 DNA primase
+PF03122	Herpes_MCP	Herpes virus major capsid protein
+PF03123	CAT_RBD	CAT RNA binding domain
+PF03124	EXS	EXS family
+PF03125	Sre	C. elegans Sre G protein-coupled chemoreceptor
+PF03126	Plus-3	Plus-3 domain
+PF03127	GAT	GAT domain
+PF03128	CXCXC	CXCXC repeat
+PF03129	HGTP_anticodon	Anticodon binding domain
+PF03130	HEAT_PBS	PBS lyase HEAT-like repeat
+PF03131	bZIP_Maf	bZIP Maf transcription factor
+PF03133	TTL	Tubulin-tyrosine ligase family
+PF03134	TB2_DP1_HVA22	TB2/DP1, HVA22 family
+PF03135	CagE_TrbE_VirB	CagE, TrbE, VirB family, component of type IV transporter system
+PF03136	Pup_ligase	Pup-ligase protein
+PF03137	OATP	Organic Anion Transporter Polypeptide (OATP) family
+PF03139	AnfG_VnfG	Vanadium/alternative nitrogenase delta subunit
+PF03140	DUF247	Plant protein of unknown function
+PF03141	Methyltransf_29	Putative S-adenosyl-L-methionine-dependent methyltransferase
+PF03142	Chitin_synth_2	Chitin synthase
+PF03143	GTP_EFTU_D3	Elongation factor Tu C-terminal domain
+PF03144	GTP_EFTU_D2	Elongation factor Tu domain 2
+PF03145	Sina	Seven in absentia protein family
+PF03146	NtA	Agrin NtA domain
+PF03147	FDX-ACB	Ferredoxin-fold anticodon binding domain
+PF03148	Tektin	Tektin family
+PF03150	CCP_MauG	Di-haem cytochrome c peroxidase
+PF03151	TPT	Triose-phosphate Transporter family
+PF03152	UFD1	Ubiquitin fusion degradation protein UFD1
+PF03153	TFIIA	Transcription factor IIA, alpha/beta subunit
+PF03154	Atrophin-1	Atrophin-1 family
+PF03155	Alg6_Alg8	ALG6, ALG8 glycosyltransferase family
+PF03157	Glutenin_hmw	High molecular weight glutenin subunit
+PF03158	DUF249	Multigene family 530 protein
+PF03159	XRN_N	XRN 5'-3' exonuclease N-terminus
+PF03160	Calx-beta	Calx-beta domain
+PF03161	LAGLIDADG_2	LAGLIDADG DNA endonuclease family
+PF03162	Y_phosphatase2	Tyrosine phosphatase family
+PF03164	Mon1	Trafficking protein Mon1
+PF03165	MH1	MH1 domain
+PF03166	MH2	MH2 domain
+PF03167	UDG	Uracil DNA glycosylase superfamily
+PF03168	LEA_2	Late embryogenesis abundant protein
+PF03169	OPT	OPT oligopeptide transporter protein
+PF03170	BcsB	Bacterial cellulose synthase subunit
+PF03171	2OG-FeII_Oxy	2OG-Fe(II) oxygenase superfamily
+PF03172	HSR	HSR domain
+PF03173	CHB_HEX	Putative carbohydrate binding domain
+PF03174	CHB_HEX_C	Chitobiase/beta-hexosaminidase C-terminal domain
+PF03175	DNA_pol_B_2	DNA polymerase type B, organellar and viral
+PF03176	MMPL	MMPL family
+PF03177	Nucleoporin_C	Non-repetitive/WGA-negative nucleoporin C-terminal
+PF03178	CPSF_A	CPSF A subunit region
+PF03179	V-ATPase_G	Vacuolar (H+)-ATPase G subunit
+PF03180	Lipoprotein_9	NLPA lipoprotein
+PF03181	BURP	BURP domain
+PF03183	Borrelia_rep	Borrelia repeat protein
+PF03184	DDE_1	DDE superfamily endonuclease
+PF03185	CaKB	Calcium-activated potassium channel, beta subunit
+PF03186	CobD_Cbib	CobD/Cbib protein
+PF03187	Corona_I	Corona nucleocapsid I protein
+PF03188	Cytochrom_B561	Eukaryotic cytochrome b561
+PF03189	Otopetrin	Otopetrin
+PF03190	Thioredox_DsbH	Protein of unknown function, DUF255
+PF03192	DUF257	Pyrococcus protein of unknown function, DUF257
+PF03193	RsgA_GTPase	RsgA GTPase
+PF03194	LUC7	LUC7 N_terminus
+PF03195	LOB	Lateral organ boundaries (LOB) domain
+PF03196	DUF261	Protein of unknown function, DUF261
+PF03197	FRD2	Bacteriophage FRD2 protein
+PF03198	Glyco_hydro_72	Glucanosyltransferase
+PF03199	GSH_synthase	Eukaryotic glutathione synthase
+PF03200	Glyco_hydro_63	Glycosyl hydrolase family 63 C-terminal domain
+PF03201	HMD	H2-forming N5,N10-methylene-tetrahydromethanopterin dehydrogenase
+PF03202	Lipoprotein_10	Putative mycoplasma lipoprotein, C-terminal region
+PF03203	MerC	MerC mercury resistance protein
+PF03205	MobB	Molybdopterin guanine dinucleotide synthesis protein B
+PF03206	NifW	Nitrogen fixation protein NifW
+PF03207	OspD	Borrelia outer surface protein D (OspD)
+PF03208	PRA1	PRA1 family protein
+PF03209	PUCC	PUCC protein
+PF03210	Paramyx_P_V_C	Paramyxovirus P/V phosphoprotein C-terminal
+PF03211	Pectate_lyase	Pectate lyase
+PF03212	Pertactin	Pertactin
+PF03213	Pox_P35	Poxvirus P35 protein
+PF03214	RGP	Reversibly glycosylated polypeptide
+PF03215	Rad17	Rad17 cell cycle checkpoint protein
+PF03216	Rhabdo_ncap_2	Rhabdovirus nucleoprotein
+PF03217	SLAP	SLAP domain
+PF03219	TLC	TLC ATP/ADP transporter
+PF03220	Tombus_P19	Tombusvirus P19 core protein
+PF03221	HTH_Tnp_Tc5	Tc5 transposase DNA-binding domain
+PF03222	Trp_Tyr_perm	Tryptophan/tyrosine permease family
+PF03223	V-ATPase_C	V-ATPase subunit C
+PF03224	V-ATPase_H_N	V-ATPase subunit H
+PF03225	Viral_Hsp90	Viral heat shock protein Hsp90 homologue 
+PF03226	Yippee-Mis18	Yippee zinc-binding/DNA-binding /Mis18, centromere assembly
+PF03227	GILT	Gamma interferon inducible lysosomal thiol reductase (GILT)
+PF03228	Adeno_VII	Adenoviral core protein VII
+PF03229	Alpha_GJ	Alphavirus glycoprotein J
+PF03230	Antirestrict	Antirestriction protein
+PF03231	Bunya_NS-S_2	Bunyavirus non-structural protein NS-S
+PF03232	COQ7	Ubiquinone biosynthesis protein COQ7
+PF03233	Cauli_AT	Aphid transmission protein
+PF03234	CDC37_N	Cdc37 N terminal kinase binding
+PF03235	DUF262	Protein of unknown function DUF262
+PF03237	Terminase_6	Terminase-like family
+PF03238	ESAG1	ESAG protein
+PF03239	FTR1	Iron permease FTR1 family
+PF03241	HpaB	4-hydroxyphenylacetate 3-hydroxylase C terminal
+PF03242	LEA_3	Late embryogenesis abundant protein
+PF03243	MerB	Alkylmercury lyase
+PF03244	PSI_PsaH	Photosystem I reaction centre subunit VI
+PF03245	Phage_lysis	Bacteriophage Rz lysis protein
+PF03246	Pneumo_ncap	Pneumovirus nucleocapsid protein
+PF03247	Prothymosin	Prothymosin/parathymosin family
+PF03248	Rer1	Rer1 family
+PF03249	TSA	Type specific antigen
+PF03250	Tropomodulin	Tropomodulin
+PF03251	Tymo_45kd_70kd	Tymovirus 45/70Kd protein
+PF03252	Herpes_UL21	Herpesvirus UL21
+PF03253	UT	Urea transporter
+PF03254	XG_FTase	Xyloglucan fucosyltransferase
+PF03255	ACCA	Acetyl co-enzyme A carboxylase carboxyltransferase alpha subunit
+PF03256	ANAPC10	Anaphase-promoting complex, subunit 10 (APC10)
+PF03257	Adhesin_P1	Mycoplasma adhesin P1
+PF03258	Baculo_FP	Baculovirus FP protein
+PF03259	Robl_LC7	Roadblock/LC7 domain
+PF03260	Lipoprotein_11	Lepidopteran low molecular weight (30 kD) lipoprotein
+PF03261	CDK5_activator	Cyclin-dependent kinase 5 activator protein
+PF03262	Corona_6B_7B	Coronavirus 6B/7B protein
+PF03263	Cucumo_2B	Cucumovirus protein 2B
+PF03264	Cytochrom_NNT	NapC/NirT cytochrome c family, N-terminal region
+PF03265	DNase_II	Deoxyribonuclease II
+PF03266	NTPase_1	NTPase
+PF03268	DUF267	Caenorhabditis protein of unknown function, DUF267
+PF03269	DUF268	Caenorhabditis protein of unknown function, DUF268
+PF03270	DUF269	Protein of unknown function, DUF269
+PF03271	EB1	EB1-like C-terminal motif
+PF03272	Mucin_bdg	Putative mucin or carbohydrate-binding module
+PF03273	Baculo_gp64	Baculovirus gp64 envelope glycoprotein family
+PF03274	Foamy_BEL	Foamy virus BEL 1/2 protein
+PF03275	GLF	UDP-galactopyranose mutase
+PF03276	Gag_spuma	Spumavirus gag protein
+PF03277	Herpes_UL4	Herpesvirus UL4 family
+PF03278	IpaB_EvcA	IpaB/EvcA family
+PF03279	Lip_A_acyltrans	Bacterial lipid A biosynthesis acyltransferase
+PF03280	Lipase_chap	Proteobacterial lipase chaperone protein
+PF03281	Mab-21	Mab-21 protein
+PF03283	PAE	Pectinacetylesterase
+PF03284	PHZA_PHZB	Phenazine biosynthesis protein A/B
+PF03285	Paralemmin	Paralemmin
+PF03286	Pox_Ag35	Pox virus Ag35 surface protein
+PF03287	Pox_C7_F8A	Poxvirus C7/F8A protein
+PF03288	Pox_D5	Poxvirus D5 protein-like
+PF03289	Pox_I1	Poxvirus protein I1
+PF03290	Peptidase_C57	Vaccinia virus I7 processing peptidase
+PF03291	Pox_MCEL	mRNA capping enzyme
+PF03292	Pox_P4B	Poxvirus P4B major core protein
+PF03293	Pox_RNA_pol	Poxvirus DNA-directed RNA polymerase, 18 kD subunit
+PF03294	Pox_Rap94	RNA polymerase-associated transcription specificity factor, Rap94
+PF03295	Pox_TAA1	Poxvirus trans-activator protein A1 C-terminal
+PF03296	Pox_polyA_pol	Poxvirus poly(A) polymerase nucleotidyltransferase domain
+PF03297	Ribosomal_S25	S25 ribosomal protein
+PF03298	Stanniocalcin	Stanniocalcin family
+PF03299	TF_AP-2	Transcription factor AP-2
+PF03300	Tenui_NS4	Tenuivirus non-structural, movement protein NS4
+PF03301	Trp_dioxygenase	Tryptophan 2,3-dioxygenase
+PF03302	VSP	Giardia variant-specific surface protein
+PF03303	WTF	WTF protein
+PF03304	Mlp	Mlp lipoprotein family
+PF03305	Lipoprotein_X	Mycoplasma MG185/MG260 protein
+PF03306	AAL_decarboxy	Alpha-acetolactate decarboxylase
+PF03307	Adeno_E3_15_3	Adenovirus 15.3kD protein in E3 region
+PF03308	ArgK	ArgK protein
+PF03309	Pan_kinase	Type III pantothenate kinase
+PF03310	Cauli_DNA-bind	Caulimovirus DNA-binding protein
+PF03311	Cornichon	Cornichon protein
+PF03312	DUF272	Protein of unknown function (DUF272)
+PF03313	SDH_alpha	Serine dehydratase alpha chain
+PF03314	DUF273	Protein of unknown function, DUF273
+PF03315	SDH_beta	Serine dehydratase beta chain
+PF03317	ELF	ELF protein
+PF03318	ETX_MTX2	Clostridium epsilon toxin ETX/Bacillus mosquitocidal toxin MTX2
+PF03319	EutN_CcmL	Ethanolamine utilisation protein EutN/carboxysome
+PF03320	FBPase_glpX	Bacterial fructose-1,6-bisphosphatase, glpX-encoded
+PF03321	GH3	GH3 auxin-responsive promoter
+PF03323	GerA	Bacillus/Clostridium GerA spore germination protein
+PF03324	Herpes_HEPA	Herpesvirus DNA helicase/primase complex associated protein
+PF03325	Herpes_PAP	Herpesvirus polymerase accessory protein
+PF03326	Herpes_TAF50	Herpesvirus transcription activation factor (transactivator)
+PF03327	Herpes_VP19C	Herpesvirus capsid shell protein VP19C
+PF03328	HpcH_HpaI	HpcH/HpaI aldolase/citrate lyase family
+PF03330	DPBB_1	Lytic transglycolase
+PF03331	LpxC	UDP-3-O-acyl N-acetylglycosamine deacetylase
+PF03332	PMM	Eukaryotic phosphomannomutase
+PF03333	PapB	Adhesin biosynthesis transcription regulatory protein
+PF03334	PhaG_MnhG_YufB	Na+/H+ antiporter subunit
+PF03335	Phage_fiber	Phage tail fibre repeat
+PF03336	Pox_C4_C10	Poxvirus C4/C10 protein
+PF03337	Pox_F12L	Poxvirus F12L protein
+PF03338	Pox_J1	Poxvirus J1 protein
+PF03339	Pox_L3_FP4	Poxvirus L3/FP4 protein
+PF03340	Pox_Rif	Poxvirus rifampicin resistance protein
+PF03341	Pox_mRNA-cap	Poxvirus mRNA capping enzyme, small subunit
+PF03342	Rhabdo_M1	Rhabdovirus M1 matrix protein (M1 polymerase-associated protein)
+PF03343	SART-1	SART-1 family
+PF03344	Daxx	Daxx N-terminal Rassf1C-interacting domain
+PF03345	DDOST_48kD	Oligosaccharyltransferase 48 kDa subunit beta
+PF03347	TDH	Vibrio thermostable direct hemolysin
+PF03348	Serinc	Serine incorporator (Serinc)
+PF03349	Toluene_X	Outer membrane protein transport protein (OMPP1/FadL/TodX)
+PF03350	UPF0114	Uncharacterized protein family, UPF0114
+PF03351	DOMON	DOMON domain
+PF03352	Adenine_glyco	Methyladenine glycosylase
+PF03353	Lin-8	Ras-mediated vulval-induction antagonist
+PF03354	Terminase_1	Phage Terminase 
+PF03355	Pox_TAP	Viral Trans-Activator Protein 
+PF03356	Pox_LP_H2	Viral late protein H2
+PF03357	Snf7	Snf7
+PF03358	FMN_red	NADPH-dependent FMN reductase
+PF03359	GKAP	Guanylate-kinase-associated protein (GKAP) protein
+PF03360	Glyco_transf_43	Glycosyltransferase family 43
+PF03361	Herpes_IE2_3	Herpes virus intermediate/early protein 2/3
+PF03362	Herpes_UL47	Herpesvirus UL47 protein
+PF03363	Herpes_LP	Herpesvirus leader protein
+PF03364	Polyketide_cyc	Polyketide cyclase / dehydrase and lipid transport
+PF03366	YEATS	YEATS family
+PF03367	zf-ZPR1	ZPR1 zinc-finger domain
+PF03368	Dicer_dimer	Dicer dimerisation domain
+PF03369	Herpes_UL3	Herpesvirus UL3 protein
+PF03370	CBM_21	Carbohydrate/starch-binding module (family 21)
+PF03371	PRP38	PRP38 family
+PF03372	Exo_endo_phos	Endonuclease/Exonuclease/phosphatase family
+PF03373	Octapeptide	Octapeptide repeat
+PF03374	ANT	Phage antirepressor protein KilAC domain
+PF03376	Adeno_E3B	Adenovirus E3B protein
+PF03377	TAL_effector	TAL effector repeat
+PF03378	CAS_CSE1	CAS/CSE protein, C-terminus
+PF03379	CcmB	CcmB protein
+PF03380	DUF282	Caenorhabditis protein of unknown function, DUF282
+PF03381	CDC50	LEM3 (ligand-effect modulator 3) family / CDC50 family
+PF03382	DUF285	Mycoplasma protein of unknown function, DUF285
+PF03383	Serpentine_r_xa	Caenorhabditis serpentine receptor-like protein, class xa
+PF03384	DUF287	Drosophila protein of unknown function, DUF287
+PF03385	STELLO	STELLO glycosyltransferases
+PF03386	ENOD93	Early nodulin 93 ENOD93 protein
+PF03387	Herpes_UL46	Herpesvirus UL46 protein
+PF03388	Lectin_leg-like	Legume-like lectin family
+PF03389	MobA_MobL	MobA/MobL family
+PF03390	2HCT	2-hydroxycarboxylate transporter family
+PF03391	Nepo_coat	Nepovirus coat protein, central domain
+PF03392	OS-D	Insect pheromone-binding family, A10/OS-D
+PF03393	Pneumo_matrix	Pneumovirus matrix protein
+PF03394	Pox_E8	Poxvirus E8 protein
+PF03395	Pox_P4A	Poxvirus P4A protein
+PF03396	Pox_RNA_pol_35	Poxvirus DNA-directed RNA polymerase, 35 kD subunit
+PF03397	Rhabdo_matrix	Rhabdovirus matrix protein
+PF03398	Ist1	Regulator of Vps4 activity in the MVB pathway
+PF03399	SAC3_GANP	SAC3/GANP family
+PF03400	DDE_Tnp_IS1	IS1 transposase
+PF03401	TctC	Tripartite tricarboxylate transporter family receptor
+PF03402	V1R	Vomeronasal organ pheromone receptor family, V1R
+PF03403	PAF-AH_p_II	Platelet-activating factor acetylhydrolase, isoform II
+PF03404	Mo-co_dimer	Mo-co oxidoreductase dimerisation domain
+PF03405	FA_desaturase_2	Fatty acid desaturase
+PF03406	Phage_fiber_2	Phage tail fibre repeat
+PF03407	Nucleotid_trans	Nucleotide-diphospho-sugar transferase
+PF03408	Foamy_virus_ENV	Foamy virus envelope protein  
+PF03409	Glycoprotein	Transmembrane glycoprotein
+PF03410	Peptidase_M44	Metallopeptidase from vaccinia pox
+PF03411	Peptidase_M74	Penicillin-insensitive murein endopeptidase
+PF03412	Peptidase_C39	Peptidase C39 family
+PF03413	PepSY	Peptidase propeptide and YPEB domain
+PF03414	Glyco_transf_6	Glycosyltransferase family 6
+PF03415	Peptidase_C11	Clostripain family
+PF03416	Peptidase_C54	Peptidase family C54
+PF03417	AAT	Acyl-coenzyme A:6-aminopenicillanic acid acyl-transferase
+PF03418	Peptidase_A25	Germination protease
+PF03419	Peptidase_U4	Sporulation factor SpoIIGA 
+PF03420	Peptidase_S77	Prohead core protein serine protease
+PF03421	Acetyltransf_14	YopJ Serine/Threonine acetyltransferase
+PF03422	CBM_6	Carbohydrate binding module (family 6)
+PF03423	CBM_25	Carbohydrate binding domain (family 25)
+PF03424	CBM_17_28	Carbohydrate binding domain (family 17/28)
+PF03425	CBM_11	Carbohydrate binding domain (family 11)
+PF03426	CBM_15	Carbohydrate binding domain (family 15)
+PF03427	CBM_19	Carbohydrate binding domain (family 19)
+PF03428	RP-C	Replication protein C N-terminal domain
+PF03429	MSP1b	Major surface protein 1B
+PF03430	TATR	Trans-activating transcriptional regulator 
+PF03431	RNA_replicase_B	RNA replicase, beta-chain 
+PF03432	Relaxase	Relaxase/Mobilisation nuclease domain 
+PF03433	EspA	EspA-like secreted protein 
+PF03434	DUF276	DUF276 
+PF03435	Sacchrp_dh_NADP	Saccharopine dehydrogenase NADP binding domain
+PF03436	DUF281	Domain of unknown function (DUF281) 
+PF03437	BtpA	BtpA family
+PF03438	Pneumo_NS1	Pneumovirus NS1 protein
+PF03439	Spt5-NGN	Early transcription elongation factor of RNA pol II, NGN section
+PF03440	APT	Aerolysin/Pertussis toxin (APT) domain
+PF03441	FAD_binding_7	FAD binding domain of DNA photolyase
+PF03442	CBM_X2	Carbohydrate binding domain X2
+PF03443	Glyco_hydro_61	Glycosyl hydrolase family 61
+PF03444	HrcA_DNA-bdg	Winged helix-turn-helix transcription repressor, HrcA DNA-binding
+PF03445	DUF294	Putative nucleotidyltransferase DUF294
+PF03446	NAD_binding_2	NAD binding domain of 6-phosphogluconate dehydrogenase
+PF03447	NAD_binding_3	Homoserine dehydrogenase, NAD binding domain
+PF03448	MgtE_N	MgtE intracellular N domain
+PF03449	GreA_GreB_N	Transcription elongation factor, N-terminal
+PF03450	CO_deh_flav_C	CO dehydrogenase flavoprotein C-terminal domain
+PF03451	HELP	HELP motif
+PF03452	Anp1	Anp1
+PF03453	MoeA_N	MoeA N-terminal region (domain I and II)
+PF03454	MoeA_C	MoeA C-terminal region (domain IV)
+PF03455	dDENN	dDENN domain
+PF03456	uDENN	uDENN domain
+PF03457	HA	Helicase associated domain
+PF03458	UPF0126	UPF0126 domain
+PF03459	TOBE	TOBE domain
+PF03460	NIR_SIR_ferr	Nitrite/Sulfite reductase ferredoxin-like half domain
+PF03461	TRCF	TRCF domain
+PF03462	PCRF	PCRF domain
+PF03463	eRF1_1	eRF1 domain 1
+PF03464	eRF1_2	eRF1 domain 2
+PF03465	eRF1_3	eRF1 domain 3
+PF03466	LysR_substrate	LysR substrate binding domain
+PF03467	Smg4_UPF3	Smg-4/UPF3 family
+PF03468	XS	XS domain
+PF03469	XH	XH domain
+PF03470	zf-XS	XS zinc finger domain
+PF03471	CorC_HlyC	Transporter associated domain
+PF03472	Autoind_bind	Autoinducer binding domain
+PF03473	MOSC	MOSC domain
+PF03474	DMA	DMRTA motif
+PF03475	3-alpha	3-alpha domain
+PF03476	MOSC_N	MOSC N-terminal beta barrel domain
+PF03477	ATP-cone	ATP cone domain
+PF03478	DUF295	Protein of unknown function (DUF295)
+PF03479	DUF296	Domain of unknown function (DUF296)
+PF03480	DctP	Bacterial extracellular solute-binding protein, family 7
+PF03481	SUA5	Putative GTP-binding controlling metal-binding
+PF03482	SIC	sic protein repeat
+PF03483	B3_4	B3/4 domain
+PF03484	B5	tRNA synthetase B5 domain
+PF03485	Arg_tRNA_synt_N	Arginyl tRNA synthetase N terminal domain
+PF03486	HI0933_like	HI0933-like protein
+PF03487	IL13	Interleukin-13
+PF03488	Ins_beta	Nematode insulin-related peptide beta type
+PF03489	SapB_2	Saposin-like type B, region 2
+PF03490	Varsurf_PPLC	Variant-surface-glycoprotein phospholipase C
+PF03491	5HT_transport_N	Serotonin (5-HT) neurotransmitter transporter, N-terminus
+PF03492	Methyltransf_7	SAM dependent carboxyl methyltransferase
+PF03493	BK_channel_a	Calcium-activated BK potassium channel alpha subunit
+PF03494	Beta-APP	Beta-amyloid peptide (beta-APP)
+PF03495	Binary_toxB	Clostridial binary toxin B/anthrax toxin PA Ca-binding domain
+PF03496	ADPrib_exo_Tox	ADP-ribosyltransferase exoenzyme
+PF03497	Anthrax_toxA	Anthrax toxin LF subunit
+PF03498	CDtoxinA	Cytolethal distending toxin A/C domain
+PF03500	Cellsynth_D	Cellulose synthase subunit D
+PF03501	S10_plectin	Plectin/S10 domain
+PF03502	Channel_Tsx	Nucleoside-specific channel-forming protein, Tsx
+PF03503	Chlam_OMP3	Chlamydia cysteine-rich outer membrane protein 3
+PF03504	Chlam_OMP6	Chlamydia cysteine-rich outer membrane protein 6
+PF03505	Clenterotox	Clostridium enterotoxin
+PF03506	Flu_C_NS1	Influenza C non-structural protein (NS1)
+PF03507	CagA	CagA exotoxin
+PF03508	Connexin43	Gap junction alpha-1 protein (Cx43)
+PF03509	Connexin50	Gap junction alpha-8 protein (Cx50)
+PF03510	Peptidase_C24	2C endopeptidase (C24) cysteine protease family
+PF03511	Fanconi_A	Fanconi anaemia group A protein
+PF03512	Glyco_hydro_52	Glycosyl hydrolase family 52
+PF03513	Cloacin_immun	Cloacin immunity protein
+PF03514	GRAS	GRAS domain family
+PF03515	Cloacin	Colicin-like bacteriocin tRNase domain
+PF03516	Filaggrin	Filaggrin
+PF03517	Voldacs	Regulator of volume decrease after cellular swelling
+PF03519	Invas_SpaK	Invasion protein B family
+PF03520	KCNQ_channel	KCNQ voltage-gated potassium channel
+PF03521	Kv2channel	Kv2 voltage-gated K+ channel
+PF03522	SLC12	Solute carrier family 12
+PF03523	Macscav_rec	Macrophage scavenger receptor
+PF03524	CagX	Conjugal transfer protein
+PF03525	Meiotic_rec114	Meiotic recombination protein rec114
+PF03526	Microcin	Colicin E1 (microcin) immunity protein
+PF03527	RHS	RHS protein
+PF03528	Rabaptin	Rabaptin
+PF03529	TF_Otx	Otx1 transcription factor
+PF03530	SK_channel	Calcium-activated SK potassium channel
+PF03531	SSrecog	Structure-specific recognition protein (SSRP1)
+PF03532	OMS28_porin	OMS28 porin
+PF03533	SPO11_like	SPO11 homologue
+PF03534	SpvB	Salmonella virulence plasmid 65kDa B protein
+PF03535	Paxillin	Paxillin family
+PF03536	VRP3	Salmonella virulence-associated 28kDa protein
+PF03537	Glyco_hydro_114	Glycoside-hydrolase family GH114
+PF03538	VRP1	Salmonella virulence plasmid 28.1kDa A protein
+PF03539	Spuma_A9PTase	Spumavirus aspartic protease (A9)
+PF03540	TFIID_30kDa	Transcription initiation factor TFIID 23-30kDa subunit
+PF03542	Tuberin	Tuberin
+PF03543	Peptidase_C58	Yersinia/Haemophilus virulence surface antigen
+PF03544	TonB_C	Gram-negative bacterial TonB protein C-terminal
+PF03545	YopE	Yersinia virulence determinant (YopE)
+PF03546	Treacle	Treacher Collins syndrome protein Treacle
+PF03547	Mem_trans	Membrane transport protein
+PF03548	LolA	Outer membrane lipoprotein carrier protein LolA
+PF03549	Tir_receptor_M	Translocated intimin receptor (Tir) intimin-binding domain
+PF03550	LolB	Outer membrane lipoprotein LolB
+PF03551	PadR	Transcriptional regulator PadR-like family
+PF03552	Cellulose_synt	Cellulose synthase
+PF03553	Na_H_antiporter	Na+/H+ antiporter family
+PF03554	Herpes_UL73	UL73 viral envelope glycoprotein  
+PF03555	Flu_C_NS2	Influenza C non-structural protein (NS2)
+PF03556	Cullin_binding	Cullin binding
+PF03557	Bunya_G1	Bunyavirus glycoprotein G1
+PF03558	TBSV_P22	TBSV core protein P21/P22
+PF03559	Hexose_dehydrat	NDP-hexose 2,3-dehydratase
+PF03561	Allantoicase	Allantoicase repeat
+PF03562	MltA	MltA specific insert domain
+PF03563	Bunya_G2	Bunyavirus glycoprotein G2
+PF03564	DUF1759	Protein of unknown function (DUF1759)
+PF03566	Peptidase_A21	Peptidase family A21
+PF03567	Sulfotransfer_2	Sulfotransferase family
+PF03568	Peptidase_C50	Peptidase family C50
+PF03569	Peptidase_C8	Peptidase family C8
+PF03571	Peptidase_M49	Peptidase family M49
+PF03572	Peptidase_S41	Peptidase family S41
+PF03573	OprD	outer membrane porin, OprD family
+PF03574	Peptidase_S48	Peptidase family S48
+PF03575	Peptidase_S51	Peptidase family S51
+PF03576	Peptidase_S58	Peptidase family S58 
+PF03577	Peptidase_C69	Peptidase family C69
+PF03578	HGWP	HGWP repeat
+PF03579	SHP	Small hydrophobic protein
+PF03580	Herpes_UL14	Herpesvirus UL14-like protein
+PF03581	Herpes_UL33	Herpesvirus UL33-like protein
+PF03583	LIP	Secretory lipase 
+PF03584	Herpes_ICP4_N	Herpesvirus ICP4-like protein N-terminal region
+PF03585	Herpes_ICP4_C	Herpesvirus ICP4-like protein C-terminal region
+PF03586	Herpes_UL36	Herpesvirus UL36 tegument protein
+PF03587	EMG1	EMG1/NEP1 methyltransferase
+PF03588	Leu_Phe_trans	Leucyl/phenylalanyl-tRNA protein transferase
+PF03589	Antiterm	Antitermination protein
+PF03590	AsnA	Aspartate-ammonia ligase
+PF03591	AzlC	AzlC protein
+PF03592	Terminase_2	Terminase small subunit 
+PF03594	BenE	Benzoate membrane transport protein
+PF03595	SLAC1	Voltage-dependent anion channel
+PF03596	Cad	Cadmium resistance transporter
+PF03597	FixS	Cytochrome oxidase maturation protein cbb3-type
+PF03598	CdhC	CO dehydrogenase/acetyl-CoA synthase complex beta subunit
+PF03599	CdhD	CO dehydrogenase/acetyl-CoA synthase delta subunit
+PF03600	CitMHS	Citrate transporter
+PF03601	Cons_hypoth698	Conserved hypothetical protein 698
+PF03602	Cons_hypoth95	Conserved hypothetical protein 95
+PF03603	DNA_III_psi	DNA polymerase III psi subunit
+PF03604	DNA_RNApol_7kD	DNA directed RNA polymerase, 7 kDa subunit
+PF03605	DcuA_DcuB	Anaerobic c4-dicarboxylate membrane transporter
+PF03606	DcuC	C4-dicarboxylate anaerobic carrier
+PF03607	DCX	Doublecortin
+PF03608	EII-GUT	PTS system enzyme II sorbitol-specific factor
+PF03609	EII-Sor	PTS system sorbose-specific iic component
+PF03610	EIIA-man	PTS system fructose IIA component
+PF03611	EIIC-GAT	PTS system sugar-specific permease component
+PF03612	EIIBC-GUT_N	Sorbitol phosphotransferase enzyme II N-terminus
+PF03613	EIID-AGA	PTS system mannose/fructose/sorbose family IID component
+PF03614	Flag1_repress	Repressor of phase-1 flagellin
+PF03615	GCM	GCM motif protein
+PF03616	Glt_symporter	Sodium/glutamate symporter
+PF03617	IBV_3A	IBV 3A protein 
+PF03618	Kinase-PPPase	Kinase/pyrophosphorylase
+PF03619	Solute_trans_a	Organic solute transporter Ostalpha
+PF03620	IBV_3C	IBV 3C protein
+PF03621	MbtH	MbtH-like protein
+PF03622	IBV_3B	IBV 3B protein 
+PF03623	Focal_AT	Focal adhesion targeting region
+PF03625	DUF302	Domain of unknown function DUF302 
+PF03626	COX4_pro	Prokaryotic Cytochrome C oxidase subunit IV 
+PF03627	PapG_N	PapG carbohydrate binding domain
+PF03628	PapG_C	PapG chaperone-binding domain 
+PF03629	SASA	Carbohydrate esterase, sialic acid-specific acetylesterase
+PF03630	Fumble	Fumble 
+PF03631	Virul_fac_BrkB	Virulence factor BrkB
+PF03632	Glyco_hydro_65m	Glycosyl hydrolase family 65 central catalytic domain
+PF03633	Glyco_hydro_65C	Glycosyl hydrolase family 65, C-terminal domain 
+PF03634	TCP	TCP family transcription factor
+PF03635	Vps35	Vacuolar protein sorting-associated protein 35 
+PF03636	Glyco_hydro_65N	Glycosyl hydrolase family 65, N-terminal domain 
+PF03637	Mob1_phocein	Mob1/phocein family
+PF03638	TCR	Tesmin/TSO1-like CXC domain, cysteine-rich domain
+PF03639	Glyco_hydro_81	Glycosyl hydrolase family 81 
+PF03640	Lipoprotein_15	Secreted repeat of unknown function
+PF03641	Lysine_decarbox	Possible lysine decarboxylase
+PF03642	MAP	MAP domain
+PF03643	Vps26	Vacuolar protein sorting-associated protein 26 
+PF03644	Glyco_hydro_85	Glycosyl hydrolase family 85 
+PF03645	Tctex-1	Tctex-1 family
+PF03646	FlaG	FlaG protein
+PF03647	Tmemb_14	Transmembrane proteins 14C
+PF03648	Glyco_hydro_67N	Glycosyl hydrolase family 67 N-terminus
+PF03649	UPF0014	Uncharacterised protein family (UPF0014)
+PF03650	MPC	Uncharacterised protein family (UPF0041)
+PF03652	RuvX	Holliday junction resolvase
+PF03653	UPF0093	Uncharacterised protein family (UPF0093)
+PF03656	Pam16	Pam16
+PF03657	UPF0113	Uncharacterised protein family (UPF0113)
+PF03658	Ub-RnfH	RnfH family Ubiquitin
+PF03659	Glyco_hydro_71	Glycosyl hydrolase family 71
+PF03660	PHF5	PHF5-like protein
+PF03661	UPF0121	Uncharacterised protein family (UPF0121)
+PF03662	Glyco_hydro_79n	Glycosyl hydrolase family 79, N-terminal domain 
+PF03663	Glyco_hydro_76	Glycosyl hydrolase family 76 
+PF03664	Glyco_hydro_62	Glycosyl hydrolase family 62 
+PF03665	UPF0172	Uncharacterised protein family (UPF0172)
+PF03666	NPR3	Nitrogen Permease regulator of amino acid transport activity 3
+PF03668	ATP_bind_2	P-loop ATPase protein family
+PF03669	UPF0139	Uncharacterised protein family (UPF0139)
+PF03670	UPF0184	Uncharacterised protein family (UPF0184)
+PF03671	Ufm1	Ubiquitin fold modifier 1 protein
+PF03672	UPF0154	Uncharacterised protein family (UPF0154)
+PF03673	UPF0128	Uncharacterised protein family (UPF0128)
+PF03676	UPF0183	Uncharacterised protein family (UPF0183)
+PF03677	UPF0137	Uncharacterised protein family (UPF0137)
+PF03678	Adeno_hexon_C	Hexon, adenovirus major coat protein, C-terminal domain
+PF03682	UPF0158	Uncharacterised protein family (UPF0158)
+PF03683	UPF0175	Uncharacterised protein family (UPF0175)
+PF03684	UPF0179	Uncharacterised protein family (UPF0179)
+PF03685	UPF0147	Uncharacterised protein family (UPF0147)
+PF03686	UPF0146	Uncharacterised protein family (UPF0146)
+PF03687	UPF0164	Uncharacterised protein family (UPF0164)
+PF03688	Nepo_coat_C	Nepovirus coat protein, C-terminal domain
+PF03689	Nepo_coat_N	Nepovirus coat protein, N-terminal domain
+PF03690	UPF0160	Uncharacterised protein family (UPF0160)
+PF03691	UPF0167	Uncharacterised protein family (UPF0167)
+PF03692	CxxCxxCC	Putative zinc- or iron-chelating domain
+PF03693	ParD_antitoxin	Bacterial antitoxin of ParD toxin-antitoxin type II system and RHH
+PF03694	Erg28	Erg28 like protein
+PF03695	UPF0149	Uncharacterised protein family (UPF0149)
+PF03698	UPF0180	Uncharacterised protein family (UPF0180)
+PF03699	UPF0182	Uncharacterised protein family (UPF0182)
+PF03700	Sorting_nexin	Sorting nexin, N-terminal domain 
+PF03701	UPF0181	Uncharacterised protein family (UPF0181)
+PF03702	AnmK	Anhydro-N-acetylmuramic acid kinase
+PF03703	bPH_2	Bacterial PH domain
+PF03704	BTAD	Bacterial transcriptional activator domain
+PF03705	CheR_N	CheR methyltransferase, all-alpha domain
+PF03706	LPG_synthase_TM	Lysylphosphatidylglycerol synthase TM region
+PF03707	MHYT	Bacterial signalling protein N terminal repeat
+PF03708	Avian_gp85	Avian retrovirus envelope protein, gp85 
+PF03709	OKR_DC_1_N	Orn/Lys/Arg decarboxylase, N-terminal domain
+PF03710	GlnE	Glutamate-ammonia ligase adenylyltransferase
+PF03711	OKR_DC_1_C	Orn/Lys/Arg decarboxylase, C-terminal domain
+PF03712	Cu2_monoox_C	Copper type II ascorbate-dependent monooxygenase, C-terminal domain
+PF03713	DUF305	Domain of unknown function (DUF305)
+PF03714	PUD	Bacterial pullanase-associated domain
+PF03715	Noc2	Noc2p family
+PF03716	WCCH	WCCH motif 
+PF03717	PBP_dimer	Penicillin-binding Protein dimerisation domain
+PF03718	Glyco_hydro_49	Glycosyl hydrolase family 49
+PF03719	Ribosomal_S5_C	Ribosomal protein S5, C-terminal domain
+PF03720	UDPG_MGDP_dh_C	UDP-glucose/GDP-mannose dehydrogenase family, UDP binding domain
+PF03721	UDPG_MGDP_dh_N	UDP-glucose/GDP-mannose dehydrogenase family, NAD binding domain
+PF03722	Hemocyanin_N	Hemocyanin, all-alpha domain
+PF03723	Hemocyanin_C	Hemocyanin, ig-like domain
+PF03724	META	META domain
+PF03725	RNase_PH_C	3' exoribonuclease family, domain 2
+PF03726	PNPase	Polyribonucleotide nucleotidyltransferase, RNA binding domain
+PF03727	Hexokinase_2	Hexokinase
+PF03728	Viral_DNA_Zn_bi	Viral DNA-binding protein, zinc binding domain
+PF03729	DUF308	Short repeat of unknown function (DUF308)
+PF03730	Ku_C	Ku70/Ku80 C-terminal arm
+PF03731	Ku_N	Ku70/Ku80 N-terminal alpha/beta domain
+PF03732	Retrotrans_gag	Retrotransposon gag protein 
+PF03733	YccF	Inner membrane component domain
+PF03734	YkuD	L,D-transpeptidase catalytic domain
+PF03735	ENT	ENT domain
+PF03736	EPTP	EPTP domain
+PF03737	RraA-like	Aldolase/RraA
+PF03738	GSP_synth	Glutathionylspermidine synthase preATP-grasp
+PF03739	YjgP_YjgQ	Predicted permease YjgP/YjgQ family
+PF03740	PdxJ	Pyridoxal phosphate biosynthesis protein PdxJ
+PF03741	TerC	Integral membrane protein TerC family
+PF03742	PetN	PetN 
+PF03743	TrbI	Bacterial conjugation TrbI-like protein 
+PF03744	BioW	6-carboxyhexanoate--CoA ligase
+PF03745	DUF309	Domain of unknown function (DUF309)
+PF03746	LamB_YcsF	LamB/YcsF family
+PF03747	ADP_ribosyl_GH	ADP-ribosylglycohydrolase
+PF03748	FliL	Flagellar basal body-associated protein FliL
+PF03749	SfsA	Sugar fermentation stimulation protein
+PF03750	Csm2_III-A	Csm2 Type III-A
+PF03752	ALF	Short repeats of unknown function
+PF03753	HHV6-IE	Human herpesvirus 6 immediate early protein 
+PF03754	DUF313	Domain of unknown function (DUF313) 
+PF03755	YicC_N	YicC-like family, N-terminal region 
+PF03756	AfsA	A-factor biosynthesis hotdog domain
+PF03759	PRONE	PRONE (Plant-specific Rop nucleotide exchanger)
+PF03760	LEA_1	Late embryogenesis abundant (LEA) group 1 
+PF03761	DUF316	Chymotrypsin family Peptidase-S1
+PF03762	VOMI	Vitelline membrane outer layer protein I (VOMI) 
+PF03763	Remorin_C	Remorin, C-terminal region 
+PF03764	EFG_IV	Elongation factor G, domain IV
+PF03765	CRAL_TRIO_N	CRAL/TRIO, N-terminal domain
+PF03766	Remorin_N	Remorin, N-terminal region 
+PF03767	Acid_phosphat_B	HAD superfamily, subfamily IIIB (Acid phosphatase)
+PF03768	Attacin_N	Attacin, N-terminal region
+PF03769	Attacin_C	Attacin, C-terminal region
+PF03770	IPK	Inositol polyphosphate kinase 
+PF03771	SPDY	Domain of unknown function (DUF317)
+PF03772	Competence	Competence protein
+PF03773	ArsP_1	Predicted permease
+PF03775	MinC_C	Septum formation inhibitor MinC, C-terminal domain
+PF03776	MinE	Septum formation topological specificity factor MinE
+PF03777	DUF320	Small secreted domain (DUF320)  
+PF03778	DUF321	Protein of unknown function (DUF321) 
+PF03779	SPW	SPW repeat
+PF03780	Asp23	Asp23 family, cell envelope-related function
+PF03781	FGE-sulfatase	Sulfatase-modifying factor enzyme 1
+PF03782	AMOP	AMOP domain
+PF03783	CsgG	Curli production assembly/transport component CsgG
+PF03784	Cyclotide	Cyclotide family
+PF03785	Peptidase_C25_C	Peptidase family C25, C terminal ig-like domain
+PF03786	UxuA	D-mannonate dehydratase (UxuA)
+PF03787	RAMPs	RAMP superfamily
+PF03788	LrgA	LrgA family
+PF03789	ELK	ELK domain 
+PF03790	KNOX1	KNOX1 domain 
+PF03791	KNOX2	KNOX2 domain 
+PF03792	PBC	PBC domain
+PF03793	PASTA	PASTA domain
+PF03795	YCII	YCII-related domain
+PF03796	DnaB_C	DnaB-like helicase C terminal domain
+PF03797	Autotransporter	Autotransporter beta-domain
+PF03798	TRAM_LAG1_CLN8	TLC domain
+PF03799	FtsQ	Cell division protein FtsQ
+PF03800	Nuf2	Nuf2 family
+PF03801	Ndc80_HEC	HEC/Ndc80p family
+PF03802	CitX	Apo-citrate lyase phosphoribosyl-dephospho-CoA transferase
+PF03803	Scramblase	Scramblase 
+PF03804	DUF325	Viral domain of unknown function
+PF03805	CLAG	Cytoadherence-linked asexual protein
+PF03806	ABG_transport	AbgT putative transporter family
+PF03807	F420_oxidored	NADP oxidoreductase coenzyme F420-dependent
+PF03808	Glyco_tran_WecB	Glycosyl transferase WecB/TagA/CpsF family
+PF03810	IBN_N	Importin-beta N-terminal domain
+PF03811	Zn_Tnp_IS1	InsA N-terminal domain
+PF03812	KdgT	2-keto-3-deoxygluconate permease
+PF03813	Nrap	Nrap protein domain 1
+PF03814	KdpA	Potassium-transporting ATPase A subunit
+PF03815	LCCL	LCCL domain
+PF03816	LytR_cpsA_psr	Cell envelope-related transcriptional attenuator domain
+PF03817	MadL	Malonate transporter MadL subunit
+PF03818	MadM	Malonate/sodium symporter MadM subunit
+PF03819	MazG	MazG nucleotide pyrophosphohydrolase domain
+PF03820	Mtc	Tricarboxylate carrier
+PF03821	Mtp	Golgi 4-transmembrane spanning transporter
+PF03822	NAF	NAF domain
+PF03823	Neurokinin_B	Neurokinin B
+PF03824	NicO	High-affinity nickel-transport protein
+PF03825	Nuc_H_symport	Nucleoside H+ symporter
+PF03826	OAR	OAR domain
+PF03827	Orexin_rec2	Orexin receptor type 2
+PF03828	PAP_assoc	Cid1 family poly A polymerase
+PF03829	PTSIIA_gutA	PTS system glucitol/sorbitol-specific IIA component
+PF03830	PTSIIB_sorb	PTS system sorbose subfamily IIB component
+PF03831	PhnA	PhnA domain
+PF03832	WSK	WSK motif
+PF03833	PolC_DP2	DNA polymerase II large subunit DP2
+PF03834	Rad10	Binding domain of DNA repair protein Ercc1 (rad10/Swi10)
+PF03835	Rad4	Rad4 transglutaminase-like domain
+PF03836	RasGAP_C	RasGAP C-terminus
+PF03837	RecT	RecT family
+PF03838	RecU	Recombination protein U
+PF03839	Sec62	Translocation protein Sec62
+PF03840	SecG	Preprotein translocase SecG subunit
+PF03841	SelA	L-seryl-tRNA selenium transferase
+PF03842	Silic_transp	Silicon transporter
+PF03843	Slp	Outer membrane lipoprotein Slp family
+PF03845	Spore_permease	Spore germination protein
+PF03846	SulA	Cell division inhibitor SulA
+PF03847	TFIID_20kDa	Transcription initiation factor TFIID subunit A
+PF03848	TehB	Tellurite resistance protein TehB
+PF03849	Tfb2	Transcription factor Tfb2
+PF03850	Tfb4	Transcription factor Tfb4
+PF03851	UvdE	UV-endonuclease UvdE
+PF03852	Vsr	DNA mismatch endonuclease Vsr
+PF03853	YjeF_N	YjeF-related protein N-terminus
+PF03854	zf-P11	P-11 zinc finger
+PF03855	M-factor	M-factor
+PF03856	SUN	Beta-glucosidase (SUN family)
+PF03857	Colicin_im	Colicin immunity protein
+PF03858	Crust_neuro_H	Crustacean neurohormone H
+PF03859	CG-1	CG-1 domain
+PF03860	DUF326	Domain of Unknown Function (DUF326) 
+PF03861	ANTAR	ANTAR domain
+PF03862	SpoVAC_SpoVAEB	SpoVAC/SpoVAEB sporulation membrane protein
+PF03863	Phage_mat-A	Phage maturation protein
+PF03864	Phage_cap_E	Phage major capsid protein E
+PF03865	ShlB	Haemolysin secretion/activation protein ShlB/FhaC/HecB
+PF03866	HAP	Hydrophobic abundant protein (HAP)        
+PF03867	FTZ	Fushi tarazu (FTZ), N-terminal region
+PF03868	Ribosomal_L6e_N	Ribosomal protein L6, N-terminal domain
+PF03869	Arc	Arc-like DNA binding domain
+PF03870	RNA_pol_Rpb8	RNA polymerase Rpb8
+PF03871	RNA_pol_Rpb5_N	RNA polymerase Rpb5, N-terminal domain
+PF03872	RseA_N	Anti sigma-E protein RseA, N-terminal domain
+PF03873	RseA_C	Anti sigma-E protein RseA, C-terminal domain
+PF03874	RNA_pol_Rpb4	RNA polymerase Rpb4
+PF03875	Statherin	Statherin
+PF03876	SHS2_Rpb7-N	SHS2 domain found in N terminus of Rpb7p/Rpc25p/MJ0397
+PF03878	YIF1	YIF1
+PF03879	Cgr1	Cgr1 family
+PF03880	DbpA	DbpA RNA binding domain   
+PF03881	Fructosamin_kin	Fructosamine kinase
+PF03882	KicB	MukF winged-helix domain
+PF03883	H2O2_YaaD	Peroxide stress protein YaaA
+PF03884	YacG	DNA gyrase inhibitor YacG
+PF03885	DUF327	Protein of unknown function (DUF327)
+PF03886	ABC_trans_aux	ABC-type transport auxiliary lipoprotein component
+PF03887	YfbU	YfbU domain
+PF03888	MucB_RseB	MucB/RseB N-terminal domain
+PF03889	DUF331	Domain of unknown function
+PF03891	DUF333	Domain of unknown function (DUF333)
+PF03892	NapB	Nitrate reductase cytochrome c-type subunit (NapB)
+PF03893	Lipase3_N	Lipase 3 N-terminal region
+PF03894	XFP	D-xylulose 5-phosphate/D-fructose 6-phosphate phosphoketolase
+PF03895	YadA_anchor	YadA-like membrane anchor domain
+PF03896	TRAP_alpha	Translocon-associated protein (TRAP), alpha subunit
+PF03898	TNV_CP	Satellite tobacco necrosis virus coat protein
+PF03899	ATP-synt_I	ATP synthase I chain
+PF03900	Porphobil_deamC	Porphobilinogen deaminase, C-terminal domain
+PF03901	Glyco_transf_22	Alg9-like mannosyltransferase family
+PF03902	Gal4_dimer	Gal4-like dimerisation domain
+PF03903	Phage_T4_gp36	Phage T4 tail fibre
+PF03904	DUF334	Domain of unknown function (DUF334)
+PF03905	Corona_NS4	Coronavirus non-structural protein NS4
+PF03906	Phage_T7_tail	Phage T7 tail fibre protein
+PF03907	Spo7	Spo7-like protein
+PF03908	Sec20	Sec20
+PF03909	BSD	BSD domain  
+PF03910	Adeno_PV	Adenovirus minor core protein PV
+PF03911	Sec61_beta	Sec61beta family
+PF03912	Psb28	Psb28 protein
+PF03913	Amb_V_allergen	Amb V Allergen
+PF03914	CBF	CBF/Mak21 family
+PF03915	AIP3	Actin interacting protein 3
+PF03916	NrfD	Polysulphide reductase, NrfD
+PF03917	GSH_synth_ATP	Eukaryotic glutathione synthase, ATP binding domain
+PF03918	CcmH	Cytochrome C biogenesis protein
+PF03919	mRNA_cap_C	mRNA capping enzyme, C-terminal domain
+PF03920	TLE_N	Groucho/TLE N-terminal Q-rich domain
+PF03921	ICAM_N	Intercellular adhesion molecule (ICAM), N-terminal domain
+PF03922	OmpW	OmpW family
+PF03923	Lipoprotein_16	Uncharacterized lipoprotein
+PF03924	CHASE	CHASE domain
+PF03925	SeqA	SeqA protein C-terminal domain
+PF03927	NapD	NapD protein
+PF03928	Haem_degrading	Haem-degrading
+PF03929	PepSY_TM	PepSY-associated TM region
+PF03930	Flp_N	Recombinase Flp protein N-terminus
+PF03931	Skp1_POZ	Skp1 family, tetramerisation domain
+PF03932	CutC	CutC family
+PF03934	T2SSK	Type II secretion system (T2SS), protein K
+PF03935	SKN1	Beta-glucan synthesis-associated protein (SKN1)
+PF03936	Terpene_synth_C	Terpene synthase family, metal binding domain
+PF03937	Sdh5	Flavinator of succinate dehydrogenase
+PF03938	OmpH	Outer membrane protein (OmpH-like)
+PF03939	Ribosomal_L23eN	Ribosomal protein L23, N-terminal domain
+PF03940	MSSP	Male specific sperm protein
+PF03941	INCENP_ARK-bind	Inner centromere protein, ARK binding region
+PF03942	DTW	DTW domain
+PF03943	TAP_C	TAP C-terminal domain
+PF03944	Endotoxin_C	delta endotoxin
+PF03945	Endotoxin_N	delta endotoxin, N-terminal domain
+PF03946	Ribosomal_L11_N	Ribosomal protein L11, N-terminal domain
+PF03947	Ribosomal_L2_C	Ribosomal Proteins L2, C-terminal domain
+PF03948	Ribosomal_L9_C	Ribosomal protein L9, C-terminal domain
+PF03949	Malic_M	Malic enzyme, NAD binding domain
+PF03950	tRNA-synt_1c_C	tRNA synthetases class I (E and Q), anti-codon binding domain
+PF03951	Gln-synt_N	Glutamine synthetase, beta-Grasp domain
+PF03952	Enolase_N	Enolase, N-terminal domain
+PF03953	Tubulin_C	Tubulin C-terminal domain
+PF03954	Lectin_N	Hepatic lectin, N-terminal domain
+PF03955	Adeno_PIX	Adenovirus hexon-associated protein (IX)
+PF03956	Lys_export	Lysine exporter LysO
+PF03957	Jun	Jun-like transcription factor
+PF03958	Secretin_N	Bacterial type II/III secretion system short domain
+PF03959	FSH1	Serine hydrolase (FSH1)
+PF03960	ArsC	ArsC family
+PF03961	FapA	Flagellar Assembly Protein A
+PF03962	Mnd1	Mnd1 family
+PF03963	FlgD	Flagellar hook capping protein - N-terminal region
+PF03964	Chorion_2	Chorion family 2
+PF03965	Penicillinase_R	Penicillinase repressor
+PF03966	Trm112p	Trm112p-like protein
+PF03967	PRCH	Photosynthetic reaction centre, H-chain N-terminal region
+PF03968	OstA	OstA-like protein
+PF03969	AFG1_ATPase	AFG1-like ATPase
+PF03970	Herpes_UL37_1	Herpesvirus UL37 tegument protein
+PF03971	IDH	Monomeric isocitrate dehydrogenase
+PF03972	MmgE_PrpD	MmgE/PrpD family
+PF03973	Triabin	Triabin
+PF03974	Ecotin	Ecotin
+PF03975	CheD	CheD chemotactic sensory transduction
+PF03976	PPK2	Polyphosphate kinase 2 (PPK2)
+PF03977	OAD_beta	Na+-transporting oxaloacetate decarboxylase beta subunit
+PF03978	Borrelia_REV	Borrelia burgdorferi REV protein
+PF03979	Sigma70_r1_1	Sigma-70 factor, region 1.1
+PF03980	Nnf1	Nnf1 
+PF03981	Ubiq_cyt_C_chap	Ubiquinol-cytochrome C chaperone 
+PF03982	DAGAT	Diacylglycerol acyltransferase 
+PF03983	SHD1	SLA1 homology domain 1, SHD1 
+PF03984	DUF346	Repeat of unknown function (DUF346)  
+PF03985	Paf1	Paf1 
+PF03986	Autophagy_N	Autophagocytosis associated protein (Atg3), N-terminal domain 
+PF03987	Autophagy_act_C	Autophagocytosis associated protein, active-site domain 
+PF03988	DUF347	Repeat of Unknown Function (DUF347) 
+PF03989	DNA_gyraseA_C	DNA gyrase C-terminal domain, beta-propeller
+PF03990	DUF348	Domain of unknown function (DUF348)     
+PF03991	Prion_octapep	Copper binding octapeptide repeat
+PF03992	ABM	Antibiotic biosynthesis monooxygenase
+PF03993	DUF349	Domain of Unknown Function (DUF349)
+PF03994	DUF350	Domain of Unknown Function (DUF350) 
+PF03995	Inhibitor_I36	Peptidase inhibitor family I36
+PF03996	Hema_esterase	Hemagglutinin esterase
+PF03997	VPS28	VPS28 protein
+PF03998	Utp11	Utp11 protein
+PF03999	MAP65_ASE1	Microtubule associated protein (MAP65/ASE1 family)
+PF04000	Sas10_Utp3	Sas10/Utp3/C1D family
+PF04001	Vhr1	Transcription factor Vhr1
+PF04002	RadC	RadC-like JAB domain
+PF04003	Utp12	Dip2/Utp12 Family
+PF04004	Leo1	Leo1-like protein
+PF04005	Hus1	Hus1-like protein
+PF04006	Mpp10	Mpp10 protein
+PF04007	DUF354	Protein of unknown function (DUF354)
+PF04008	Adenosine_kin	Adenosine specific kinase
+PF04009	DUF356	Protein of unknown function (DUF356)
+PF04010	DUF357	Protein of unknown function (DUF357)
+PF04011	LemA	LemA family
+PF04012	PspA_IM30	PspA/IM30 family
+PF04013	Methyltrn_RNA_2	Putative SAM-dependent RNA methyltransferase
+PF04014	MazE_antitoxin	Antidote-toxin recognition MazE, bacterial antitoxin
+PF04015	DUF362	Domain of unknown function (DUF362) 
+PF04016	DUF364	Putative heavy-metal chelation
+PF04017	DUF366	Domain of unknown function (DUF366)
+PF04018	DUF368	Domain of unknown function (DUF368)
+PF04019	DUF359	Protein of unknown function (DUF359)
+PF04020	Phage_holin_4_2	Mycobacterial 4 TMS phage holin, superfamily IV
+PF04021	Class_IIIsignal	Class III signal peptide
+PF04022	Staphylcoagulse	Staphylocoagulase repeat
+PF04023	FeoA	FeoA domain
+PF04024	PspC	PspC domain
+PF04025	DUF370	Domain of unknown function (DUF370)
+PF04026	SpoVG	SpoVG
+PF04027	DUF371	Domain of unknown function (DUF371)
+PF04028	DUF374	Domain of unknown function (DUF374)
+PF04029	2-ph_phosp	2-phosphosulpholactate phosphatase
+PF04030	ALO	D-arabinono-1,4-lactone oxidase 
+PF04031	Las1	Las1-like 
+PF04032	Rpr2	RNAse P Rpr2/Rpp21/SNM1 subunit domain
+PF04033	DUF365	Domain of unknown function (DUF365)
+PF04034	Ribo_biogen_C	Ribosome biogenesis protein, C-terminal
+PF04037	DUF382	Domain of unknown function (DUF382) 
+PF04038	DHNA	Dihydroneopterin aldolase
+PF04039	MnhB	Domain related to MnhB subunit of Na+/H+ antiporter
+PF04041	Glyco_hydro_130	beta-1,4-mannooligosaccharide phosphorylase
+PF04042	DNA_pol_E_B	DNA polymerase alpha/epsilon subunit B
+PF04043	PMEI	Plant invertase/pectin methylesterase inhibitor
+PF04045	P34-Arc	Arp2/3 complex, 34 kD subunit p34-Arc
+PF04046	PSP	PSP
+PF04048	Sec8_exocyst	Sec8 exocyst complex component specific domain
+PF04049	ANAPC8	Anaphase promoting complex subunit 8 / Cdc23 
+PF04050	Upf2	Up-frameshift suppressor 2 
+PF04051	TRAPP	Transport protein particle (TRAPP) component
+PF04052	TolB_N	TolB amino-terminal domain
+PF04053	Coatomer_WDAD	Coatomer WD associated region 
+PF04054	Not1	CCR4-Not complex component, Not1
+PF04055	Radical_SAM	Radical SAM superfamily
+PF04056	Ssl1	Ssl1-like
+PF04057	Rep-A_N	Replication factor-A protein 1, N-terminal domain
+PF04059	RRM_2	RNA recognition motif 2
+PF04060	FeS	Putative Fe-S cluster
+PF04061	ORMDL	ORMDL family 
+PF04062	P21-Arc	ARP2/3 complex ARPC3 (21 kDa) subunit
+PF04063	DUF383	Domain of unknown function (DUF383)
+PF04064	DUF384	Domain of unknown function (DUF384)
+PF04065	Not3	Not1 N-terminal domain, CCR4-Not complex component 
+PF04066	MrpF_PhaF	Multiple resistance and pH regulation protein F (MrpF / PhaF)
+PF04068	RLI	Possible Fer4-like domain in RNase L inhibitor, RLI
+PF04069	OpuAC	Substrate binding domain of ABC-type glycine betaine transport system
+PF04070	DUF378	Domain of unknown function (DUF378)
+PF04071	zf-like	Cysteine-rich small domain
+PF04072	LCM	Leucine carboxyl methyltransferase
+PF04073	tRNA_edit	Aminoacyl-tRNA editing domain
+PF04074	DUF386	Domain of unknown function (DUF386)
+PF04075	F420H2_quin_red	F420H(2)-dependent quinone reductase
+PF04076	BOF	Bacterial OB fold (BOF) protein
+PF04077	DsrH	DsrH like protein
+PF04078	Rcd1	Cell differentiation family, Rcd1-like 
+PF04079	SMC_ScpB	Segregation and condensation complex subunit ScpB
+PF04080	Per1	Per1-like family
+PF04081	DNA_pol_delta_4	DNA polymerase delta, subunit 4 
+PF04082	Fungal_trans	Fungal specific transcription factor domain 
+PF04083	Abhydro_lipase	Partial alpha/beta-hydrolase lipase region
+PF04084	ORC2	Origin recognition complex subunit 2 
+PF04085	MreC	rod shape-determining protein MreC
+PF04086	SRP-alpha_N	Signal recognition particle, alpha subunit, N-terminal
+PF04087	DUF389	Domain of unknown function (DUF389) 
+PF04088	Peroxin-13_N	Peroxin 13, N-terminal region
+PF04089	BRICHOS	BRICHOS domain
+PF04090	RNA_pol_I_TF	RNA polymerase I specific initiation factor
+PF04091	Sec15	Exocyst complex subunit Sec15-like 
+PF04092	SAG	SRS domain
+PF04093	MreD	rod shape-determining protein MreD
+PF04094	DUF390	Protein of unknown function (DUF390)
+PF04095	NAPRTase	Nicotinate phosphoribosyltransferase (NAPRTase) family
+PF04096	Nucleoporin2	Nucleoporin autopeptidase
+PF04097	Nic96	Nup93/Nic96
+PF04098	Rad52_Rad22	Rad52/22 family double-strand break repair protein
+PF04099	Sybindin	Sybindin-like family 
+PF04100	Vps53_N	Vps53-like, N-terminal 
+PF04101	Glyco_tran_28_C	Glycosyltransferase family 28 C-terminal domain
+PF04102	SlyX	SlyX
+PF04103	CD20	CD20-like family
+PF04104	DNA_primase_lrg	Eukaryotic and archaeal DNA primase, large subunit
+PF04106	APG5	Autophagy protein Apg5 
+PF04107	GCS2	Glutamate-cysteine ligase family 2(GCS2)
+PF04108	APG17	Autophagy protein Apg17 
+PF04109	APG9	Autophagy protein Apg9 
+PF04110	APG12	Ubiquitin-like autophagy protein Apg12 
+PF04111	APG6	Autophagy protein Apg6
+PF04112	Mak10	Mak10 subunit, NatC N(alpha)-terminal acetyltransferase
+PF04113	Gpi16	Gpi16 subunit, GPI transamidase component
+PF04114	Gaa1	Gaa1-like, GPI transamidase component 
+PF04115	Ureidogly_lyase	Ureidoglycolate lyase
+PF04116	FA_hydroxylase	Fatty acid hydroxylase superfamily
+PF04117	Mpv17_PMP22	Mpv17 / PMP22 family 
+PF04118	Dopey_N	Dopey, N-terminal
+PF04119	HSP9_HSP12	Heat shock protein 9/12
+PF04120	Iron_permease	Low affinity iron permease 
+PF04121	Nup84_Nup100	Nuclear pore protein 84 / 107 
+PF04122	CW_binding_2	Putative cell wall binding repeat 2
+PF04123	DUF373	Domain of unknown function (DUF373)
+PF04124	Dor1	Dor1-like family 
+PF04126	Cyclophil_like	Cyclophilin-like
+PF04127	DFP	DNA / pantothenate metabolism flavoprotein
+PF04129	Vps52	Vps52 / Sac2 family 
+PF04130	Spc97_Spc98	Spc97 / Spc98 family
+PF04131	NanE	Putative N-acetylmannosamine-6-phosphate epimerase
+PF04133	Vps55	Vacuolar protein sorting 55 
+PF04134	DUF393	Protein of unknown function, DUF393
+PF04135	Nop10p	Nucleolar RNA-binding protein, Nop10p family
+PF04136	Sec34	Sec34-like family 
+PF04137	ERO1	Endoplasmic Reticulum Oxidoreductin 1 (ERO1)
+PF04138	GtrA	GtrA-like protein
+PF04139	Rad9	Rad9
+PF04140	ICMT	Isoprenylcysteine carboxyl methyltransferase (ICMT) family 
+PF04142	Nuc_sug_transp	Nucleotide-sugar transporter
+PF04143	Sulf_transp	Sulphur transport
+PF04144	SCAMP	SCAMP family
+PF04145	Ctr	Ctr copper transporter family
+PF04146	YTH	YT521-B-like domain
+PF04147	Nop14	Nop14-like family 
+PF04148	Erv26	Transmembrane adaptor Erv26
+PF04149	DUF397	Domain of unknown function (DUF397)
+PF04151	PPC	Bacterial pre-peptidase C-terminal domain
+PF04152	Mre11_DNA_bind	Mre11 DNA-binding presumed domain 
+PF04153	NOT2_3_5	NOT2 / NOT3 / NOT5 family
+PF04155	Ground-like	Ground-like domain
+PF04156	IncA	IncA protein
+PF04157	EAP30	EAP30/Vps36 family
+PF04158	Sof1	Sof1-like domain 
+PF04159	NB	NB glycoprotein
+PF04160	Borrelia_orfX	Orf-X protein
+PF04161	Arv1	Arv1-like family 
+PF04162	Gyro_capsid	Gyrovirus capsid protein (VP1)
+PF04163	Tht1	Tht1-like nuclear fusion protein 
+PF04165	DUF401	Protein of unknown function (DUF401) 
+PF04166	PdxA	Pyridoxal phosphate biosynthetic protein PdxA
+PF04167	DUF402	Protein of unknown function (DUF402)
+PF04168	Alpha-E	A predicted alpha-helical domain with a conserved ER motif.
+PF04170	NlpE	NlpE N-terminal domain
+PF04172	LrgB	LrgB-like family 
+PF04173	DoxD	TQO small subunit DoxD
+PF04174	CP_ATPgrasp_1	A circularly permuted ATPgrasp 
+PF04175	DUF406	Protein of unknown function (DUF406) 
+PF04176	TIP41	TIP41-like family 
+PF04177	TAP42	TAP42-like family
+PF04178	Got1	Got1/Sft2-like family 
+PF04179	Init_tRNA_PT	Rit1 DUSP-like domain
+PF04180	LTV	Low temperature viability protein 
+PF04181	RPAP2_Rtr1	Rtr1/RPAP2 family
+PF04182	B-block_TFIIIC	B-block binding subunit of TFIIIC
+PF04183	IucA_IucC	IucA / IucC family
+PF04184	ST7	ST7 protein
+PF04185	Phosphoesterase	Phosphoesterase family
+PF04186	FxsA	FxsA cytoplasmic membrane protein 
+PF04187	Cofac_haem_bdg	Haem-binding uptake, Tiki superfamily, ChaN
+PF04188	Mannosyl_trans2	Mannosyltransferase (PIG-V)
+PF04189	Gcd10p	Gcd10p family
+PF04190	DUF410	Protein of unknown function (DUF410) 
+PF04191	PEMT	Phospholipid methyltransferase 
+PF04192	Utp21	Utp21 specific WD40 associated putative domain 
+PF04193	PQ-loop	PQ loop repeat 
+PF04194	PDCD2_C	Programmed cell death protein 2, C-terminal putative domain 
+PF04195	Transposase_28	Putative gypsy type transposon
+PF04196	Bunya_RdRp	Bunyavirus RNA dependent RNA polymerase
+PF04197	Birna_RdRp	Birnavirus RNA dependent RNA polymerase (VP1)
+PF04198	Sugar-bind	Putative sugar-binding domain
+PF04199	Cyclase	Putative cyclase
+PF04200	Lipoprotein_17	Lipoprotein associated domain
+PF04201	TPD52	Tumour protein D52 family
+PF04202	Mfp-3	Foot protein 3
+PF04203	Sortase	Sortase family
+PF04204	HTS	Homoserine O-succinyltransferase 
+PF04205	FMN_bind	FMN-binding domain
+PF04206	MtrE	Tetrahydromethanopterin S-methyltransferase, subunit E 
+PF04207	MtrD	Tetrahydromethanopterin S-methyltransferase, subunit D 
+PF04208	MtrA	Tetrahydromethanopterin S-methyltransferase, subunit A 
+PF04209	HgmA	homogentisate 1,2-dioxygenase
+PF04210	MtrG	Tetrahydromethanopterin S-methyltransferase, subunit G 
+PF04211	MtrC	Tetrahydromethanopterin S-methyltransferase, subunit C 
+PF04212	MIT	MIT (microtubule interacting and transport) domain
+PF04213	HtaA	Htaa
+PF04214	DUF411	Protein of unknown function, DUF
+PF04216	FdhE	Protein involved in formate dehydrogenase formation
+PF04217	DUF412	Protein of unknown function, DUF412
+PF04218	CENP-B_N	CENP-B N-terminal DNA-binding domain
+PF04219	DUF413	Protein of unknown function, DUF
+PF04220	YihI	Der GTPase activator (YihI)
+PF04221	RelB	RelB antitoxin
+PF04222	DUF416	Protein of unknown function (DUF416)
+PF04223	CitF	Citrate lyase, alpha subunit (CitF)
+PF04224	DUF417	Protein of unknown function, DUF417
+PF04225	OapA	Opacity-associated protein A LysM-like domain
+PF04226	Transgly_assoc	Transglycosylase associated protein
+PF04227	Indigoidine_A	Indigoidine synthase A like protein
+PF04228	Zn_peptidase	Putative neutral zinc metallopeptidase
+PF04229	GrpB	GrpB protein
+PF04230	PS_pyruv_trans	Polysaccharide pyruvyl transferase
+PF04231	Endonuclease_1	Endonuclease I
+PF04232	SpoVS	Stage V sporulation protein S (SpoVS)
+PF04233	Phage_Mu_F	Phage Mu protein F like protein
+PF04234	CopC	CopC domain
+PF04235	DUF418	Protein of unknown function (DUF418)
+PF04236	Transp_Tc5_C	Tc5 transposase C-terminal domain
+PF04237	YjbR	YjbR
+PF04238	DUF420	Protein of unknown function (DUF420)
+PF04239	DUF421	Protein of unknown function (DUF421)
+PF04240	Caroten_synth	Carotenoid biosynthesis protein
+PF04241	DUF423	Protein of unknown function (DUF423)
+PF04242	DUF424	Protein of unknown function (DUF424)
+PF04244	DPRP	Deoxyribodipyrimidine photo-lyase-related protein
+PF04245	NA37	37-kD nucleoid-associated bacterial protein
+PF04246	RseC_MucC	Positive regulator of sigma(E), RseC/MucC
+PF04247	SirB	Invasion gene expression up-regulator, SirB
+PF04248	NTP_transf_9	Domain of unknown function (DUF427)
+PF04250	DUF429	Protein of unknown function (DUF429)
+PF04252	RNA_Me_trans	Predicted SAM-dependent RNA methyltransferase
+PF04253	TFR_dimer	Transferrin receptor-like dimerisation domain
+PF04254	DUF432	Protein of unknown function (DUF432)
+PF04255	DUF433	Protein of unknown function (DUF433)
+PF04256	DUF434	Protein of unknown function (DUF434)
+PF04257	Exonuc_V_gamma	Exodeoxyribonuclease V, gamma subunit 
+PF04258	Peptidase_A22B	Signal peptide peptidase
+PF04259	SASP_gamma	Small, acid-soluble spore protein, gamma-type 
+PF04260	DUF436	Protein of unknown function (DUF436) 
+PF04261	Dyp_perox	Dyp-type peroxidase family 
+PF04262	Glu_cys_ligase	Glutamate-cysteine ligase 
+PF04263	TPK_catalytic	Thiamin pyrophosphokinase, catalytic domain
+PF04264	YceI	YceI-like domain
+PF04265	TPK_B1_binding	Thiamin pyrophosphokinase, vitamin B1 binding domain
+PF04266	ASCH	ASCH domain
+PF04267	SoxD	Sarcosine oxidase, delta subunit family 
+PF04268	SoxG	Sarcosine oxidase, gamma subunit family 
+PF04269	DUF440	Protein of unknown function, DUF440
+PF04270	Strep_his_triad	Streptococcal histidine triad protein 
+PF04272	Phospholamban	Phospholamban
+PF04273	DUF442	Putative phosphatase (DUF442)
+PF04275	P-mevalo_kinase	Phosphomevalonate kinase 
+PF04276	DUF443	Protein of unknown function (DUF443) 
+PF04277	OAD_gamma	Oxaloacetate decarboxylase, gamma chain 
+PF04278	Tic22	Tic22-like family
+PF04279	IspA	Intracellular septation protein A 
+PF04280	Tim44	Tim44-like domain
+PF04281	Tom22	Mitochondrial import receptor subunit Tom22 
+PF04282	DUF438	Family of unknown function (DUF438)
+PF04283	CheF-arch	Chemotaxis signal transduction system protein F from archaea
+PF04284	DUF441	Protein of unknown function (DUF441)
+PF04285	DUF444	Protein of unknown function (DUF444)
+PF04286	DUF445	Protein of unknown function (DUF445)
+PF04287	DUF446	tRNA pseudouridine synthase C
+PF04288	MukE	MukE-like family
+PF04289	DUF447	Protein of unknown function (DUF447)
+PF04290	DctQ	Tripartite ATP-independent periplasmic transporters, DctQ component
+PF04293	SpoVR	SpoVR like protein
+PF04294	VanW	VanW like protein
+PF04295	GD_AH_C	D-galactarate dehydratase / Altronate hydrolase, C terminus
+PF04296	DUF448	Protein of unknown function (DUF448)
+PF04297	UPF0122	Putative helix-turn-helix protein, YlxM / p13 like
+PF04298	Zn_peptidase_2	Putative neutral zinc metallopeptidase
+PF04299	FMN_bind_2	Putative FMN-binding domain
+PF04300	FBA	F-box associated region
+PF04301	DUF452	Protein of unknown function (DUF452)
+PF04303	PrpF	PrpF protein
+PF04304	DUF454	Protein of unknown function (DUF454)
+PF04305	DUF455	Protein of unknown function (DUF455)
+PF04306	DUF456	Protein of unknown function (DUF456)
+PF04307	YdjM	LexA-binding, inner membrane-associated putative hydrolase
+PF04308	RNaseH_like	Ribonuclease H-like
+PF04309	G3P_antiterm	Glycerol-3-phosphate responsive antiterminator
+PF04310	MukB	MukB N-terminal
+PF04311	DUF459	Protein of unknown function (DUF459)
+PF04312	DUF460	Protein of unknown function (DUF460)
+PF04313	HSDR_N	Type I restriction enzyme R protein N terminus (HSDR_N)
+PF04314	PCuAC	Copper chaperone PCu(A)C
+PF04315	EpmC	Elongation factor P hydroxylase
+PF04316	FlgM	Anti-sigma-28 factor, FlgM
+PF04317	DUF463	YcjX-like family, DUF463
+PF04318	DUF468	Protein of unknown function (DUF468) 
+PF04319	NifZ	NifZ domain
+PF04320	DUF469	Protein with unknown function (DUF469)
+PF04321	RmlD_sub_bind	RmlD substrate binding domain
+PF04322	DUF473	Protein of unknown function (DUF473)
+PF04324	Fer2_BFD	BFD-like [2Fe-2S] binding domain
+PF04325	DUF465	Protein of unknown function (DUF465)
+PF04326	AlbA_2	Putative DNA-binding domain
+PF04327	Peptidase_Prp	Cysteine protease Prp
+PF04328	Sel_put	Selenoprotein, putative 
+PF04332	DUF475	Protein of unknown function (DUF475)
+PF04333	MlaA	MlaA lipoprotein
+PF04334	DUF478	Protein of unknown function (DUF478)
+PF04335	VirB8	VirB8 protein
+PF04336	ACP_PD	Acyl carrier protein phosphodiesterase
+PF04337	DUF480	Protein of unknown function, DUF480
+PF04338	DUF481	Protein of unknown function, DUF481
+PF04339	FemAB_like	Peptidogalycan biosysnthesis/recognition
+PF04340	DUF484	Protein of unknown function, DUF484
+PF04341	DUF485	Protein of unknown function, DUF485
+PF04342	DMT_6	Putative member of DMT superfamily (DUF486)
+PF04343	DUF488	Protein of unknown function, DUF488
+PF04344	CheZ	Chemotaxis phosphatase, CheZ
+PF04345	Chor_lyase	Chorismate lyase
+PF04346	EutH	Ethanolamine utilisation protein, EutH
+PF04347	FliO	Flagellar biosynthesis protein, FliO
+PF04348	LppC	LppC putative lipoprotein
+PF04349	MdoG	Periplasmic glucan biosynthesis protein, MdoG
+PF04350	PilO	Pilus assembly protein, PilO
+PF04351	PilP	Pilus assembly protein, PilP
+PF04352	ProQ	ProQ/FINO family
+PF04353	Rsd_AlgQ	Regulator of RNA polymerase sigma(70) subunit, Rsd/AlgQ
+PF04354	ZipA_C	ZipA, C-terminal FtsZ-binding domain
+PF04355	SmpA_OmlA	SmpA / OmlA family
+PF04356	DUF489	Protein of unknown function (DUF489)
+PF04357	TamB	TamB, inner membrane protein subunit of TAM complex
+PF04358	DsrC	DsrC like protein
+PF04359	DUF493	Protein of unknown function (DUF493)
+PF04360	Serglycin	Serglycin 
+PF04361	DUF494	Protein of unknown function (DUF494)
+PF04362	Iron_traffic	Bacterial Fe(2+) trafficking
+PF04363	DUF496	Protein of unknown function (DUF496)
+PF04364	DNA_pol3_chi	DNA polymerase III chi subunit, HolC
+PF04365	BrnT_toxin	Ribonuclease toxin, BrnT, of type II toxin-antitoxin system
+PF04366	Ysc84	Las17-binding protein actin regulator
+PF04367	DUF502	Protein of unknown function (DUF502)
+PF04368	DUF507	Protein of unknown function (DUF507)
+PF04369	Lactococcin	Lactococcin-like family
+PF04370	DUF508	Domain of unknown function (DUF508) 
+PF04371	PAD_porph	Porphyromonas-type peptidyl-arginine deiminase
+PF04375	HemX	HemX, putative uroporphyrinogen-III C-methyltransferase
+PF04376	ATE_N	Arginine-tRNA-protein transferase, N terminus
+PF04377	ATE_C	Arginine-tRNA-protein transferase, C terminus
+PF04378	RsmJ	Ribosomal RNA large subunit methyltransferase D, RlmJ
+PF04379	DUF525	ApaG domain 
+PF04380	BMFP	Membrane fusogenic activity
+PF04381	RdgC	Putative exonuclease, RdgC
+PF04382	SAB	SAB domain
+PF04383	KilA-N	KilA-N domain
+PF04384	Fe-S_assembly	Iron-sulphur cluster assembly
+PF04385	FAINT	Domain of unknown function, DUF529
+PF04386	SspB	Stringent starvation protein B
+PF04387	PTPLA	Protein tyrosine phosphatase-like protein, PTPLA
+PF04388	Hamartin	Hamartin protein
+PF04389	Peptidase_M28	Peptidase family M28
+PF04390	LptE	Lipopolysaccharide-assembly
+PF04391	DUF533	Protein of unknown function (DUF533)
+PF04392	ABC_sub_bind	ABC transporter substrate binding protein
+PF04393	DUF535	Protein of unknown function (DUF535)
+PF04394	DUF536	Protein of unknown function, DUF536
+PF04395	Poxvirus_B22R	Poxvirus B22R protein
+PF04397	LytTR	LytTr DNA-binding domain
+PF04398	DUF538	Protein of unknown function, DUF538
+PF04399	Glutaredoxin2_C	Glutaredoxin 2, C terminal domain
+PF04400	NqrM	(Na+)-NQR maturation NqrM
+PF04402	SIMPL	Protein of unknown function (DUF541)
+PF04403	PqiA	Paraquat-inducible protein A
+PF04404	ERF	ERF superfamily
+PF04405	ScdA_N	Domain of Unknown function (DUF542)  
+PF04406	TP6A_N	Type IIB DNA topoisomerase
+PF04407	DUF531	Protein of unknown function (DUF531)
+PF04408	HA2	Helicase associated domain (HA2)
+PF04409	DUF530	Protein of unknown function (DUF530)
+PF04410	Gar1	Gar1/Naf1 RNA binding region
+PF04411	PDDEXK_7	PD-(D/E)XK nuclease superfamily
+PF04412	DUF521	Protein of unknown function (DUF521)
+PF04413	Glycos_transf_N	3-Deoxy-D-manno-octulosonic-acid transferase (kdotransferase)
+PF04414	tRNA_deacylase	D-aminoacyl-tRNA deacylase
+PF04415	DUF515	Protein of unknown function (DUF515)    
+PF04417	DUF501	Protein of unknown function (DUF501)
+PF04418	DUF543	Domain of unknown function (DUF543)
+PF04419	4F5	4F5 protein family
+PF04420	CHD5	CHD5-like protein
+PF04421	Mss4	Mss4 protein
+PF04422	FrhB_FdhB_N	Coenzyme F420 hydrogenase/dehydrogenase, beta subunit N-term
+PF04423	Rad50_zn_hook	Rad50 zinc hook motif
+PF04424	MINDY_DUB	MINDY deubiquitinase
+PF04425	Bul1_N	Bul1 N terminus
+PF04426	Bul1_C	Bul1 C terminus
+PF04427	Brix	Brix domain
+PF04428	Choline_kin_N	Choline kinase N terminus
+PF04430	DUF498	Protein of unknown function (DUF498/DUF598)
+PF04431	Pec_lyase_N	Pectate lyase, N terminus
+PF04432	FrhB_FdhB_C	Coenzyme F420 hydrogenase/dehydrogenase, beta subunit C terminus
+PF04433	SWIRM	SWIRM domain
+PF04434	SWIM	SWIM zinc finger
+PF04435	SPK	Domain of unknown function (DUF545)  
+PF04437	RINT1_TIP1	RINT-1 / TIP-1 family
+PF04438	zf-HIT	HIT zinc finger
+PF04439	Adenyl_transf	Streptomycin adenylyltransferase
+PF04440	Dysbindin	Dysbindin (Dystrobrevin binding protein 1)
+PF04441	Pox_VERT_large	Poxvirus early transcription factor (VETF), large subunit 
+PF04442	CtaG_Cox11	Cytochrome c oxidase assembly protein CtaG/Cox11
+PF04443	LuxE	Acyl-protein synthetase, LuxE
+PF04444	Dioxygenase_N	Catechol dioxygenase N terminus
+PF04445	SAM_MT	Putative SAM-dependent methyltransferase
+PF04446	Thg1	tRNAHis guanylyltransferase
+PF04447	DUF550	Protein of unknown function (DUF550)
+PF04448	DUF551	Protein of unknown function (DUF551)   
+PF04449	Fimbrial_CS1	CS1 type fimbrial major subunit
+PF04450	BSP	Peptidase of plants and bacteria
+PF04451	Capsid_NCLDV	Large eukaryotic DNA virus major capsid protein
+PF04452	Methyltrans_RNA	RNA methyltransferase
+PF04453	OstA_C	Organic solvent tolerance protein
+PF04454	Linocin_M18	Encapsulating protein for peroxidase
+PF04455	Saccharop_dh_N	LOR/SDH bifunctional enzyme conserved region 
+PF04456	DUF503	Protein of unknown function (DUF503)
+PF04457	DUF504	Protein of unknown function (DUF504)
+PF04458	DUF505	Protein of unknown function (DUF505)
+PF04459	DUF512	Protein of unknown function (DUF512)
+PF04461	DUF520	Protein of unknown function (DUF520)
+PF04463	DUF523	Protein of unknown function (DUF523)
+PF04464	Glyphos_transf	CDP-Glycerol:Poly(glycerophosphate) glycerophosphotransferase 
+PF04465	DUF499	Protein of unknown function (DUF499)
+PF04466	Terminase_3	Phage terminase large subunit
+PF04467	DUF483	Protein of unknown function (DUF483)
+PF04468	PSP1	PSP1 C-terminal conserved region
+PF04471	Mrr_cat	Restriction endonuclease
+PF04472	SepF	Cell division protein SepF
+PF04473	DUF553	Transglutaminase-like domain
+PF04474	DUF554	Protein of unknown function (DUF554)
+PF04475	DUF555	Protein of unknown function (DUF555)
+PF04476	4HFCP_synth	4-HFC-P synthase
+PF04478	Mid2	Mid2 like cell wall stress sensor
+PF04479	RTA1	RTA1 like protein
+PF04480	DUF559	Protein of unknown function (DUF559)
+PF04481	DUF561	Protein of unknown function (DUF561)
+PF04483	DUF565	Protein of unknown function (DUF565)
+PF04484	QWRF	QWRF family
+PF04485	NblA	Phycobilisome degradation protein nblA 
+PF04486	SchA_CurD	SchA/CurD like domain
+PF04487	CITED	CITED
+PF04488	Gly_transf_sug	Glycosyltransferase sugar-binding region containing DXD motif   
+PF04489	DUF570	Protein of unknown function (DUF570)    
+PF04490	Pox_T4_C	Poxvirus T4 protein, C terminus
+PF04491	Pox_T4_N	Poxvirus T4 protein, N terminus
+PF04492	Phage_rep_O	Bacteriophage replication protein O      
+PF04493	Endonuclease_5	Endonuclease V
+PF04494	TFIID_NTD2	WD40 associated region in TFIID subunit, NTD2 domain
+PF04495	GRASP55_65	GRASP55/65 PDZ-like domain 
+PF04496	Herpes_UL35	Herpesvirus UL35 family 
+PF04497	Pox_E2-like	Poxviridae protein 
+PF04498	Pox_VP8_L4R	Poxvirus nucleic acid binding protein VP8/L4R
+PF04499	SAPS	SIT4 phosphatase-associated protein
+PF04500	FLYWCH	FLYWCH zinc finger domain
+PF04501	Baculo_VP39	Baculovirus major capsid protein VP39
+PF04502	DUF572	Family of unknown function (DUF572) 
+PF04503	SSDP	Single-stranded DNA binding protein, SSDP
+PF04504	DUF573	Protein of unknown function, DUF573
+PF04505	CD225	Interferon-induced transmembrane protein
+PF04506	Rft-1	Rft protein
+PF04507	DUF576	Csa1 family
+PF04508	Pox_A_type_inc	Viral A-type inclusion protein repeat 
+PF04509	CheC	CheC-like family
+PF04510	DUF577	Family of unknown function (DUF577)
+PF04511	DER1	Der1-like family
+PF04512	Baculo_PEP_N	Baculovirus polyhedron envelope protein, PEP, N terminus
+PF04513	Baculo_PEP_C	Baculovirus polyhedron envelope protein, PEP, C terminus 
+PF04514	BTV_NS2	Bluetongue virus non-structural protein NS2
+PF04515	Choline_transpo	Plasma-membrane choline transporter
+PF04516	CP2	CP2 transcription factor
+PF04517	Microvir_lysis	Microvirus lysis protein (E), C terminus
+PF04518	Effector_1	Effector from type III secretion system
+PF04519	Bactofilin	Polymer-forming cytoskeletal
+PF04520	Senescence_reg	Senescence regulator
+PF04521	Viral_P18	ssRNA positive strand viral 18kD cysteine rich protein
+PF04522	DUF585	Protein of unknown function (DUF585)
+PF04523	Herpes_U30	Herpes virus tegument protein U30
+PF04525	LOR	LURP-one-related
+PF04526	DUF568	Protein of unknown function (DUF568)
+PF04527	Retinin_C	Drosophila Retinin like protein
+PF04528	Adeno_E4_34	Adenovirus early E4 34 kDa protein conserved region
+PF04529	Herpes_U59	Herpesvirus U59 protein   
+PF04530	Viral_Beta_CD	Viral Beta C/D like family
+PF04531	Phage_holin_1	Bacteriophage holin
+PF04532	DUF587	Protein of unknown function (DUF587)
+PF04533	Herpes_U44	Herpes virus U44 protein
+PF04534	Herpes_UL56	Herpesvirus UL56 protein
+PF04535	DUF588	Domain of unknown function (DUF588)
+PF04536	TPM_phosphatase	TPM domain
+PF04537	Herpes_UL55	Herpesvirus UL55 protein
+PF04538	BEX	Brain expressed X-linked like family 
+PF04539	Sigma70_r3	Sigma-70 region 3
+PF04540	Herpes_UL51	Herpesvirus UL51 protein
+PF04541	Herpes_U34	Herpesvirus virion protein U34    
+PF04542	Sigma70_r2	Sigma-70 region 2 
+PF04544	Herpes_UL20	Herpesvirus egress protein UL20
+PF04545	Sigma70_r4	Sigma-70, region 4
+PF04546	Sigma70_ner	Sigma-70, non-essential region
+PF04547	Anoctamin	Calcium-activated chloride channel
+PF04548	AIG1	AIG1 family
+PF04549	CD47	CD47 transmembrane region
+PF04550	Phage_holin_3_2	Phage holin family 2 
+PF04551	GcpE	GcpE protein
+PF04552	Sigma54_DBD	Sigma-54, DNA binding domain
+PF04553	Tis11B_N	Tis11B like protein, N terminus
+PF04554	Extensin_2	Extensin-like region
+PF04555	XhoI	Restriction endonuclease XhoI
+PF04556	DpnII	DpnII restriction endonuclease
+PF04557	tRNA_synt_1c_R2	Glutaminyl-tRNA synthetase, non-specific RNA binding region part 2    
+PF04558	tRNA_synt_1c_R1	Glutaminyl-tRNA synthetase, non-specific RNA binding region part 1    
+PF04559	Herpes_UL17	Herpesvirus UL17 protein
+PF04560	RNA_pol_Rpb2_7	RNA polymerase Rpb2, domain 7
+PF04561	RNA_pol_Rpb2_2	RNA polymerase Rpb2, domain 2
+PF04562	Dicty_spore_N	Dictyostelium spore coat protein, N terminus
+PF04563	RNA_pol_Rpb2_1	RNA polymerase beta subunit
+PF04564	U-box	U-box domain
+PF04565	RNA_pol_Rpb2_3	RNA polymerase Rpb2, domain 3
+PF04566	RNA_pol_Rpb2_4	RNA polymerase Rpb2, domain 4
+PF04567	RNA_pol_Rpb2_5	RNA polymerase Rpb2, domain 5
+PF04568	IATP	Mitochondrial ATPase inhibitor, IATP
+PF04569	DUF591	Protein of unknown function
+PF04570	zf-FLZ	zinc-finger of the FCS-type, C2-C2
+PF04571	Lipin_N	lipin, N-terminal conserved region
+PF04572	Gb3_synth	Alpha 1,4-glycosyltransferase conserved region
+PF04573	SPC22	Signal peptidase subunit
+PF04574	DUF592	Protein of unknown function (DUF592)
+PF04575	DUF560	Protein of unknown function (DUF560)
+PF04576	Zein-binding	Zein-binding
+PF04577	DUF563	Protein of unknown function (DUF563)
+PF04578	DUF594	Protein of unknown function, DUF594
+PF04579	Keratin_matx	Keratin, high-sulphur matrix protein
+PF04580	Pox_D3	Chordopoxvirinae D3 protein 
+PF04582	Reo_sigmaC	Reovirus sigma C capsid protein
+PF04583	Baculo_p74	Baculoviridae p74 conserved region
+PF04584	Pox_A28	Poxvirus A28 family
+PF04586	Peptidase_S78	Caudovirus prohead serine protease 
+PF04587	ADP_PFK_GK	ADP-specific Phosphofructokinase/Glucokinase conserved region
+PF04588	HIG_1_N	Hypoxia induced protein conserved region
+PF04589	RFX1_trans_act	RFX1 transcription activation region      
+PF04591	DUF596	Protein of unknown function, DUF596
+PF04592	SelP_N	Selenoprotein P, N terminal region
+PF04593	SelP_C	Selenoprotein P, C terminal region
+PF04595	Pox_I6	Poxvirus I6-like family
+PF04596	Pox_F15	Poxvirus protein F15
+PF04597	Ribophorin_I	Ribophorin I
+PF04598	Gasdermin	Gasdermin family
+PF04599	Pox_G5	Poxvirus G5 protein
+PF04601	DUF569	Domain of unknown function (DUF569)
+PF04602	Arabinose_trans	Mycobacterial cell wall arabinan synthesis protein
+PF04603	Mog1	Ran-interacting Mog1 protein
+PF04604	L_biotic_typeA	Type-A lantibiotic
+PF04606	Ogr_Delta	Ogr/Delta-like zinc finger
+PF04607	RelA_SpoT	Region found in RelA / SpoT proteins
+PF04608	PgpA	Phosphatidylglycerophosphatase A
+PF04609	MCR_C	Methyl-coenzyme M reductase operon protein C
+PF04610	TrbL	TrbL/VirB6 plasmid conjugal transfer protein
+PF04611	AalphaY_MDB	Mating type protein A alpha Y mating type dependent binding region 
+PF04612	T2SSM	Type II secretion system (T2SS), protein M
+PF04613	LpxD	UDP-3-O-[3-hydroxymyristoyl] glucosamine N-acyltransferase, LpxD  
+PF04614	Pex19	Pex19 protein family
+PF04615	Utp14	Utp14 protein
+PF04616	Glyco_hydro_43	Glycosyl hydrolases family 43
+PF04617	Hox9_act	Hox9 activation region    
+PF04618	HD-ZIP_N	HD-ZIP protein N terminus
+PF04619	Adhesin_Dr	Dr-family adhesin
+PF04620	FlaA	Flagellar filament outer layer protein Flaa
+PF04621	ETS_PEA3_N	PEA3 subfamily ETS-domain transcription factor N terminal domain
+PF04622	ERG2_Sigma1R	ERG2 and Sigma1 receptor like protein
+PF04623	Adeno_E1B_55K_N	Adenovirus E1B protein N-terminus
+PF04624	Dec-1	Dec-1 repeat
+PF04625	DEC-1_N	DEC-1 protein, N-terminal region
+PF04626	DEC-1_C	Dec-1 protein, C terminal region
+PF04627	ATP-synt_Eps	Mitochondrial ATP synthase epsilon chain
+PF04628	Sedlin_N	Sedlin, N-terminal conserved region
+PF04629	ICA69	Islet cell autoantigen ICA69, C-terminal domain
+PF04630	Phage_TTP_1	Phage tail tube protein
+PF04631	PIF2	Per os infectivity factor 2
+PF04632	FUSC	Fusaric acid resistance protein family
+PF04633	Herpes_BMRF2	Herpesvirus BMRF2 protein
+PF04634	DUF600	Protein of unknown function, DUF600
+PF04636	PA26	PA26 p53-induced protein (sestrin)
+PF04637	Herpes_pp85	Herpesvirus phosphoprotein 85 (HHV6-7 U14/HCMV UL25)
+PF04639	Baculo_E56	Baculoviral E56 protein, specific to ODV envelope
+PF04640	PLATZ	PLATZ transcription factor
+PF04641	Rtf2	Rtf2 RING-finger
+PF04642	DUF601	Protein of unknown function, DUF601
+PF04643	Motilin_assoc	Motilin/ghrelin-associated peptide
+PF04644	Motilin_ghrelin	Motilin/ghrelin
+PF04645	DUF603	Protein of unknown function, DUF603
+PF04646	DUF604	Protein of unknown function, DUF604
+PF04647	AgrB	Accessory gene regulator B
+PF04648	MF_alpha	Yeast mating factor alpha hormone
+PF04649	VlpA_repeat	Mycoplasma hyorhinis VlpA repeat 
+PF04650	YSIRK_signal	YSIRK type signal peptide
+PF04651	Pox_A12	Poxvirus A12 protein
+PF04652	Vta1	Vta1 like
+PF04654	DUF599	Protein of unknown function, DUF599
+PF04655	APH_6_hur	Aminoglycoside/hydroxyurea antibiotic resistance kinase
+PF04656	Pox_E6	Pox virus E6 protein
+PF04657	DMT_YdcZ	Putative inner membrane exporter, YdcZ 
+PF04658	TAFII55_N	TAFII55 protein conserved region
+PF04659	Arch_fla_DE	Archaeal flagella protein 
+PF04660	Nanovirus_coat	Nanovirus coat protein
+PF04661	Pox_I3	Poxvirus I3 ssDNA-binding protein
+PF04662	Luteo_PO	Luteovirus P0 protein
+PF04663	Phenol_monoox	Phenol hydroxylase conserved region
+PF04664	OGFr_N	Opioid growth factor receptor (OGFr) conserved region
+PF04665	Pox_A32	Poxvirus A32 protein
+PF04666	Glyco_transf_54	N-Acetylglucosaminyltransferase-IV (GnT-IV) conserved region
+PF04667	Endosulfine	cAMP-regulated phosphoprotein/endosulfine conserved region
+PF04668	Tsg	Twisted gastrulation (Tsg) protein conserved region
+PF04669	Polysacc_synt_4	Polysaccharide biosynthesis
+PF04670	Gtr1_RagA	Gtr1/RagA G protein conserved region
+PF04671	Ag332	Erythrocyte membrane-associated giant protein antigen 332 
+PF04672	Methyltransf_19	S-adenosyl methyltransferase
+PF04673	Cyclase_polyket	Polyketide synthesis cyclase
+PF04674	Phi_1	Phosphate-induced protein 1 conserved region
+PF04675	DNA_ligase_A_N	DNA ligase N terminus
+PF04676	CwfJ_C_2	Protein similar to CwfJ C-terminus 2
+PF04677	CwfJ_C_1	Protein similar to CwfJ C-terminus 1
+PF04678	MCU	Mitochondrial calcium uniporter
+PF04679	DNA_ligase_A_C	ATP dependent DNA ligase C terminal region        
+PF04680	OGFr_III	Opioid growth factor receptor repeat
+PF04681	Bys1	Blastomyces yeast-phase-specific protein
+PF04682	Herpes_BTRF1	Herpesvirus BTRF1 protein conserved region
+PF04683	Proteasom_Rpn13	Proteasome complex subunit Rpn13 ubiquitin receptor
+PF04684	BAF1_ABF1	BAF1 / ABF1 chromatin reorganising factor
+PF04685	DUF608	Glycosyl-hydrolase family 116, catalytic region
+PF04686	SsgA	Streptomyces sporulation and cell division protein, SsgA
+PF04687	Microvir_H	Microvirus H protein (pilot protein)
+PF04688	Holin_SPP1	SPP1 phage holin
+PF04689	S1FA	DNA binding protein S1FA
+PF04690	YABBY	YABBY protein
+PF04691	ApoC-I	Apolipoprotein C-I (ApoC-1)
+PF04692	PDGF_N	Platelet-derived growth factor, N terminal region
+PF04693	DDE_Tnp_2	Archaeal putative transposase ISC1217
+PF04694	Corona_3	Coronavirus ORF3 protein
+PF04695	Pex14_N	Peroxisomal membrane anchor protein (Pex14p) conserved region
+PF04696	Pinin_SDK_memA	pinin/SDK/memA/ protein conserved region
+PF04697	Pinin_SDK_N	pinin/SDK conserved region
+PF04698	Rab_eff_C	Rab effector MyRIP/melanophilin C-terminus
+PF04699	P16-Arc	ARP2/3 complex 16 kDa subunit (p16-Arc)
+PF04700	Baculo_gp41	Structural glycoprotein p40/gp41 conserved region
+PF04701	Pox_D2	Pox virus D2 protein
+PF04702	Vicilin_N	Vicilin N terminal region
+PF04703	FaeA	FaeA-like protein
+PF04704	Zfx_Zfy_act	Zfx / Zfy transcription activation region
+PF04705	TSNR_N	Thiostrepton-resistance methylase, N terminus
+PF04706	Dickkopf_N	Dickkopf N-terminal cysteine-rich region
+PF04707	PRELI	PRELI-like family
+PF04708	Pox_F16	Poxvirus F16 protein
+PF04709	AMH_N	Anti-Mullerian hormone, N terminal region
+PF04710	Pellino	Pellino
+PF04711	ApoA-II	Apolipoprotein A-II (ApoA-II)
+PF04712	Radial_spoke	Radial spokehead-like protein
+PF04713	Pox_I5	Poxvirus protein I5
+PF04714	BCL_N	BCL7, N-terminal conserver region
+PF04715	Anth_synt_I_N	Anthranilate synthase component I, N terminal region
+PF04716	ETC_C1_NDUFA5	ETC complex I subunit conserved region
+PF04717	Phage_base_V	Type VI secretion system, phage-baseplate injector
+PF04718	ATP-synt_G	Mitochondrial ATP synthase g subunit
+PF04719	TAFII28	hTAFII28-like protein conserved region
+PF04720	PDDEXK_6	PDDEXK-like family of unknown function
+PF04721	PAW	PNGase C-terminal domain, mannose-binding module PAW
+PF04722	Ssu72	Ssu72-like protein
+PF04723	GRDA	Glycine reductase complex selenoprotein A
+PF04724	Glyco_transf_17	Glycosyltransferase family 17
+PF04725	PsbR	Photosystem II 10 kDa polypeptide PsbR
+PF04726	Microvir_J	Microvirus J protein
+PF04727	ELMO_CED12	ELMO/CED-12 family
+PF04728	LPP	Lipoprotein leucine-zipper
+PF04729	ASF1_hist_chap	ASF1 like histone chaperone
+PF04730	Agro_virD5	Agrobacterium VirD5 protein
+PF04731	Caudal_act	Caudal like protein activation region
+PF04732	Filament_head	Intermediate filament head (DNA binding) region
+PF04733	Coatomer_E	Coatomer epsilon subunit
+PF04734	Ceramidase_alk	Neutral/alkaline non-lysosomal ceramidase, N-terminal
+PF04735	Baculo_helicase	Baculovirus DNA helicase
+PF04736	Eclosion	Eclosion hormone
+PF04738	Lant_dehydr_N	Lantibiotic dehydratase, C terminus
+PF04739	AMPKBI	5'-AMP-activated protein kinase beta subunit, interaction domain
+PF04740	LXG	LXG domain of WXG superfamily
+PF04741	InvH	InvH outer membrane lipoprotein
+PF04744	Monooxygenase_B	Monooxygenase subunit B protein
+PF04745	Pox_A8	VITF-3 subunit protein
+PF04746	DUF575	Protein of unknown function (DUF575)
+PF04747	DUF612	Protein of unknown function, DUF612
+PF04748	Polysacc_deac_2	Divergent polysaccharide deacetylase
+PF04749	PLAC8	PLAC8 family
+PF04750	Far-17a_AIG1	FAR-17a/AIG1-like protein
+PF04751	DUF615	Protein of unknown function (DUF615)
+PF04752	ChaC	ChaC-like protein
+PF04753	Corona_NS2	Coronavirus non-structural protein NS2
+PF04754	Transposase_31	Putative transposase, YhgA-like
+PF04755	PAP_fibrillin	PAP_fibrillin
+PF04756	OST3_OST6	OST3 / OST6 family, transporter family
+PF04757	Pex2_Pex12	Pex2 / Pex12 amino terminal region
+PF04758	Ribosomal_S30	Ribosomal protein S30
+PF04759	DUF617	Protein of unknown function, DUF617
+PF04760	IF2_N	Translation initiation factor IF-2, N-terminal region
+PF04761	Phage_Treg	Lactococcus bacteriophage putative transcription regulator
+PF04762	IKI3	IKI3 family
+PF04763	DUF562	Protein of unknown function (DUF562)
+PF04764	DUF613	Protein of unknown function (DUF613)
+PF04765	DUF616	Protein of unknown function (DUF616)
+PF04766	Baculo_p26	Nucleopolyhedrovirus p26 protein
+PF04767	Pox_F17	DNA-binding 11 kDa phosphoprotein
+PF04768	NAT	NAT, N-acetyltransferase, of N-acetylglutamate synthase
+PF04769	MATalpha_HMGbox	Mating-type protein MAT alpha 1 HMG-box
+PF04770	ZF-HD_dimer	ZF-HD protein dimerisation region
+PF04771	CAV_VP3	Chicken anaemia virus VP-3 protein
+PF04772	Flu_B_M2	Influenza B matrix protein 2 (BM2)
+PF04773	FecR	FecR protein
+PF04774	HABP4_PAI-RBP1	Hyaluronan / mRNA binding family
+PF04775	Bile_Hydr_Trans	Acyl-CoA thioester hydrolase/BAAT N-terminal region
+PF04776	protein_MS5	Protein MS5
+PF04777	Evr1_Alr	Erv1 / Alr family
+PF04778	LMP	LMP repeated region
+PF04780	DUF629	Protein of unknown function (DUF629)
+PF04781	DUF627	Protein of unknown function (DUF627)
+PF04782	DUF632	Protein of unknown function (DUF632)
+PF04783	DUF630	Protein of unknown function (DUF630)
+PF04784	DUF547	Protein of unknown function, DUF547
+PF04785	Rhabdo_M2	Rhabdovirus matrix protein M2
+PF04786	Baculo_DNA_bind	ssDNA binding protein 
+PF04787	Pox_H7	Late protein H7
+PF04788	DUF620	Protein of unknown function (DUF620)
+PF04789	DUF621	Protein of unknown function (DUF621)
+PF04790	Sarcoglycan_1	Sarcoglycan complex subunit protein
+PF04791	LMBR1	LMBR1-like membrane protein
+PF04792	LcrV	V antigen (LcrV) protein
+PF04793	Herpes_BBRF1	BRRF1-like protein
+PF04794	YdjC	YdjC-like protein
+PF04795	PAPA-1	PAPA-1-like conserved region
+PF04796	RepA_C	Plasmid encoded RepA protein
+PF04797	Herpes_ORF11	Herpesvirus dUTPase protein
+PF04798	Baculo_19	Baculovirus 19 kDa protein conserved region
+PF04799	Fzo_mitofusin	fzo-like conserved region
+PF04800	ETC_C1_NDUFA4	ETC complex I subunit conserved region
+PF04801	Sin_N	Sin-like protein conserved region
+PF04802	SMK-1	Component of IIS longevity pathway SMK-1
+PF04803	Cor1	Cor1/Xlr/Xmr conserved region
+PF04805	Pox_E10	E10-like protein conserved region
+PF04806	EspF	EspF protein repeat
+PF04807	Gemini_AC4_5	Geminivirus AC4/5 conserved region
+PF04808	CTV_P23	Citrus tristeza virus (CTV) P23 protein 
+PF04809	HupH_C	HupH hydrogenase expression protein, C-terminal conserved region
+PF04810	zf-Sec23_Sec24	Sec23/Sec24 zinc finger
+PF04811	Sec23_trunk	Sec23/Sec24 trunk domain
+PF04812	HNF-1B_C	Hepatocyte nuclear factor 1 (HNF-1), beta isoform C terminus
+PF04813	HNF-1A_C	Hepatocyte nuclear factor 1 (HNF-1), alpha isoform C terminus
+PF04814	HNF-1_N	Hepatocyte nuclear factor 1 (HNF-1), N terminus
+PF04815	Sec23_helical	Sec23/Sec24 helical domain
+PF04816	TrmK	tRNA (adenine(22)-N(1))-methyltransferase
+PF04817	Umbravirus_LDM	Umbravirus long distance movement (LDM) family 
+PF04818	CTD_bind	RNA polymerase II-binding domain.
+PF04819	DUF716	Family of unknown function (DUF716) 
+PF04820	Trp_halogenase	Tryptophan halogenase
+PF04821	TIMELESS	Timeless protein
+PF04822	Takusan	Takusan
+PF04823	Herpes_UL49_2	Herpesvirus UL49 tegument protein
+PF04824	Rad21_Rec8	Conserved region of Rad21 / Rec8 like protein
+PF04825	Rad21_Rec8_N	N terminus of Rad21 / Rec8 like protein
+PF04826	Arm_2	Armadillo-like
+PF04827	Plant_tran	Plant transposon protein
+PF04828	GFA	Glutathione-dependent formaldehyde-activating enzyme
+PF04829	PT-VENN	Pre-toxin domain with VENN motif
+PF04830	DUF637	Possible hemagglutinin (DUF637)
+PF04831	Popeye	Popeye protein conserved region
+PF04832	SOUL	SOUL heme-binding protein
+PF04833	COBRA	COBRA-like protein
+PF04834	Adeno_E3_14_5	Early E3 14.5 kDa protein
+PF04835	Pox_A9	A9 protein conserved region
+PF04836	IFRD_C	Interferon-related protein conserved region
+PF04837	MbeB_N	MbeB-like, N-term conserved region
+PF04838	Baculo_LEF5	Baculoviridae late expression factor 5 
+PF04839	PSRP-3_Ycf65	Plastid and cyanobacterial ribosomal protein (PSRP-3 / Ycf65)
+PF04840	Vps16_C	Vps16, C-terminal region
+PF04841	Vps16_N	Vps16, N-terminal region
+PF04842	DUF639	Plant protein of unknown function (DUF639)
+PF04843	Herpes_teg_N	Herpesvirus tegument protein, N-terminal conserved region
+PF04844	Ovate	Transcriptional repressor, ovate
+PF04845	PurA	PurA ssDNA and RNA-binding protein
+PF04846	Herpes_pp38	Herpesvirus pp38 phosphoprotein
+PF04847	Calcipressin	Calcipressin
+PF04848	Pox_A22	Poxvirus A22 protein
+PF04849	HAP1_N	HAP1 N-terminal conserved region
+PF04850	Baculo_E66	Baculovirus E66 occlusion-derived virus envelope protein
+PF04851	ResIII	Type III restriction enzyme, res subunit
+PF04852	DUF640	Protein of unknown function (DUF640)
+PF04854	DUF624	Protein of unknown function, DUF624
+PF04855	SNF5	SNF5 / SMARCB1 / INI1
+PF04856	Securin	Securin sister-chromatid separation inhibitor
+PF04857	CAF1	CAF1 family ribonuclease
+PF04858	TH1	TH1 protein
+PF04859	DUF641	Plant protein of unknown function (DUF641)
+PF04860	Phage_portal	Phage portal protein
+PF04862	DUF642	Protein of unknown function (DUF642)
+PF04863	EGF_alliinase	Alliinase EGF-like domain
+PF04864	Alliinase_C	Allinase
+PF04865	Baseplate_J	Baseplate J-like protein
+PF04866	Rota_NS6	Rotavirus non-structural protein 6
+PF04867	DUF643	Protein of unknown function (DUF643)
+PF04868	PDE6_gamma	Retinal cGMP phosphodiesterase, gamma subunit
+PF04869	Uso1_p115_head	Uso1 / p115 like vesicle tethering protein, head region
+PF04870	Moulting_cycle	Moulting cycle
+PF04871	Uso1_p115_C	Uso1 / p115 like vesicle tethering protein, C terminal region
+PF04872	Pox_L5	Poxvirus L5 protein family
+PF04873	EIN3	Ethylene insensitive 3
+PF04874	Mak16	Mak16 protein C-terminal region
+PF04875	DUF645	Protein of unknown function, DUF645
+PF04876	Tenui_NCP	Tenuivirus major non-capsid protein
+PF04877	Hairpins	HrpZ
+PF04878	Baculo_p48	Baculovirus P48 protein
+PF04879	Molybdop_Fe4S4	Molybdopterin oxidoreductase Fe4S4 domain
+PF04880	NUDE_C	NUDE protein, C-terminal conserved region
+PF04881	Adeno_GP19K	Adenovirus GP19K
+PF04882	Peroxin-3	Peroxin-3
+PF04883	HK97-gp10_like	Bacteriophage HK97-gp10, putative tail-component
+PF04884	DUF647	Vitamin B6 photo-protection and homoeostasis
+PF04885	Stig1	Stigma-specific protein, Stig1
+PF04886	PT	PT repeat
+PF04887	Pox_M2	Poxvirus M2 protein
+PF04888	SseC	Secretion system effector C (SseC) like family 
+PF04889	Cwf_Cwc_15	Cwf15/Cwc15 cell cycle control protein
+PF04890	DUF648	Family of unknown function (DUF648) 
+PF04891	NifQ	NifQ
+PF04892	VanZ	VanZ like family 
+PF04893	Yip1	Yip1 domain
+PF04894	Nre_N	Archaeal Nre, N-terminal
+PF04895	Nre_C	Archaeal Nre, C-terminal 
+PF04896	AmoC	Ammonia monooxygenase/methane monooxygenase, subunit C
+PF04898	Glu_syn_central	Glutamate synthase central domain
+PF04899	MbeD_MobD	MbeD/MobD like 
+PF04900	Fcf1	Fcf1
+PF04901	RAMP	Receptor activity modifying family 
+PF04902	Nab1	Conserved region in Nab1
+PF04904	NCD1	NAB conserved region 1 (NCD1)
+PF04905	NCD2	NAB conserved region 2 (NCD2)
+PF04906	Tweety	Tweety
+PF04908	SH3BGR	SH3-binding, glutamic acid-rich protein
+PF04909	Amidohydro_2	Amidohydrolase
+PF04910	Tcf25	Transcriptional repressor TCF25
+PF04911	ATP-synt_J	ATP synthase j chain
+PF04912	Dynamitin	Dynamitin 
+PF04913	Baculo_Y142	Baculovirus Y142 protein
+PF04914	DltD	DltD protein
+PF04916	Phospholip_B	Phospholipase B
+PF04917	Shufflon_N	Bacterial shufflon protein, N-terminal constant region
+PF04919	DUF655	Protein of unknown function (DUF655)
+PF04920	DUF656	Family of unknown function (DUF656) 
+PF04921	XAP5	XAP5, circadian clock regulator
+PF04922	DIE2_ALG10	DIE2/ALG10 family
+PF04923	Ninjurin	Ninjurin 
+PF04924	Pox_A6	Poxvirus A6 protein 
+PF04925	SHQ1	SHQ1 protein
+PF04926	PAP_RNA-bind	Poly(A) polymerase predicted RNA binding domain
+PF04927	SMP	Seed maturation protein
+PF04928	PAP_central	Poly(A) polymerase central domain
+PF04929	Herpes_DNAp_acc	Herpes DNA replication accessory factor 
+PF04930	FUN14	FUN14 family
+PF04931	DNA_pol_phi	DNA polymerase phi
+PF04932	Wzy_C	O-Antigen ligase
+PF04934	Med6	MED6 mediator sub complex component
+PF04935	SURF6	Surfeit locus protein 6
+PF04936	DUF658	Protein of unknown function (DUF658)
+PF04937	DUF659	Protein of unknown function (DUF 659)
+PF04938	SIP1	Survival motor neuron (SMN) interacting protein 1 (SIP1)
+PF04939	RRS1	Ribosome biogenesis regulatory protein (RRS1)
+PF04940	BLUF	Sensors of blue-light using FAD
+PF04941	LEF-8	Late expression factor 8 (LEF-8)
+PF04942	CC	CC domain
+PF04943	Pox_F11	Poxvirus F11 protein
+PF04945	YHS	YHS domain
+PF04947	Pox_VLTF3	Poxvirus Late Transcription Factor VLTF3 like 
+PF04948	Pox_A51	Poxvirus A51 protein 
+PF04949	Transcrip_act	Transcriptional activator
+PF04950	RIBIOP_C	40S ribosome biogenesis protein Tsr1 and BMS1 C-terminal
+PF04951	Peptidase_M55	D-aminopeptidase
+PF04952	AstE_AspA	Succinylglutamate desuccinylase / Aspartoacylase family
+PF04954	SIP	Siderophore-interacting protein
+PF04955	HupE_UreJ	HupE / UreJ protein
+PF04956	TrbC	TrbC/VIRB2 family
+PF04957	RMF	Ribosome modulation factor
+PF04958	AstA	Arginine N-succinyltransferase beta subunit
+PF04959	ARS2	Arsenite-resistance protein 2
+PF04960	Glutaminase	Glutaminase
+PF04961	FTCD_C	Formiminotransferase-cyclodeaminase
+PF04962	KduI	KduI/IolB family
+PF04963	Sigma54_CBD	Sigma-54 factor, core binding domain
+PF04964	Flp_Fap	Flp/Fap pilin component
+PF04965	GPW_gp25	Gene 25-like lysozyme
+PF04966	OprB	Carbohydrate-selective porin, OprB family
+PF04967	HTH_10	HTH DNA binding domain
+PF04968	CHORD	CHORD 
+PF04969	CS	CS domain
+PF04970	LRAT	Lecithin retinol acyltransferase
+PF04971	Phage_holin_2_1	Bacteriophage P21 holin S 
+PF04972	BON	BON domain
+PF04973	NMN_transporter	Nicotinamide mononucleotide transporter
+PF04976	DmsC	DMSO reductase anchor subunit (DmsC)
+PF04977	DivIC	Septum formation initiator
+PF04978	DUF664	Protein of unknown function (DUF664)
+PF04979	IPP-2	Protein phosphatase inhibitor 2 (IPP-2)
+PF04981	NMD3	NMD3 family 
+PF04982	HPP	HPP family
+PF04983	RNA_pol_Rpb1_3	RNA polymerase Rpb1, domain 3
+PF04984	Phage_sheath_1	Phage tail sheath protein subtilisin-like domain
+PF04985	Phage_tube	Phage tail tube protein FII
+PF04986	Y2_Tnp	Putative transposase
+PF04987	PigN	Phosphatidylinositolglycan class N (PIG-N)
+PF04988	AKAP95	A-kinase anchoring protein 95 (AKAP95)
+PF04989	CmcI	Cephalosporin hydroxylase
+PF04990	RNA_pol_Rpb1_7	RNA polymerase Rpb1, domain 7
+PF04991	LicD	LicD family
+PF04992	RNA_pol_Rpb1_6	RNA polymerase Rpb1, domain 6
+PF04993	TfoX_N	TfoX N-terminal domain
+PF04994	TfoX_C	TfoX C-terminal domain
+PF04995	CcmD	Heme exporter protein D (CcmD)
+PF04996	AstB	Succinylarginine dihydrolase
+PF04997	RNA_pol_Rpb1_1	RNA polymerase Rpb1, domain 1
+PF04998	RNA_pol_Rpb1_5	RNA polymerase Rpb1, domain 5
+PF04999	FtsL	Cell division protein FtsL
+PF05000	RNA_pol_Rpb1_4	RNA polymerase Rpb1, domain 4
+PF05001	RNA_pol_Rpb1_R	RNA polymerase Rpb1 C-terminal repeat 
+PF05002	SGS	SGS domain 
+PF05003	DUF668	Protein of unknown function (DUF668)
+PF05004	IFRD	Interferon-related developmental regulator (IFRD)
+PF05005	Ocnus	Janus/Ocnus family (Ocnus)
+PF05006	PIF3	Per os infectivity factor 3
+PF05007	Mannosyl_trans	Mannosyltransferase (PIG-M)
+PF05008	V-SNARE	Vesicle transport v-SNARE protein N-terminus
+PF05009	EBV-NA3	Epstein-Barr virus nuclear antigen 3 (EBNA-3)
+PF05010	TACC	Transforming acidic coiled-coil-containing protein (TACC)
+PF05011	DBR1	Lariat debranching enzyme, C-terminal domain
+PF05013	FGase	N-formylglutamate amidohydrolase
+PF05014	Nuc_deoxyrib_tr	Nucleoside 2-deoxyribosyltransferase
+PF05015	HigB-like_toxin	RelE-like toxin of type II toxin-antitoxin system HigB
+PF05016	ParE_toxin	ParE toxin of type II toxin-antitoxin system, parDE
+PF05017	TMP	TMP repeat
+PF05018	DUF667	Protein of unknown function (DUF667)
+PF05019	Coq4	Coenzyme Q (ubiquinone) biosynthesis protein Coq4
+PF05020	zf-NPL4	NPL4 family, putative zinc binding region
+PF05021	NPL4	NPL4 family
+PF05022	SRP40_C	SRP40, C-terminal domain
+PF05023	Phytochelatin	Phytochelatin synthase
+PF05024	Gpi1	N-acetylglucosaminyl transferase component (Gpi1)
+PF05025	RbsD_FucU	RbsD / FucU transport protein family
+PF05026	DCP2	Dcp2, box A domain
+PF05028	PARG_cat	Poly (ADP-ribose) glycohydrolase (PARG)
+PF05029	TIMELESS_C	Timeless protein C terminal region
+PF05030	SSXT	SSXT protein (N-terminal region)
+PF05031	NEAT	Iron Transport-associated domain 
+PF05032	Spo12	Spo12 family
+PF05033	Pre-SET	Pre-SET motif
+PF05034	MAAL_N	Methylaspartate ammonia-lyase N-terminus
+PF05035	DGOK	2-keto-3-deoxy-galactonokinase
+PF05036	SPOR	Sporulation related domain
+PF05037	DUF669	Protein of unknown function (DUF669)
+PF05038	Cytochrom_B558a	Cytochrome Cytochrome b558 alpha-subunit
+PF05039	Agouti	Agouti protein
+PF05041	Pecanex_C	Pecanex protein (C-terminus)
+PF05042	Caleosin	Caleosin related protein
+PF05043	Mga	Mga helix-turn-helix domain
+PF05044	HPD	Homeo-prospero domain
+PF05045	RgpF	Rhamnan synthesis protein F
+PF05046	Img2	Mitochondrial large subunit ribosomal protein (Img2)
+PF05047	L51_S25_CI-B8	Mitochondrial ribosomal protein L51 / S25 / CI-B8 domain 
+PF05048	NosD	Periplasmic copper-binding protein (NosD)
+PF05049	IIGP	Interferon-inducible GTPase (IIGP)
+PF05050	Methyltransf_21	Methyltransferase FkbM domain
+PF05051	COX17	Cytochrome C oxidase copper chaperone (COX17)
+PF05052	MerE	MerE protein
+PF05053	Menin	Menin
+PF05054	AcMNPV_Ac109	Autographa californica nuclear polyhedrosis virus (AcMNPV) protein
+PF05055	DUF677	Protein of unknown function (DUF677)
+PF05056	DUF674	Protein of unknown function (DUF674)
+PF05057	DUF676	Putative serine esterase (DUF676)
+PF05058	ActA	ActA Protein
+PF05059	Orbi_VP4	Orbivirus VP4 core protein
+PF05060	MGAT2	N-acetylglucosaminyltransferase II (MGAT2)
+PF05061	Pox_A11	Poxvirus A11 Protein
+PF05062	RICH	RICH domain
+PF05063	MT-A70	MT-A70 
+PF05064	Nsp1_C	Nsp1-like C-terminal region
+PF05065	Phage_capsid	Phage capsid family 
+PF05066	HARE-HTH	HB1, ASXL, restriction endonuclease HTH domain
+PF05067	Mn_catalase	Manganese containing catalase
+PF05068	MtlR	Mannitol repressor
+PF05069	Phage_tail_S	Phage virion morphogenesis family 
+PF05071	NDUFA12	NADH ubiquinone oxidoreductase subunit NDUFA12
+PF05072	Herpes_UL43	Herpesvirus UL43 protein
+PF05073	Baculo_p24	Baculovirus P24 capsid protein
+PF05075	DUF684	Protein of unknown function (DUF684)
+PF05076	SUFU	Suppressor of fused protein (SUFU)
+PF05077	DUF678	Protein of unknown function (DUF678)
+PF05078	DUF679	Protein of unknown function (DUF679)
+PF05079	DUF680	Protein of unknown function (DUF680)
+PF05080	DUF681	Protein of unknown function (DUF681)
+PF05081	DUF682	Protein of unknown function (DUF682)
+PF05082	Rop-like	Rop-like
+PF05083	LST1	LST-1 protein
+PF05084	GRA6	Granule antigen protein (GRA6)
+PF05085	DUF685	Protein of unknown function (DUF685)
+PF05086	Dicty_REP	Dictyostelium (Slime Mold) REP protein
+PF05087	Rota_VP2	Rotavirus VP2 protein
+PF05088	Bac_GDH	Bacterial NAD-glutamate dehydrogenase
+PF05089	NAGLU	Alpha-N-acetylglucosaminidase (NAGLU) tim-barrel domain
+PF05090	VKG_Carbox	Vitamin K-dependent gamma-carboxylase
+PF05091	eIF-3_zeta	Eukaryotic translation initiation factor 3 subunit 7 (eIF-3)
+PF05092	PIF	Per os infectivity
+PF05093	CIAPIN1	Cytokine-induced anti-apoptosis inhibitor 1, Fe-S biogenesis
+PF05094	LEF-9	Late expression factor 9 (LEF-9)
+PF05095	DUF687	Protein of unknown function (DUF687)
+PF05096	Glu_cyclase_2	Glutamine cyclotransferase
+PF05097	DUF688	Protein of unknown function (DUF688)
+PF05098	LEF-4	Late expression factor 4 (LEF-4)
+PF05099	TerB	Tellurite resistance protein TerB
+PF05100	Phage_tail_L	Phage minor tail protein L 
+PF05101	VirB3	Type IV secretory pathway, VirB3-like protein
+PF05102	Holin_BlyA	holin, BlyA family
+PF05103	DivIVA	DivIVA protein
+PF05104	Rib_recp_KP_reg	Ribosome receptor lysine/proline rich region
+PF05105	Phage_holin_4_1	Bacteriophage holin family 
+PF05106	Phage_holin_3_1	Phage holin family (Lysis protein S)
+PF05107	Cas_Cas7	CRISPR-associated protein Cas7
+PF05108	T7SS_ESX1_EccB	Type VII secretion system ESX-1, transport TM domain B
+PF05109	Herpes_BLLF1	Herpes virus major outer envelope glycoprotein (BLLF1)
+PF05110	AF-4	AF-4 proto-oncoprotein
+PF05111	Amelin	Ameloblastin precursor (Amelin)
+PF05112	Baculo_p47	Baculovirus P47 protein
+PF05113	DUF693	Protein of unknown function (DUF693)
+PF05114	DUF692	Protein of unknown function (DUF692)
+PF05115	PetL	Cytochrome B6-F complex subunit VI (PetL)
+PF05116	S6PP	Sucrose-6F-phosphate phosphohydrolase
+PF05117	DUF695	Family of unknown function (DUF695) 
+PF05118	Asp_Arg_Hydrox	Aspartyl/Asparaginyl beta-hydroxylase
+PF05119	Terminase_4	Phage terminase, small subunit
+PF05120	GvpG	Gas vesicle protein G 
+PF05121	GvpK	Gas vesicle protein K  
+PF05122	SpdB	Mobile element transfer protein
+PF05123	S_layer_N	S-layer like family, N-terminal region 
+PF05124	S_layer_C	S-layer like family, C-terminal region 
+PF05125	Phage_cap_P2	Phage major capsid protein, P2 family 
+PF05127	Helicase_RecD	Helicase
+PF05128	DUF697	Domain of unknown function (DUF697) 
+PF05129	Elf1	Transcription elongation factor Elf1 like
+PF05130	FlgN	FlgN protein
+PF05131	Pep3_Vps18	Pep3/Vps18/deep orange family
+PF05132	RNA_pol_Rpc4	RNA polymerase III RPC4
+PF05133	Phage_prot_Gp6	Phage portal protein, SPP1 Gp6-like
+PF05134	T2SSL	Type II secretion system (T2SS), protein L
+PF05135	Phage_connect_1	Phage gp6-like head-tail connector protein
+PF05136	Phage_portal_2	Phage portal protein, lambda family 
+PF05137	PilN	Fimbrial assembly protein (PilN)
+PF05138	PaaA_PaaC	Phenylacetic acid catabolic protein
+PF05139	Erythro_esteras	Erythromycin esterase
+PF05140	ResB	ResB-like family 
+PF05141	DIT1_PvcA	Pyoverdine/dityrosine biosynthesis protein
+PF05142	DUF702	Domain of unknown function (DUF702) 
+PF05144	Phage_CRI	Phage replication protein CRI  
+PF05145	AbrB	Transition state regulatory protein AbrB
+PF05147	LANC_like	Lanthionine synthetase C-like protein
+PF05148	Methyltransf_8	Hypothetical methyltransferase
+PF05149	Flagellar_rod	Paraflagellar rod protein
+PF05150	Legionella_OMP	Legionella pneumophila major outer membrane protein precursor
+PF05151	PsbM	Photosystem II reaction centre M protein (PsbM)
+PF05152	DUF705	Protein of unknown function (DUF705)
+PF05153	MIOX	Myo-inositol oxygenase
+PF05154	TM2	TM2 domain
+PF05155	Phage_X	Phage X family   
+PF05157	T2SSE_N	Type II secretion system (T2SS), protein E, N-terminal domain
+PF05158	RNA_pol_Rpc34	RNA polymerase Rpc34 subunit
+PF05159	Capsule_synth	Capsule polysaccharide biosynthesis protein
+PF05160	DSS1_SEM1	DSS1/SEM1 family
+PF05161	MOFRL	MOFRL family
+PF05162	Ribosomal_L41	Ribosomal protein L41
+PF05163	DinB	DinB family
+PF05164	ZapA	Cell division protein ZapA
+PF05165	GCH_III	GTP cyclohydrolase III
+PF05166	YcgL	YcgL domain
+PF05167	DUF711	Uncharacterised ACR (DUF711)
+PF05168	HEPN	HEPN domain
+PF05170	AsmA	AsmA family
+PF05171	HemS	Haemin-degrading HemS.ChuX domain
+PF05172	Nup35_RRM	Nup53/35/40-type RNA recognition motif
+PF05173	DapB_C	Dihydrodipicolinate reductase, C-terminus
+PF05174	CDRN	Cysteine-rich D. radiodurans N terminus
+PF05175	MTS	Methyltransferase small domain
+PF05176	ATP-synt_10	ATP10 protein
+PF05177	RCSD	RCSD region
+PF05178	Kri1	KRI1-like family
+PF05179	CDC73_C	RNA pol II accessory factor, Cdc73 family, C-terminal
+PF05180	zf-DNL	DNL zinc finger
+PF05181	XPA_C	XPA protein C-terminus
+PF05182	Fip1	Fip1 motif
+PF05183	RdRP	RNA dependent RNA polymerase
+PF05184	SapB_1	Saposin-like type B, region 1
+PF05185	PRMT5	PRMT5 arginine-N-methyltransferase
+PF05186	Dpy-30	Dpy-30 motif
+PF05187	ETF_QO	Electron transfer flavoprotein-ubiquinone oxidoreductase, 4Fe-4S
+PF05188	MutS_II	MutS domain II
+PF05189	RTC_insert	RNA 3'-terminal phosphate cyclase (RTC), insert domain
+PF05190	MutS_IV	MutS family domain IV
+PF05191	ADK_lid	Adenylate kinase, active site lid
+PF05192	MutS_III	MutS domain III
+PF05193	Peptidase_M16_C	Peptidase M16 inactive domain
+PF05194	UreE_C	UreE urease accessory protein, C-terminal domain
+PF05195	AMP_N	Aminopeptidase P, N-terminal domain
+PF05196	PTN_MK_N	PTN/MK heparin-binding protein family, N-terminal domain
+PF05197	TRIC	TRIC channel
+PF05198	IF3_N	Translation initiation factor IF-3, N-terminal domain
+PF05199	GMC_oxred_C	GMC oxidoreductase
+PF05201	GlutR_N	Glutamyl-tRNAGlu reductase, N-terminal domain
+PF05202	Flp_C	Recombinase Flp protein
+PF05203	Hom_end_hint	Hom_end-associated Hint
+PF05204	Hom_end	Homing endonuclease
+PF05205	COMPASS-Shg1	COMPASS (Complex proteins associated with Set1p) component shg1
+PF05206	TRM13	Methyltransferase TRM13
+PF05207	zf-CSL	CSL zinc finger
+PF05208	ALG3	ALG3 protein
+PF05209	MinC_N	Septum formation inhibitor MinC, N-terminal domain
+PF05210	Sprouty	Sprouty protein (Spry)
+PF05211	NLBH	Neuraminyllactose-binding hemagglutinin precursor (NLBH)
+PF05212	DUF707	Protein of unknown function (DUF707)
+PF05213	Corona_NS2A	Coronavirus NS2A protein
+PF05214	Baculo_p33	Baculovirus P33
+PF05215	Spiralin	Spiralin
+PF05216	UNC-50	UNC-50 family
+PF05217	STOP	STOP protein
+PF05218	DUF713	Protein of unknown function (DUF713)
+PF05219	DREV	DREV methyltransferase
+PF05220	MgpC	MgpC protein precursor
+PF05221	AdoHcyase	S-adenosyl-L-homocysteine hydrolase
+PF05222	AlaDh_PNT_N	Alanine dehydrogenase/PNT, N-terminal domain
+PF05223	MecA_N	NTF2-like N-terminal transpeptidase domain
+PF05224	NDT80_PhoG	NDT80 / PhoG like DNA-binding  family
+PF05225	HTH_psq	helix-turn-helix, Psq domain
+PF05226	CHASE2	CHASE2 domain
+PF05227	CHASE3	CHASE3 domain
+PF05228	CHASE4	CHASE4 domain
+PF05229	SCPU	Spore Coat Protein U domain
+PF05230	MASE2	MASE2 domain
+PF05231	MASE1	MASE1
+PF05232	BTP	Chlorhexidine efflux transporter
+PF05233	PHB_acc	PHB accumulation regulatory domain
+PF05234	UAF_Rrn10	UAF complex subunit Rrn10
+PF05235	CHAD	CHAD domain
+PF05236	TAF4	Transcription initiation factor TFIID component TAF4 family
+PF05238	CENP-N	Kinetochore protein CHL4 like
+PF05239	PRC	PRC-barrel domain
+PF05240	APOBEC_C	APOBEC-like C-terminal domain
+PF05241	EBP	Emopamil binding protein 
+PF05242	GLYCAM-1	Glycosylation-dependent cell adhesion molecule 1 (GlyCAM-1)
+PF05244	Brucella_OMP2	Brucella outer membrane protein 2
+PF05246	DUF735	Protein of unknown function (DUF735)
+PF05247	FlhD	Flagellar transcriptional activator (FlhD)
+PF05248	Adeno_E3A	Adenovirus E3A
+PF05250	UPF0193	Uncharacterised protein family (UPF0193)
+PF05251	Ost5	Oligosaccharyltransferase subunit 5
+PF05253	zf-U11-48K	U11-48K-like CHHC zinc finger
+PF05254	UPF0203	Uncharacterised protein family (UPF0203)
+PF05255	UPF0220	Uncharacterised protein family (UPF0220)
+PF05256	UPF0223	Uncharacterised protein family (UPF0223)
+PF05257	CHAP	CHAP domain
+PF05258	DUF721	Protein of unknown function (DUF721)
+PF05259	Herpes_UL1	Herpesvirus glycoprotein L
+PF05261	Tra_M	TraM protein, DNA-binding
+PF05262	Borrelia_P83	Borrelia P83/100 protein
+PF05263	DUF722	Protein of unknown function (DUF722)
+PF05264	CfAFP	Choristoneura fumiferana antifreeze protein (CfAFP)
+PF05265	DUF723	Protein of unknown function (DUF723)
+PF05266	DUF724	Protein of unknown function (DUF724)
+PF05267	DUF725	Protein of unknown function (DUF725)
+PF05268	GP38	Phage tail fibre adhesin Gp38
+PF05269	Phage_CII	Bacteriophage CII protein
+PF05270	AbfB	Alpha-L-arabinofuranosidase B (ABFB) domain
+PF05271	Tobravirus_2B	Tobravirus 2B protein
+PF05272	VirE	Virulence-associated protein E
+PF05273	Pox_RNA_Pol_22	Poxvirus RNA polymerase 22 kDa subunit
+PF05274	Baculo_E25	Occlusion-derived virus envelope protein E25
+PF05275	CopB	Copper resistance protein B precursor (CopB)
+PF05276	SH3BP5	SH3 domain-binding protein 5 (SH3BP5)
+PF05277	DUF726	Protein of unknown function (DUF726)
+PF05278	PEARLI-4	Arabidopsis phospholipase-like protein (PEARLI 4)
+PF05279	Asp-B-Hydro_N	Aspartyl beta-hydroxylase N-terminal region
+PF05280	FlhC	Flagellar transcriptional activator (FlhC)
+PF05281	Secretogranin_V	Neuroendocrine protein 7B2 precursor (Secretogranin V)
+PF05282	AAR2	AAR2 protein
+PF05283	MGC-24	Multi-glycosylated core protein 24 (MGC-24), sialomucin
+PF05284	DUF736	Protein of unknown function (DUF736)
+PF05285	SDA1	SDA1
+PF05287	PMG	PMG protein
+PF05288	Pox_A3L	Poxvirus A3L Protein
+PF05289	BLYB	Borrelia hemolysin accessory protein
+PF05290	Baculo_IE-1	Baculovirus immediate-early protein (IE-0)
+PF05291	Bystin	Bystin
+PF05292	MCD	Malonyl-CoA decarboxylase C-terminal domain
+PF05293	ASFV_L11L	African swine fever virus (ASFV) L11L protein
+PF05294	Toxin_5	Scorpion short toxin
+PF05295	Luciferase_N	Luciferase/LBP N-terminal domain
+PF05296	TAS2R	Taste receptor protein (TAS2R)
+PF05297	Herpes_LMP1	Herpesvirus latent membrane protein 1 (LMP1)
+PF05298	Bombinin	Bombinin
+PF05299	Peptidase_M61	M61 glycyl aminopeptidase
+PF05300	DUF737	Protein of unknown function (DUF737)
+PF05301	Acetyltransf_16	GNAT acetyltransferase, Mec-17 
+PF05302	DUF720	Protein of unknown function (DUF720)
+PF05303	DUF727	Protein of unknown function (DUF727)
+PF05304	DUF728	Protein of unknown function (DUF728)
+PF05305	DUF732	Protein of unknown function (DUF732)
+PF05306	DUF733	Protein of unknown function (DUF733)
+PF05307	Bundlin	Bundlin
+PF05308	Mito_fiss_reg	Mitochondrial fission regulator
+PF05309	TraE	TraE protein
+PF05310	Tenui_NS3	Tenuivirus movement protein
+PF05311	Baculo_PP31	Baculovirus 33KDa late protein (PP31)
+PF05313	Pox_P21	Poxvirus P21 membrane protein
+PF05314	Baculo_ODV-E27	Baculovirus occlusion-derived virus envelope protein EC27
+PF05315	ICEA	ICEA Protein
+PF05316	VAR1	Mitochondrial ribosomal protein (VAR1)
+PF05317	Thermopsin	Thermopsin
+PF05318	Tombus_movement	Tombusvirus movement protein
+PF05320	Pox_RNA_Pol_19	Poxvirus DNA-directed RNA polymerase 19 kDa subunit
+PF05321	HHA	Haemolysin expression modulating protein
+PF05322	NinE	NINE Protein
+PF05323	Pox_A21	Poxvirus A21 Protein
+PF05324	Sperm_Ag_HE2	Sperm antigen HE2
+PF05325	DUF730	Protein of unknown function (DUF730)
+PF05326	SVA	Seminal vesicle autoantigen (SVA)
+PF05327	RRN3	RNA polymerase I specific transcription initiation factor RRN3
+PF05328	CybS	CybS, succinate dehydrogenase cytochrome B small subunit
+PF05331	DUF742	Protein of unknown function (DUF742)
+PF05332	DUF743	Protein of unknown function (DUF743)
+PF05334	DUF719	Protein of unknown function (DUF719)
+PF05335	DUF745	Protein of unknown function (DUF745)
+PF05336	rhaM	L-rhamnose mutarotase
+PF05337	CSF-1	Macrophage colony stimulating factor-1 (CSF-1)
+PF05338	DUF717	Protein of unknown function (DUF717)
+PF05339	DUF739	Protein of unknown function (DUF739)
+PF05340	DUF740	Protein of unknown function (DUF740)
+PF05341	PIF6	Per os infectivity factor 6
+PF05342	Peptidase_M26_N	M26 IgA1-specific Metallo-endopeptidase N-terminal region
+PF05343	Peptidase_M42	M42 glutamyl aminopeptidase
+PF05344	DUF746	Domain of Unknown Function (DUF746)
+PF05345	He_PIG	Putative Ig domain
+PF05346	DUF747	Eukaryotic membrane protein family
+PF05347	Complex1_LYR	Complex 1 protein (LYR family)
+PF05348	UMP1	Proteasome maturation factor UMP1
+PF05349	GATA-N	GATA-type transcription activator, N-terminal 
+PF05350	GSK-3_bind	Glycogen synthase kinase-3 binding
+PF05351	GMP_PDE_delta	GMP-PDE, delta subunit
+PF05352	Phage_connector	Phage Connector (GP10)
+PF05353	Atracotoxin	Delta Atracotoxin
+PF05354	Phage_attach	Phage Head-Tail Attachment
+PF05355	Apo-CII	Apolipoprotein C-II
+PF05356	Phage_Coat_B	Phage Coat protein B 
+PF05357	Phage_Coat_A	Phage Coat Protein A
+PF05358	DicB	DicB protein
+PF05359	DUF748	Domain of Unknown Function (DUF748)
+PF05360	YiaAB	yiaA/B two helix domain
+PF05361	PP1_inhibitor	PKC-activated protein phosphatase-1 inhibitor
+PF05362	Lon_C	Lon protease (S16) C-terminal proteolytic domain
+PF05363	Herpes_US12	Herpesvirus US12 family
+PF05364	SecIII_SopE_N	Salmonella type III secretion SopE effector N-terminus
+PF05365	UCR_UQCRX_QCR9	Ubiquinol-cytochrome C reductase, UQCRX/QCR9 like
+PF05366	Sarcolipin	Sarcolipin
+PF05367	Phage_endo_I	Phage endonuclease I
+PF05368	NmrA	NmrA-like family
+PF05369	MtmB	Monomethylamine methyltransferase MtmB
+PF05370	DUF749	Domain of unknown function (DUF749)
+PF05371	Phage_Coat_Gp8	Phage major coat protein, Gp8
+PF05372	Delta_lysin	Delta lysin family
+PF05373	Pro_3_hydrox_C	L-proline 3-hydroxylase, C-terminal
+PF05374	Mu-conotoxin	Mu-Conotoxin
+PF05375	Pacifastin_I	Pacifastin inhibitor (LCMII)
+PF05377	FlaC_arch	Flagella accessory protein C (FlaC)
+PF05378	Hydant_A_N	Hydantoinase/oxoprolinase N-terminal region
+PF05379	Peptidase_C23	Carlavirus endopeptidase 
+PF05380	Peptidase_A17	Pao retrotransposon peptidase 
+PF05381	Peptidase_C21	Tymovirus endopeptidase
+PF05382	Amidase_5	Bacteriophage peptidoglycan hydrolase 
+PF05383	La	La domain
+PF05384	DegS	Sensor protein DegS
+PF05385	Adeno_E4	Mastadenovirus early E4 13 kDa protein
+PF05386	TEP1_N	TEP1 N-terminal domain
+PF05387	Chorion_3	Chorion family 3
+PF05388	Carbpep_Y_N	Carboxypeptidase Y pro-peptide
+PF05389	MecA	Negative regulator of genetic competence (MecA)
+PF05390	KRE9	Yeast cell wall synthesis protein KRE9/KNH1
+PF05391	Lsm_interact	Lsm interaction motif
+PF05392	COX7B	Cytochrome C oxidase chain VIIB
+PF05393	Hum_adeno_E3A	Human adenovirus early E3A glycoprotein
+PF05394	AvrB_AvrC	Avirulence protein
+PF05395	DARPP-32	Protein phosphatase inhibitor 1/DARPP-32
+PF05396	Phage_T7_Capsid	Phage T7 capsid assembly protein
+PF05397	Med15_fungi	Mediator complex subunit 15
+PF05398	PufQ	PufQ cytochrome subunit
+PF05399	EVI2A	Ectropic viral integration site 2A protein (EVI2A)
+PF05400	FliT	Flagellar protein FliT
+PF05401	NodS	Nodulation protein S (NodS)
+PF05402	PqqD	Coenzyme PQQ synthesis protein D (PqqD)
+PF05403	Plasmodium_HRP	Plasmodium histidine-rich protein (HRPII/III)
+PF05404	TRAP-delta	Translocon-associated protein, delta subunit precursor (TRAP-delta)
+PF05405	Mt_ATP-synt_B	Mitochondrial ATP synthase B chain precursor (ATP-synt_B)
+PF05406	WGR	WGR domain
+PF05407	Peptidase_C27	Rubella virus endopeptidase
+PF05408	Peptidase_C28	Foot-and-mouth virus L-proteinase
+PF05409	Peptidase_C30	Coronavirus  endopeptidase C30
+PF05410	Peptidase_C31	Porcine arterivirus-type cysteine proteinase alpha
+PF05411	Peptidase_C32	Equine arteritis virus putative proteinase
+PF05412	Peptidase_C33	Equine arterivirus Nsp2-type cysteine proteinase
+PF05413	Peptidase_C34	Putative closterovirus papain-like endopeptidase
+PF05414	DUF1717	Viral domain of unknown function (DUF1717)
+PF05415	Peptidase_C36	Beet necrotic yellow vein furovirus-type papain-like endopeptidase
+PF05416	Peptidase_C37	Southampton virus-type processing peptidase
+PF05417	Peptidase_C41	Hepatitis E cysteine protease
+PF05418	Apo-VLDL-II	Apovitellenin I (Apo-VLDL-II)
+PF05419	GUN4	GUN4-like 
+PF05420	BCSC_C	Cellulose synthase operon protein C C-terminus (BCSC_C)
+PF05421	DUF751	Protein of unknown function (DUF751)
+PF05422	SIN1	Stress-activated map kinase interacting protein 1 (SIN1)
+PF05423	Mycobact_memb	Mycobacterium membrane protein
+PF05424	Duffy_binding	Duffy binding domain
+PF05425	CopD	Copper resistance protein D
+PF05426	Alginate_lyase	Alginate lyase
+PF05427	FIBP	Acidic fibroblast growth factor binding (FIBP) 
+PF05428	CRF-BP	Corticotropin-releasing factor binding protein (CRF-BP)
+PF05430	Methyltransf_30	S-adenosyl-L-methionine-dependent methyltransferase
+PF05431	Toxin_10	Insecticidal Crystal Toxin, P42 
+PF05432	BSP_II	Bone sialoprotein II (BSP-II)
+PF05433	Rick_17kDa_Anti	Glycine zipper 2TM domain
+PF05434	Tmemb_9	TMEM9
+PF05435	Phi-29_GP3	Phi-29 DNA terminal protein GP3
+PF05436	MF_alpha_N	Mating factor alpha precursor N-terminus
+PF05437	AzlD	Branched-chain amino acid transport protein (AzlD)
+PF05438	TRH	Thyrotropin-releasing hormone (TRH)
+PF05439	JTB	Jumping translocation breakpoint protein (JTB)
+PF05440	MtrB	Tetrahydromethanopterin S-methyltransferase subunit B
+PF05443	ROS_MUCR	ROS/MUCR transcriptional regulator protein
+PF05444	DUF753	Protein of unknown function (DUF753)
+PF05445	Pox_ser-thr_kin	Poxvirus serine/threonine protein kinase
+PF05448	AXE1	Acetyl xylan esterase (AXE1)
+PF05449	Phage_holin_3_7	Putative 3TM holin, Phage_holin_3
+PF05450	Nicastrin	Nicastrin
+PF05451	Phytoreo_Pns	Phytoreovirus nonstructural protein Pns10/11
+PF05452	Clavanin	Clavanin
+PF05453	Toxin_6	BmTXKS1/BmP02 toxin family
+PF05454	DAG1	Dystroglycan (Dystrophin-associated glycoprotein 1)
+PF05455	GvpH	GvpH
+PF05456	eIF_4EBP	Eukaryotic translation initiation factor 4E binding protein (EIF4EBP)
+PF05458	Siva	Cd27 binding protein (Siva)
+PF05459	Herpes_UL69	Herpesvirus transcriptional regulator family
+PF05460	ORC6	Origin recognition complex subunit 6 (ORC6)
+PF05461	ApoL	Apolipoprotein L
+PF05462	Dicty_CAR	Slime mold cyclic AMP receptor
+PF05463	Sclerostin	Sclerostin (SOST)
+PF05464	Phi-29_GP4	Phi-29-like late genes activator (early protein GP4)
+PF05465	Halo_GVPC	Halobacterial gas vesicle protein C (GVPC) repeat
+PF05466	BASP1	Brain acid soluble protein 1 (BASP1 protein)
+PF05467	Herpes_U47	Herpesvirus glycoprotein U47
+PF05470	eIF-3c_N	Eukaryotic translation initiation factor 3 subunit 8 N-terminus
+PF05472	Ter	DNA replication terminus site-binding protein (Ter protein)
+PF05473	UL45	UL45 protein, carbohydrate-binding C-type lectin-like
+PF05474	Semenogelin	Semenogelin
+PF05475	Chlam_vir	Pgp3 C-terminal domain
+PF05476	PET122	PET122
+PF05477	SURF2	Surfeit locus protein 2 (SURF2)
+PF05478	Prominin	Prominin
+PF05479	PsaN	Photosystem I reaction centre subunit N (PSAN or PSI-N)
+PF05480	Staph_haemo	Staphylococcus haemolytic protein
+PF05481	Myco_19_kDa	Mycobacterium 19 kDa lipoprotein antigen
+PF05482	Serendipity_A	Serendipity locus alpha protein (SRY-A)
+PF05483	SCP-1	Synaptonemal complex protein 1 (SCP-1)
+PF05484	LRV_FeS	LRV protein FeS4 cluster
+PF05485	THAP	THAP domain
+PF05486	SRP9-21	Signal recognition particle 9 kDa protein (SRP9)
+PF05488	PAAR_motif	PAAR motif
+PF05489	Phage_tail_X	Phage Tail Protein X
+PF05491	RuvB_C	Holliday junction DNA helicase ruvB C-terminus
+PF05493	ATP_synt_H	ATP synthase subunit H 
+PF05494	MlaC	MlaC protein
+PF05495	zf-CHY	CHY zinc finger
+PF05496	RuvB_N	Holliday junction DNA helicase ruvB N-terminus
+PF05497	Destabilase	Destabilase
+PF05498	RALF	Rapid ALkalinization Factor (RALF) 
+PF05499	DMAP1	DNA methyltransferase 1-associated protein 1 (DMAP1)
+PF05501	DUF755	Domain of unknown function (DUF755) 
+PF05502	Dynactin_p62	Dynactin p62 family
+PF05503	Pox_G7	Poxvirus G7-like 
+PF05504	Spore_GerAC	Spore germination B3/ GerAC like, C-terminal 
+PF05505	Ebola_NP	Ebola nucleoprotein
+PF05506	DUF756	Domain of unknown function (DUF756)
+PF05507	MAGP	Microfibril-associated glycoprotein (MAGP)
+PF05508	Ran-binding	RanGTP-binding protein
+PF05509	TraY	TraY domain
+PF05510	Sarcoglycan_2	Sarcoglycan alpha/epsilon
+PF05511	ATP-synt_F6	Mitochondrial ATP synthase coupling factor 6
+PF05512	AWPM-19	AWPM-19-like family
+PF05513	TraA	TraA
+PF05514	HR_lesion	HR-like lesion-inducing 
+PF05515	Viral_NABP	Viral nucleic acid binding 
+PF05517	p25-alpha	p25-alpha 
+PF05518	Totivirus_coat	Totivirus coat protein
+PF05520	Citrus_P18	Citrus tristeza virus P18 protein
+PF05521	Phage_H_T_join	Phage head-tail joining protein 
+PF05522	Metallothio_6	Metallothionein
+PF05523	FdtA	WxcM-like, C-terminal 
+PF05524	PEP-utilisers_N	PEP-utilising enzyme, N-terminal
+PF05525	Branch_AA_trans	Branched-chain amino acid transport protein
+PF05526	R_equi_Vir	Rhodococcus equi virulence-associated protein
+PF05527	DUF758	Domain of unknown function (DUF758) 
+PF05528	Coronavirus_5	Coronavirus gene 5 protein
+PF05529	Bap31	B-cell receptor-associated protein 31-like 
+PF05531	NPV_P10	Nucleopolyhedrovirus P10 protein
+PF05532	CsbD	CsbD-like
+PF05533	Peptidase_C42	Beet yellows virus-type papain-like endopeptidase C42
+PF05534	HicB	HicB family
+PF05535	Chromadorea_ALT	Chromadorea ALT protein
+PF05536	Neurochondrin	Neurochondrin
+PF05537	DUF759	Borrelia burgdorferi protein of unknown function (DUF759)
+PF05538	Campylo_MOMP	Campylobacter major outer membrane protein
+PF05539	Pneumo_att_G	Pneumovirinae attachment membrane glycoprotein G
+PF05540	Serpulina_VSP	Serpulina hyodysenteriae variable surface protein
+PF05541	Spheroidin	Entomopoxvirus spheroidin protein
+PF05542	DUF760	Protein of unknown function (DUF760)
+PF05543	Peptidase_C47	Staphopain peptidase C47
+PF05544	Pro_racemase	Proline racemase
+PF05545	FixQ	Cbb3-type cytochrome oxidase component FixQ
+PF05546	She9_MDM33	She9 / Mdm33 family
+PF05547	Peptidase_M6	Immune inhibitor A peptidase M6
+PF05548	Peptidase_M11	Gametolysin peptidase M11
+PF05549	Allexi_40kDa	Allexivirus 40kDa protein
+PF05550	Peptidase_C53	Pestivirus Npro endopeptidase C53
+PF05551	zf-His_Me_endon	Zinc-binding loop region of homing endonuclease
+PF05552	TM_helix	Conserved TM helix
+PF05553	DUF761	Cotton fibre expressed protein
+PF05554	Novirhabdo_Nv	Viral hemorrhagic septicemia virus non-virion protein
+PF05555	DUF762	Coxiella burnetii protein of unknown function (DUF762)
+PF05556	Calsarcin	Calcineurin-binding protein (Calsarcin)
+PF05557	MAD	Mitotic checkpoint protein
+PF05558	DREPP	DREPP plasma membrane polypeptide
+PF05559	DUF763	Protein of unknown function (DUF763)
+PF05560	Bt_P21	Bacillus thuringiensis P21 molecular chaperone protein
+PF05561	DUF764	Borrelia burgdorferi protein of unknown function (DUF764)
+PF05562	WCOR413	Cold acclimation protein WCOR413
+PF05563	SpvD	Salmonella plasmid virulence protein SpvD
+PF05564	Auxin_repressed	Dormancy/auxin associated protein
+PF05565	Sipho_Gp157	Siphovirus Gp157
+PF05566	Pox_vIL-18BP	Orthopoxvirus interleukin 18 binding protein
+PF05567	Neisseria_PilC	Neisseria PilC beta-propeller domain
+PF05568	ASFV_J13L	African swine fever virus J13L protein
+PF05569	Peptidase_M56	BlaR1 peptidase M56
+PF05570	DUF765	Circovirus protein of unknown function (DUF765)
+PF05571	DUF766	Protein of unknown function (DUF766)
+PF05572	Peptidase_M43	Pregnancy-associated plasma protein-A
+PF05573	NosL	NosL
+PF05575	V_cholerae_RfbT	Vibrio cholerae RfbT protein
+PF05576	Peptidase_S37	PS-10 peptidase S37
+PF05577	Peptidase_S28	Serine carboxypeptidase S28
+PF05578	Peptidase_S31	Pestivirus NS3 polyprotein peptidase S31
+PF05579	Peptidase_S32	Equine arteritis virus serine endopeptidase S32
+PF05580	Peptidase_S55	SpoIVB peptidase S55
+PF05582	Peptidase_U57	YabG peptidase U57
+PF05584	Sulfolobus_pRN	Sulfolobus plasmid regulatory protein
+PF05585	DUF1758	Putative peptidase (DUF1758)
+PF05586	Ant_C	Anthrax receptor C-terminus region
+PF05587	Anth_Ig	Anthrax receptor extracellular domain
+PF05588	Botulinum_HA-17	Clostridium botulinum HA-17 domain
+PF05589	DUF768	Protein of unknown function (DUF768)
+PF05590	DUF769	Xylella fastidiosa protein of unknown function (DUF769)
+PF05591	T6SS_VipA	Type VI secretion system, VipA, VC_A0107 or Hcp2
+PF05592	Bac_rhamnosid	Bacterial alpha-L-rhamnosidase concanavalin-like domain
+PF05593	RHS_repeat	RHS Repeat
+PF05594	Fil_haemagg	Haemagluttinin repeat
+PF05595	DUF771	Domain of unknown function (DUF771) 
+PF05596	Taeniidae_ag	Taeniidae antigen
+PF05597	Phasin	Poly(hydroxyalcanoate) granule associated protein (phasin)
+PF05598	DUF772	Transposase domain (DUF772)
+PF05599	Deltaretro_Tax	Deltaretrovirus Tax protein
+PF05600	DUF773	Protein of unknown function (DUF773)
+PF05602	CLPTM1	Cleft lip and palate transmembrane protein 1 (CLPTM1)
+PF05603	DUF775	Protein of unknown function (DUF775)
+PF05604	DUF776	Protein of unknown function (DUF776)
+PF05605	zf-Di19	Drought induced 19 protein (Di19), zinc-binding
+PF05606	DUF777	Borrelia burgdorferi protein of unknown function (DUF777)
+PF05608	DUF778	Protein of unknown function (DUF778)
+PF05609	LAP1C	Lamina-associated polypeptide 1C (LAP1C)
+PF05610	DUF779	Protein of unknown function (DUF779)
+PF05611	DUF780	Caenorhabditis elegans protein of unknown function (DUF780)
+PF05612	Leg1	Leg1
+PF05613	Herpes_U15	Human herpesvirus U15 protein
+PF05614	DUF782	Circovirus protein of unknown function (DUF782)
+PF05615	THOC7	Tho complex subunit 7
+PF05616	Neisseria_TspB	Neisseria meningitidis TspB protein
+PF05617	Prolamin_like	Prolamin-like
+PF05618	Zn_protease	Putative ATP-dependant zinc protease
+PF05619	DUF787	Borrelia burgdorferi protein of unknown function (DUF787)
+PF05620	DUF788	Protein of unknown function (DUF788)
+PF05621	TniB	Bacterial TniB protein
+PF05622	HOOK	HOOK protein
+PF05623	DUF789	Protein of unknown function (DUF789)
+PF05624	LSR	Lipolysis stimulated receptor (LSR)
+PF05625	PAXNEB	PAXNEB protein
+PF05626	DUF790	Protein of unknown function (DUF790)
+PF05627	AvrRpt-cleavage	Cleavage site for pathogenic type III effector avirulence factor Avr
+PF05628	Borrelia_P13	Borrelia membrane protein P13
+PF05629	Nanovirus_C8	Nanovirus component 8 (C8) protein
+PF05630	NPP1	Necrosis inducing protein (NPP1)
+PF05631	MFS_5	Sugar-tranasporters, 12 TM
+PF05632	DUF792	Borrelia burgdorferi protein of unknown function (DUF792)
+PF05633	BPS1	Protein BYPASS1-related
+PF05634	APO_RNA-bind	APO RNA-binding
+PF05635	23S_rRNA_IVP	23S rRNA-intervening sequence protein
+PF05636	HIGH_NTase1	HIGH Nucleotidyl Transferase
+PF05637	Glyco_transf_34	galactosyl transferase GMA12/MNN10 family
+PF05638	T6SS_HCP	Type VI secretion system effector, Hcp
+PF05639	Pup	Pup-like protein
+PF05640	NKAIN	Na,K-Atpase Interacting protein
+PF05641	Agenet	Agenet domain
+PF05642	Sporozoite_P67	Sporozoite P67 surface antigen
+PF05643	DUF799	Putative bacterial lipoprotein (DUF799)
+PF05644	Miff	Mitochondrial and peroxisomal fission factor Mff
+PF05645	RNA_pol_Rpc82	RNA polymerase III subunit RPC82
+PF05647	Epiglycanin_TR	Tandem-repeating region of mucin, epiglycanin-like
+PF05648	PEX11	Peroxisomal biogenesis factor 11 (PEX11)
+PF05649	Peptidase_M13_N	Peptidase family M13
+PF05650	DUF802	Domain of unknown function (DUF802)
+PF05651	Diacid_rec	Putative sugar diacid recognition
+PF05652	DcpS	Scavenger mRNA decapping enzyme (DcpS) N-terminal
+PF05653	Mg_trans_NIPA	Magnesium transporter NIPA
+PF05655	AvrD	Pseudomonas avirulence D protein (AvrD)
+PF05656	DUF805	Protein of unknown function (DUF805)
+PF05657	DUF806	Protein of unknown function (DUF806)
+PF05658	YadA_head	Head domain of trimeric autotransporter adhesin
+PF05659	RPW8	Arabidopsis broad-spectrum mildew resistance protein RPW8
+PF05660	DUF807	Coxiella burnetii protein of unknown function (DUF807)
+PF05661	DUF808	Protein of unknown function (DUF808)
+PF05662	YadA_stalk	Coiled stalk of trimeric autotransporter adhesin
+PF05663	DUF809	Protein of unknown function (DUF809)
+PF05664	DUF810	Plant family of unknown function (DUF810)
+PF05666	Fels1	Fels-1 Prophage Protein-like
+PF05667	DUF812	Protein of unknown function (DUF812)
+PF05669	Med31	SOH1
+PF05670	DUF814	Domain of unknown function (DUF814)
+PF05671	GETHR	GETHR pentapeptide repeat (5 copies)
+PF05672	MAP7	MAP7 (E-MAP-115) family
+PF05673	DUF815	Protein of unknown function (DUF815)
+PF05674	DUF816	Baculovirus protein of unknown function (DUF816)
+PF05675	DUF817	Protein of unknown function (DUF817)
+PF05676	NDUF_B7	NADH-ubiquinone oxidoreductase B18 subunit (NDUFB7)
+PF05677	DUF818	Chlamydia CHLPS protein (DUF818)
+PF05678	VQ	VQ motif
+PF05679	CHGN	Chondroitin N-acetylgalactosaminyltransferase
+PF05680	ATP-synt_E	ATP synthase E chain
+PF05681	Fumerase	Fumarate hydratase (Fumerase)
+PF05683	Fumerase_C	Fumarase C-terminus
+PF05684	DUF819	Protein of unknown function (DUF819)
+PF05685	Uma2	Putative restriction endonuclease
+PF05686	Glyco_transf_90	Glycosyl transferase family 90
+PF05687	BES1_N	BES1/BZR1 plant transcription factor, N-terminal
+PF05688	DUF824	Salmonella repeat of unknown function (DUF824)
+PF05689	DUF823	Salmonella repeat of unknown function (DUF823)
+PF05690	ThiG	Thiazole biosynthesis protein ThiG
+PF05691	Raffinose_syn	Raffinose synthase or seed imbibition protein Sip1
+PF05692	Myco_haema	Mycoplasma haemagglutinin
+PF05693	Glycogen_syn	Glycogen synthase
+PF05694	SBP56	56kDa selenium binding protein (SBP56)
+PF05695	DUF825	Plant protein of unknown function (DUF825)
+PF05696	DUF826	Protein of unknown function (DUF826)
+PF05697	Trigger_N	Bacterial trigger factor protein (TF)
+PF05698	Trigger_C	Bacterial trigger factor protein (TF) C-terminus
+PF05699	Dimer_Tnp_hAT	hAT family C-terminal dimerisation region
+PF05700	BCAS2	Breast carcinoma amplified sequence 2 (BCAS2)
+PF05701	WEMBL	Weak chloroplast movement under blue light
+PF05702	Herpes_UL49_5	Herpesvirus UL49.5 envelope/tegument protein
+PF05703	Auxin_canalis	Auxin canalisation
+PF05704	Caps_synth	Capsular polysaccharide synthesis protein
+PF05705	DUF829	Eukaryotic protein of unknown function (DUF829)
+PF05706	CDKN3	Cyclin-dependent kinase inhibitor 3 (CDKN3)
+PF05707	Zot	Zonular occludens toxin (Zot)
+PF05708	Peptidase_C92	Permuted papain-like amidase enzyme, YaeF/YiiX, C92 family
+PF05709	Sipho_tail	Phage tail protein
+PF05710	Coiled	Coiled coil
+PF05711	TylF	Macrocin-O-methyltransferase (TylF)
+PF05712	MRG	MRG
+PF05713	MobC	Bacterial mobilisation protein (MobC)
+PF05714	Borrelia_lipo_1	Borrelia burgdorferi virulent strain associated lipoprotein
+PF05715	zf-piccolo	Piccolo Zn-finger
+PF05716	AKAP_110	A-kinase anchor protein 110 kDa (AKAP 110)
+PF05717	TnpB_IS66	IS66 Orf2 like protein
+PF05718	Pox_int_trans	Poxvirus intermediate transcription factor
+PF05719	GPP34	Golgi phosphoprotein 3 (GPP34)
+PF05720	Dicty_CAD	Cell-cell adhesion domain
+PF05721	PhyH	Phytanoyl-CoA dioxygenase (PhyH)
+PF05722	Ustilago_mating	Ustilago B locus mating-type protein
+PF05724	TPMT	Thiopurine S-methyltransferase (TPMT)
+PF05725	FNIP	FNIP Repeat
+PF05726	Pirin_C	Pirin C-terminal cupin domain
+PF05727	UPF0228	Uncharacterised protein family (UPF0228)
+PF05728	UPF0227	Uncharacterised protein family (UPF0227)
+PF05729	NACHT	NACHT domain
+PF05730	CFEM	CFEM domain
+PF05731	TROVE	TROVE domain
+PF05732	RepL	Firmicute plasmid replication protein (RepL)
+PF05733	Tenui_N	Tenuivirus/Phlebovirus nucleocapsid protein
+PF05734	DUF832	Herpesvirus protein of unknown function (DUF832)
+PF05735	TSP_C	Thrombospondin C-terminal region
+PF05736	OprF	OprF membrane domain
+PF05737	Collagen_bind	Collagen binding domain
+PF05738	Cna_B	Cna protein B-type domain
+PF05739	SNARE	SNARE domain
+PF05741	zf-nanos	Nanos RNA binding domain
+PF05742	TANGO2	Transport and Golgi organisation 2
+PF05743	UEV	UEV domain
+PF05744	Benyvirus_P25	Benyvirus P25/P26 protein
+PF05745	CRPA	Chlamydia 15 kDa cysteine-rich outer membrane protein (CRPA)
+PF05746	DALR_1	DALR anticodon binding domain
+PF05748	Rubella_E1	Rubella membrane glycoprotein E1
+PF05749	Rubella_E2	Rubella membrane glycoprotein E2
+PF05750	Rubella_Capsid	Rubella capsid protein
+PF05751	FixH	FixH
+PF05752	Calici_MSP	Calicivirus minor structural protein
+PF05753	TRAP_beta	Translocon-associated protein beta (TRAPB)
+PF05754	DUF834	Domain of unknown function (DUF834)
+PF05755	REF	Rubber elongation factor protein (REF)
+PF05756	S-antigen	S-antigen protein
+PF05757	PsbQ	Oxygen evolving enhancer protein 3 (PsbQ)
+PF05758	Ycf1	Ycf1
+PF05760	IER	Immediate early response protein (IER)
+PF05761	5_nucleotid	5' nucleotidase family
+PF05762	VWA_CoxE	VWA domain containing CoxE-like protein
+PF05763	DUF835	Protein of unknown function (DUF835)
+PF05764	YL1	YL1 nuclear protein
+PF05766	NinG	Bacteriophage Lambda NinG protein
+PF05767	Pox_A14	Poxvirus virion envelope protein A14
+PF05768	DUF836	Glutaredoxin-like domain (DUF836)
+PF05769	SIKE	SIKE family
+PF05770	Ins134_P3_kin	Inositol 1, 3, 4-trisphosphate 5/6-kinase
+PF05771	Pox_A31	Poxvirus A31 protein
+PF05772	NinB	NinB protein
+PF05773	RWD	RWD domain
+PF05774	Herpes_heli_pri	Herpesvirus helicase-primase complex component
+PF05775	AfaD	Enterobacteria AfaD invasin protein
+PF05776	Papilloma_E5A	Papillomavirus E5A protein
+PF05777	Acp26Ab	Drosophila accessory gland-specific peptide 26Ab (Acp26Ab)
+PF05778	Apo-CIII	Apolipoprotein CIII (Apo-CIII)
+PF05781	MRVI1	MRVI1 protein
+PF05782	ECM1	Extracellular matrix protein 1 (ECM1)
+PF05783	DLIC	Dynein light intermediate chain (DLIC)
+PF05784	Herpes_UL82_83	Betaherpesvirus UL82/83 protein N terminus
+PF05785	CNF1	Rho-activating domain of cytotoxic necrotizing factor
+PF05786	Cnd2	Condensin complex subunit 2
+PF05787	DUF839	Bacterial protein of unknown function (DUF839)
+PF05788	Orbi_VP1	Orbivirus RNA-dependent RNA polymerase (VP1)
+PF05789	Baculo_VP1054	Baculovirus VP1054 protein
+PF05790	C2-set	Immunoglobulin C2-set domain
+PF05791	Bacillus_HBL	Bacillus haemolytic enterotoxin (HBL)
+PF05792	Candida_ALS	Candida agglutinin-like (ALS)
+PF05793	TFIIF_alpha	Transcription initiation factor IIF, alpha subunit (TFIIF-alpha)
+PF05794	Tcp11	T-complex protein 11
+PF05795	Plasmodium_Vir	Plasmodium vivax Vir protein
+PF05796	Chordopox_G2	Chordopoxvirus protein G2
+PF05797	Rep_4	Yeast trans-acting factor (REP1/REP2)
+PF05798	Phage_FRD3	Bacteriophage FRD3 protein
+PF05800	GvpO	Gas vesicle synthesis protein GvpO
+PF05801	DUF840	Lagovirus protein of unknown function (DUF840)
+PF05802	EspB	Enterobacterial EspB protein
+PF05803	Chordopox_L2	Chordopoxvirus L2 protein
+PF05804	KAP	Kinesin-associated protein (KAP)
+PF05805	L6_membrane	L6 membrane protein
+PF05806	Noggin	Noggin
+PF05808	Podoplanin	Podoplanin
+PF05810	NinF	NinF protein
+PF05811	DUF842	Eukaryotic protein of unknown function (DUF842)
+PF05812	Herpes_BLRF2	Herpesvirus BLRF2 protein
+PF05813	Orthopox_F7	Orthopoxvirus F7 protein
+PF05814	Ac76	Orf76 (Ac76)
+PF05815	DUF844	Baculovirus protein of unknown function (DUF844)
+PF05816	TelA	Toxic anion resistance protein (TelA)
+PF05817	Ribophorin_II	Oligosaccharyltransferase subunit Ribophorin II
+PF05818	TraT	Enterobacterial TraT complement resistance protein
+PF05819	NolX	NolX protein
+PF05820	Ac81	Baculoviridae AC81
+PF05821	NDUF_B8	NADH-ubiquinone oxidoreductase ASHI subunit (CI-ASHI or NDUFB8)
+PF05822	UMPH-1	Pyrimidine 5'-nucleotidase (UMPH-1)
+PF05823	Gp-FAR-1	Nematode fatty acid retinoid binding protein (Gp-FAR-1)
+PF05824	Pro-MCH	Pro-melanin-concentrating hormone (Pro-MCH)
+PF05825	PSP94	Beta-microseminoprotein (PSP-94)
+PF05826	Phospholip_A2_2	Phospholipase A2
+PF05827	ATP-synt_S1	Vacuolar ATP synthase subunit S1 (ATP6S1)
+PF05829	Adeno_PX	Adenovirus late L2 mu core protein (Protein X)
+PF05830	NodZ	Nodulation protein Z (NodZ)
+PF05831	GAGE	GAGE protein
+PF05832	DUF846	Eukaryotic protein of unknown function (DUF846)
+PF05833	FbpA	Fibronectin-binding protein A N-terminus (FbpA)
+PF05834	Lycopene_cycl	Lycopene cyclase protein
+PF05835	Synaphin	Synaphin protein
+PF05836	Chorion_S16	Chorion protein S16
+PF05837	CENP-H	Centromere protein H (CENP-H)
+PF05838	Glyco_hydro_108	Glycosyl hydrolase 108
+PF05839	Apc13p	Apc13p protein
+PF05840	Phage_GPA	Bacteriophage replication gene A protein (GPA)
+PF05841	Apc15p	Apc15p protein
+PF05842	Euplotes_phero	Euplotes octocarinatus mating pheromone protein
+PF05843	Suf	Suppressor of forked protein (Suf)
+PF05844	YopD	YopD protein
+PF05845	PhnH	Bacterial phosphonate metabolism protein (PhnH)
+PF05846	Chordopox_A15	Chordopoxvirus A15 protein
+PF05847	Baculo_LEF-3	Nucleopolyhedrovirus late expression factor 3 (LEF-3)
+PF05848	CtsR	Firmicute transcriptional repressor of class III stress genes (CtsR)
+PF05849	L-fibroin	Fibroin light chain (L-fibroin)
+PF05851	Lentivirus_VIF	Lentivirus virion infectivity factor (VIF)
+PF05852	DUF848	Gammaherpesvirus protein of unknown function (DUF848)
+PF05853	BKACE	beta-keto acid cleavage enzyme
+PF05854	MC1	Non-histone chromosomal protein MC1
+PF05856	ARPC4	ARP2/3 complex 20 kDa subunit (ARPC4)
+PF05857	TraX	TraX protein
+PF05858	BIV_Env	Bovine immunodeficiency virus surface protein (SU)
+PF05859	Mis12	Mis12 protein
+PF05860	Haemagg_act	haemagglutination activity domain
+PF05861	PhnI	Bacterial phosphonate metabolism protein (PhnI)
+PF05862	IceA2	Helicobacter pylori IceA2 protein
+PF05864	Chordopox_RPO7	Chordopoxvirus DNA-directed RNA polymerase 7 kDa polypeptide (RPO7)
+PF05865	Cypo_polyhedrin	Cypovirus polyhedrin protein
+PF05866	RusA	Endodeoxyribonuclease RusA
+PF05867	DUF851	Protein of unknown function (DUF851)
+PF05868	Rotavirus_VP7	Rotavirus major outer capsid protein VP7
+PF05869	Dam	DNA N-6-adenine-methyltransferase (Dam)
+PF05870	PA_decarbox	Phenolic acid decarboxylase (PAD)
+PF05871	ESCRT-II	ESCRT-II complex subunit
+PF05872	DUF853	Bacterial protein of unknown function (DUF853)
+PF05873	Mt_ATP-synt_D	ATP synthase D chain, mitochondrial (ATP5H)
+PF05874	PBAN	Pheromone biosynthesis activating neuropeptide (PBAN)
+PF05875	Ceramidase	Ceramidase
+PF05876	Terminase_GpA	Phage terminase large subunit (GpA)
+PF05878	Phyto_Pns9_10	Phytoreovirus nonstructural protein Pns9/Pns10
+PF05879	RHD3	Root hair defective 3 GTP-binding protein (RHD3)
+PF05880	Fiji_64_capsid	Fijivirus 64 kDa capsid protein
+PF05881	CNPase	2',3'-cyclic nucleotide 3'-phosphodiesterase (CNP or CNPase)
+PF05883	Baculo_RING	Baculovirus U-box/Ring-like domain
+PF05884	ZYG-11_interact	Interactor of ZYG-11
+PF05886	Orthopox_F8	Orthopoxvirus F8 protein
+PF05887	Trypan_PARP	Procyclic acidic repetitive protein (PARP)
+PF05889	SepSecS	O-phosphoseryl-tRNA(Sec) selenium transferase, SepSecS
+PF05890	Ebp2	Eukaryotic rRNA processing protein EBP2
+PF05891	Methyltransf_PK	AdoMet dependent proline di-methyltransferase
+PF05892	Tricho_coat	Trichovirus coat protein
+PF05893	LuxC	Acyl-CoA reductase (LuxC)
+PF05894	Podovirus_Gp16	Podovirus DNA encapsidation protein (Gp16)
+PF05895	DUF859	Siphovirus protein of unknown function (DUF859)
+PF05896	NQRA	Na(+)-translocating NADH-quinone reductase subunit A (NQRA)
+PF05899	Cupin_3	Protein of unknown function (DUF861)
+PF05901	Excalibur	Excalibur calcium-binding domain
+PF05902	4_1_CTD	4.1 protein C-terminal domain (CTD)
+PF05903	Peptidase_C97	PPPDE putative peptidase domain
+PF05904	DUF863	Plant protein of unknown function (DUF863)
+PF05906	DUF865	Herpesvirus-7 repeat of unknown function (DUF865)
+PF05907	DUF866	Eukaryotic protein of unknown function (DUF866)
+PF05908	Gamma_PGA_hydro	Poly-gamma-glutamate hydrolase
+PF05910	DUF868	Plant protein of unknown function (DUF868)
+PF05911	FPP	Filament-like plant protein, long coiled-coil
+PF05912	DUF870	Caenorhabditis elegans protein of unknown function (DUF870)
+PF05913	DUF871	Bacterial protein of unknown function (DUF871)
+PF05914	RIB43A	RIB43A
+PF05915	DUF872	Eukaryotic protein of unknown function (DUF872)
+PF05916	Sld5	GINS complex protein
+PF05917	DUF874	Helicobacter pylori protein of unknown function (DUF874)
+PF05918	API5	Apoptosis inhibitory protein 5 (API5)
+PF05919	Mitovir_RNA_pol	Mitovirus RNA-dependent RNA polymerase
+PF05920	Homeobox_KN	Homeobox KN domain
+PF05922	Inhibitor_I9	Peptidase inhibitor I9
+PF05923	APC_r	APC repeat
+PF05924	SAMP	SAMP Motif
+PF05925	IpgD	Enterobacterial virulence protein IpgD
+PF05926	Phage_GPL	Phage head completion protein (GPL)
+PF05927	Penaeidin	Penaeidin
+PF05928	Zea_mays_MuDR	Zea mays MURB-like protein (MuDR)
+PF05929	Phage_GPO	Phage capsid scaffolding protein (GPO) serine peptidase
+PF05930	Phage_AlpA	Prophage CP4-57 regulatory protein (AlpA)
+PF05931	AgrD	Staphylococcal AgrD protein
+PF05932	CesT	Tir chaperone protein (CesT) family
+PF05933	Fun_ATP-synt_8	Fungal ATP synthase protein 8 (A6L)
+PF05934	MCLC	Mid-1-related chloride channel (MCLC)
+PF05935	Arylsulfotrans	Arylsulfotransferase (ASST)
+PF05936	T6SS_VasE	Bacterial Type VI secretion, VC_A0110, EvfL, ImpJ, VasE 
+PF05937	EB1_binding	EB-1 Binding Domain
+PF05938	Self-incomp_S1	Plant self-incompatibility protein S1
+PF05939	Phage_min_tail	Phage minor tail protein
+PF05940	NnrS	NnrS protein
+PF05941	Chordopox_A20R	Chordopoxvirus A20R protein
+PF05942	PaREP1	Archaeal PaREP1/PaREP8 family
+PF05943	VipB	Type VI secretion protein, EvpB/VC_A0108, tail sheath
+PF05944	Phage_term_smal	Phage small terminase subunit
+PF05946	TcpA	Toxin-coregulated pilus subunit TcpA
+PF05947	T6SS_TssF	Type VI secretion system, TssF
+PF05949	DUF881	Bacterial protein of unknown function (DUF881)
+PF05950	Orthopox_A36R	Orthopoxvirus A36R protein
+PF05951	Peptidase_M15_2	Bacterial protein of unknown function (DUF882)
+PF05952	ComX	Bacillus competence pheromone ComX
+PF05953	Allatostatin	Allatostatin
+PF05954	Phage_GPD	Phage late control gene D protein (GPD)
+PF05955	Herpes_gp2	Equine herpesvirus glycoprotein gp2
+PF05956	APC_basic	APC basic domain
+PF05957	DUF883	Bacterial protein of unknown function (DUF883)
+PF05958	tRNA_U5-meth_tr	tRNA (Uracil-5-)-methyltransferase
+PF05959	DUF884	Nucleopolyhedrovirus protein of unknown function (DUF884)
+PF05960	DUF885	Bacterial protein of unknown function (DUF885)
+PF05961	Chordopox_A13L	Chordopoxvirus A13L protein
+PF05962	HutD	HutD
+PF05963	Cytomega_US3	Cytomegalovirus US3 protein
+PF05964	FYRN	F/Y-rich N-terminus
+PF05965	FYRC	F/Y rich C-terminus
+PF05966	Chordopox_A33R	Chordopoxvirus A33R protein
+PF05968	Bacillus_PapR	Bacillus PapR protein
+PF05969	PSII_Ycf12	Photosystem II complex subunit Ycf12
+PF05970	PIF1	PIF1-like helicase
+PF05971	Methyltransf_10	Protein of unknown function (DUF890)
+PF05972	APC_15aa	APC 15 residue motif
+PF05973	Gp49	Phage derived protein Gp49-like (DUF891)
+PF05974	DUF892	Domain of unknown function (DUF892)
+PF05975	EcsB	Bacterial ABC transporter protein EcsB
+PF05977	MFS_3	Transmembrane secretion effector
+PF05978	UNC-93	Ion channel regulatory protein UNC-93
+PF05979	DUF896	Bacterial protein of unknown function (DUF896)
+PF05980	Toxin_7	Toxin 7
+PF05981	CreA	CreA protein
+PF05982	Sbt_1	Na+-dependent bicarbonate transporter superfamily
+PF05983	Med7	MED7 protein
+PF05984	Cytomega_UL20A	Cytomegalovirus UL20A protein
+PF05985	EutC	Ethanolamine ammonia-lyase light chain (EutC)
+PF05986	ADAM_spacer1	ADAM-TS Spacer 1
+PF05987	DUF898	Bacterial protein of unknown function (DUF898)
+PF05988	DUF899	Bacterial protein of unknown function (DUF899)
+PF05989	Chordopox_A35R	Chordopoxvirus A35R protein
+PF05990	DUF900	Alpha/beta hydrolase of unknown function (DUF900)
+PF05991	NYN_YacP	YacP-like NYN domain
+PF05992	SbmA_BacA	SbmA/BacA-like family
+PF05993	Reovirus_M2	Reovirus major virion structural protein Mu-1/Mu-1C (M2)
+PF05994	FragX_IP	Cytoplasmic Fragile-X interacting family
+PF05995	CDO_I	Cysteine dioxygenase type I
+PF05996	Fe_bilin_red	Ferredoxin-dependent bilin reductase
+PF05997	Nop52	Nucleolar protein,Nop52
+PF05999	Herpes_U5	Herpesvirus U5-like family
+PF06001	DUF902	Domain of Unknown Function (DUF902)
+PF06002	CST-I	Alpha-2,3-sialyltransferase (CST-I)
+PF06003	SMN	Survival motor neuron protein (SMN)
+PF06004	DUF903	Bacterial protein of unknown function (DUF903)
+PF06005	ZapB	Cell division protein ZapB 
+PF06006	DUF905	Bacterial protein of unknown function (DUF905)
+PF06007	PhnJ	Phosphonate metabolism protein PhnJ
+PF06008	Laminin_I	Laminin Domain I
+PF06009	Laminin_II	Laminin Domain II
+PF06011	TRP	Transient receptor potential (TRP) ion channel
+PF06012	DUF908	Domain of Unknown Function (DUF908)
+PF06013	WXG100	Proteins of 100 residues with WXG
+PF06014	DUF910	Bacterial protein of unknown function (DUF910)
+PF06015	Chordopox_A30L	Chordopoxvirus A30L protein
+PF06016	Reovirus_L2	Reovirus core-spike protein lambda-2 (L2)
+PF06017	Myosin_TH1	Unconventional myosin tail, actin- and lipid-binding
+PF06018	CodY	CodY GAF-like domain
+PF06019	Phage_30_8	Phage GP30.8 protein
+PF06020	Roughex	Drosophila roughex protein
+PF06021	Gly_acyl_tr_N	Aralkyl acyl-CoA:amino acid N-acyltransferase
+PF06022	Cir_Bir_Yir	Plasmodium variant antigen protein Cir/Yir/Bir
+PF06023	Csa1	CRISPR-associated exonuclease Csa1
+PF06024	Orf78	Orf78 (ac78)
+PF06025	DUF913	Domain of Unknown Function (DUF913)
+PF06026	Rib_5-P_isom_A	Ribose 5-phosphate isomerase A (phosphoriboisomerase A)
+PF06027	SLC35F	Solute carrier family 35
+PF06028	DUF915	Alpha/beta hydrolase of unknown function (DUF915)
+PF06029	AlkA_N	AlkA N-terminal domain
+PF06030	DUF916	Bacterial protein of unknown function (DUF916)
+PF06031	SERTA	SERTA motif
+PF06032	DUF917	Protein of unknown function (DUF917)
+PF06033	DUF918	Nucleopolyhedrovirus protein of unknown function (DUF918)
+PF06034	DUF919	Nucleopolyhedrovirus protein of unknown function (DUF919)
+PF06035	Peptidase_C93	Bacterial transglutaminase-like cysteine proteinase BTLCP
+PF06037	DUF922	Bacterial protein of unknown function (DUF922)
+PF06039	Mqo	Malate:quinone oxidoreductase (Mqo)
+PF06040	Adeno_E3	Adenovirus E3 protein
+PF06041	DUF924	Bacterial protein of unknown function (DUF924)
+PF06042	NTP_transf_6	Nucleotidyltransferase
+PF06043	Reo_P9	Reovirus P9-like family
+PF06044	DpnI	Dam-replacing family
+PF06045	Rhamnogal_lyase	Rhamnogalacturonate lyase family
+PF06046	Sec6	Exocyst complex component Sec6
+PF06047	SynMuv_product	Ras-induced vulval development antagonist
+PF06048	DUF927	Domain of unknown function (DUF927)
+PF06049	LSPR	Coagulation Factor V LSPD Repeat
+PF06050	HGD-D	2-hydroxyglutaryl-CoA dehydratase, D-component 
+PF06051	DUF928	Domain of Unknown Function (DUF928)
+PF06052	3-HAO	3-hydroxyanthranilic acid dioxygenase
+PF06053	DUF929	Domain of unknown function (DUF929)
+PF06054	CoiA	Competence protein CoiA-like family
+PF06055	ExoD	Exopolysaccharide synthesis, ExoD
+PF06056	Terminase_5	Putative ATPase subunit of terminase (gpP-like)
+PF06057	VirJ	Bacterial virulence protein (VirJ)
+PF06058	DCP1	Dcp1-like decapping family
+PF06059	DUF930	Domain of Unknown Function (DUF930)
+PF06060	Mesothelin	Pre-pro-megakaryocyte potentiating factor precursor (Mesothelin)
+PF06061	Baculo_ME53	Baculoviridae ME53
+PF06062	UPF0231	Uncharacterised protein family (UPF0231)
+PF06064	Gam	Host-nuclease inhibitor protein Gam
+PF06066	SepZ	SepZ
+PF06067	DUF932	Domain of unknown function (DUF932)
+PF06068	TIP49	TIP49 C-terminus
+PF06069	PerC	PerC transcriptional activator
+PF06070	Herpes_UL32	Herpesvirus large structural phosphoprotein UL32
+PF06071	YchF-GTPase_C	Protein of unknown function (DUF933)
+PF06072	Herpes_US9	Alphaherpesvirus tegument protein US9
+PF06073	DUF934	Bacterial protein of unknown function (DUF934)
+PF06074	DUF935	Protein of unknown function (DUF935)
+PF06075	DUF936	Plant protein of unknown function (DUF936)
+PF06076	Orthopox_F14	Orthopoxvirus F14 protein
+PF06078	DUF937	Bacterial protein of unknown function (DUF937)
+PF06079	Apyrase	Apyrase
+PF06080	DUF938	Protein of unknown function (DUF938)
+PF06081	ArAE_1	Aromatic acid exporter family member 1
+PF06082	YjbH	Exopolysaccharide biosynthesis protein YbjH
+PF06083	IL17	Interleukin-17
+PF06084	Cytomega_TRL10	Cytomegalovirus TRL10 protein
+PF06085	Rz1	Lipoprotein Rz1 precursor
+PF06086	Pox_A30L_A26L	Orthopoxvirus A26L/A30L protein
+PF06087	Tyr-DNA_phospho	Tyrosyl-DNA phosphodiesterase
+PF06088	TLP-20	Nucleopolyhedrovirus telokin-like protein-20 (TLP20)
+PF06089	Asparaginase_II	L-asparaginase II
+PF06090	Ins_P5_2-kin	Inositol-pentakisphosphate 2-kinase
+PF06092	DUF943	Enterobacterial putative membrane protein (DUF943)
+PF06093	Spt4	Spt4/RpoE2 zinc finger
+PF06094	GGACT	Gamma-glutamyl cyclotransferase, AIG2-like
+PF06096	Baculo_8kDa	Baculoviridae 8.2 KDa protein
+PF06097	DUF945	Bacterial protein of unknown function (DUF945)
+PF06098	Radial_spoke_3	Radial spoke protein 3
+PF06099	Phenol_hyd_sub	Phenol hydroxylase subunit
+PF06100	MCRA	MCRA family
+PF06101	Vps62	Vacuolar protein sorting-associated protein 62
+PF06102	RRP36	rRNA biogenesis protein RRP36
+PF06103	DUF948	Bacterial protein of unknown function (DUF948)
+PF06105	Aph-1	Aph-1 protein
+PF06106	SAUGI	S. aureus uracil DNA glycosylase inhibitor
+PF06107	DUF951	Bacterial protein of unknown function (DUF951)
+PF06108	DUF952	Protein of unknown function (DUF952)
+PF06109	HlyE	Haemolysin E (HlyE)
+PF06110	DUF953	Eukaryotic protein of unknown function (DUF953)
+PF06112	Herpes_capsid	Gammaherpesvirus capsid protein
+PF06113	BRE	Brain and reproductive organ-expressed protein (BRE)
+PF06114	Peptidase_M78	IrrE N-terminal-like domain
+PF06115	DUF956	Domain of unknown function (DUF956)
+PF06116	RinB	Transcriptional activator RinB
+PF06117	DUF957	Enterobacterial protein of unknown function (DUF957)
+PF06119	NIDO	Nidogen-like
+PF06120	Phage_HK97_TLTM	Tail length tape measure protein
+PF06121	DUF959	Domain of Unknown Function (DUF959) 
+PF06122	TraH	Conjugative relaxosome accessory transposon protein
+PF06123	CreD	Inner membrane protein CreD
+PF06124	DUF960	Staphylococcal protein of unknown function (DUF960)
+PF06125	DUF961	Bacterial protein of unknown function (DUF961)
+PF06126	Herpes_LAMP2	Herpesvirus Latent membrane protein 2
+PF06127	DUF962	Protein of unknown function (DUF962)
+PF06128	Shigella_OspC	Shigella flexneri OspC protein
+PF06129	Chordopox_G3	Chordopoxvirus G3 protein
+PF06130	PTAC	Phosphate propanoyltransferase
+PF06131	DUF963	Schizosaccharomyces pombe repeat of unknown function (DUF963)
+PF06133	Com_YlbF	Control of competence regulator ComK, YlbF/YmcA
+PF06134	RhaA	L-rhamnose isomerase (RhaA)
+PF06135	DUF965	Bacterial protein of unknown function (DUF965)
+PF06136	DUF966	Domain of unknown function (DUF966)
+PF06138	Chordopox_E11	Chordopoxvirus E11 protein
+PF06139	BphX	BphX-like
+PF06140	Ifi-6-16	Interferon-induced 6-16 family 
+PF06141	Phage_tail_U	Phage minor tail protein U
+PF06143	Baculo_11_kDa	Baculovirus 11 kDa family
+PF06144	DNA_pol3_delta	DNA polymerase III, delta subunit
+PF06145	Corona_NS1	Coronavirus nonstructural protein NS1
+PF06146	PsiE	Phosphate-starvation-inducible E
+PF06147	DUF968	Protein of unknown function (DUF968)
+PF06148	COG2	COG (conserved oligomeric Golgi) complex component, COG2
+PF06149	DUF969	Protein of unknown function (DUF969)
+PF06150	ChaB	ChaB
+PF06151	Trehalose_recp	Trehalose receptor
+PF06152	Phage_min_cap2	Phage minor capsid protein 2
+PF06153	CdAMP_rec	Cyclic-di-AMP receptor
+PF06154	CbeA_antitoxin	CbeA_antitoxin, type IV, cytoskeleton bundling-enhancing factor A
+PF06155	DUF971	Protein of unknown function (DUF971)
+PF06156	YabB	Initiation control protein YabA
+PF06157	DUF973	Protein of unknown function (DUF973)
+PF06159	DUF974	Protein of unknown function (DUF974)
+PF06160	EzrA	Septation ring formation regulator, EzrA 
+PF06161	DUF975	Protein of unknown function (DUF975)
+PF06162	PgaPase_1	Putative pyroglutamyl peptidase PgaPase_1
+PF06163	DUF977	Bacterial protein of unknown function (DUF977)
+PF06165	Glyco_transf_36	Glycosyltransferase family 36
+PF06166	DUF979	Protein of unknown function (DUF979)
+PF06167	Peptidase_M90	Glucose-regulated metallo-peptidase M90
+PF06168	DUF981	Protein of unknown function (DUF981)
+PF06169	DUF982	Protein of unknown function (DUF982)
+PF06170	DUF983	Protein of unknown function (DUF983)
+PF06172	Cupin_5	Cupin superfamily (DUF985)
+PF06173	DUF986	Protein of unknown function (DUF986)
+PF06174	DUF987	Protein of unknown function (DUF987)
+PF06175	MiaE	tRNA-(MS[2]IO[6]A)-hydroxylase (MiaE)
+PF06176	WaaY	Lipopolysaccharide core biosynthesis protein (WaaY)
+PF06177	QueT	QueT transporter
+PF06178	KdgM	Oligogalacturonate-specific porin protein (KdgM)
+PF06179	Med22	Surfeit locus protein 5 subunit 22 of Mediator complex
+PF06180	CbiK	Cobalt chelatase (CbiK)
+PF06181	Urate_ox_N	Urate oxidase N-terminal
+PF06182	ABC2_membrane_6	ABC-2 family transporter protein
+PF06183	DinI	DinI-like family
+PF06184	Potex_coat	Potexvirus coat protein
+PF06185	YecM	YecM protein
+PF06186	DUF992	Protein of unknown function (DUF992)
+PF06187	DUF993	Protein of unknown function (DUF993)
+PF06188	HrpE	HrpE/YscL/FliH and V-type ATPase subunit E
+PF06189	5-nucleotidase	5'-nucleotidase
+PF06191	DUF995	Protein of unknown function (DUF995)
+PF06193	Orthopox_A5L	Orthopoxvirus A5L protein-like
+PF06194	Phage_Orf51	Phage Conserved Open Reading Frame 51
+PF06195	DUF996	Protein of unknown function (DUF996)
+PF06196	DUF997	Protein of unknown function (DUF997)
+PF06197	DUF998	Protein of unknown function (DUF998)
+PF06198	DUF999	Protein of unknown function (DUF999)
+PF06199	Phage_tail_2	Phage tail tube protein
+PF06200	tify	tify domain
+PF06201	PITH	PITH domain
+PF06202	GDE_C	Amylo-alpha-1,6-glucosidase 
+PF06203	CCT	CCT motif
+PF06206	CpeT	CpeT/CpcT family (DUF1001)
+PF06207	DUF1002	Protein of unknown function (DUF1002)
+PF06208	BDV_G	Borna disease virus G protein
+PF06209	COBRA1	Cofactor of BRCA1 (COBRA1)
+PF06210	DUF1003	Protein of unknown function (DUF1003)
+PF06211	BAMBI	BMP and activin membrane-bound inhibitor (BAMBI) N-terminal domain
+PF06212	GRIM-19	GRIM-19 protein
+PF06213	CobT	Cobalamin biosynthesis protein CobT
+PF06214	SLAM	Signaling lymphocytic activation molecule (SLAM) protein
+PF06215	ISAV_HA	Infectious salmon anaemia virus haemagglutinin
+PF06216	RTBV_P46	Rice tungro bacilliform virus P46 protein
+PF06217	GAGA_bind	GAGA binding protein-like family
+PF06218	NPR2	Nitrogen permease regulator 2
+PF06219	DUF1005	Protein of unknown function (DUF1005)
+PF06220	zf-U1	U1 zinc finger
+PF06221	zf-C2HC5	Putative zinc finger motif, C2HC5-type
+PF06222	Phage_TAC_1	Phage tail assembly chaperone
+PF06223	Phage_tail_T	Minor tail protein T
+PF06224	HTH_42	Winged helix DNA-binding domain
+PF06226	DUF1007	Protein of unknown function (DUF1007)
+PF06227	Poxvirus	dsDNA Poxvirus
+PF06228	ChuX_HutX	Haem utilisation ChuX/HutX
+PF06229	FRG1	FRG1-like domain
+PF06230	DUF1009	Protein of unknown function (DUF1009)
+PF06231	DUF1010	Protein of unknown function (DUF1010)
+PF06232	ATS3	Embryo-specific protein 3, (ATS3)
+PF06233	Usg	Usg-like family
+PF06234	TmoB	Toluene-4-monooxygenase system protein B (TmoB)
+PF06235	NAD4L	NADH dehydrogenase subunit 4L (NAD4L)
+PF06236	MelC1	Tyrosinase co-factor MelC1
+PF06237	DUF1011	Protein of unknown function (DUF1011)
+PF06238	Borrelia_lipo_2	Borrelia burgdorferi BBR25 lipoprotein
+PF06239	ECSIT	Evolutionarily conserved signalling intermediate in Toll pathway
+PF06240	COXG	Carbon monoxide dehydrogenase subunit G (CoxG)
+PF06241	Castor_Poll_mid	Castor and Pollux, part of voltage-gated ion channel
+PF06242	DUF1013	Protein of unknown function (DUF1013)
+PF06243	PaaB	Phenylacetic acid degradation B
+PF06244	Ccdc124	Coiled-coil domain-containing protein 124
+PF06245	DUF1015	Protein of unknown function (DUF1015)
+PF06246	Isy1	Isy1-like splicing family
+PF06247	Plasmod_Pvs28	Pvs28 EGF domain
+PF06248	Zw10	Centromere/kinetochore Zw10
+PF06249	EutQ	Ethanolamine utilisation protein EutQ
+PF06250	DUF1016	Protein of unknown function (DUF1016)
+PF06251	Caps_synth_GfcC	Capsule biosynthesis GfcC
+PF06252	DUF1018	Protein of unknown function (DUF1018)
+PF06253	MTTB	Trimethylamine methyltransferase (MTTB)
+PF06254	YdaT_toxin	Putative bacterial toxin ydaT
+PF06255	MafB	Neisseria toxin MafB
+PF06256	Nucleo_LEF-12	Nucleopolyhedrovirus LEF-12 protein
+PF06257	VEG	Biofilm formation stimulator VEG
+PF06258	Mito_fiss_Elm1	Mitochondrial fission ELM1
+PF06259	Abhydrolase_8	Alpha/beta hydrolase
+PF06260	DUF1024	Protein of unknown function (DUF1024)
+PF06261	LktC	Actinobacillus actinomycetemcomitans leukotoxin activator LktC
+PF06262	Zincin_1	Zincin-like metallopeptidase
+PF06265	DUF1027	Protein of unknown function (DUF1027)
+PF06266	HrpF	HrpF protein
+PF06267	DUF1028	Family of unknown function (DUF1028)
+PF06268	Fascin	Fascin domain
+PF06269	DUF1029	Protein of unknown function (DUF1029)
+PF06270	DUF1030	Protein of unknown function (DUF1030)
+PF06271	RDD	RDD family
+PF06273	eIF-4B	Plant specific eukaryotic initiation factor 4B
+PF06275	DUF1031	Protein of unknown function (DUF1031)
+PF06276	FhuF	Ferric iron reductase FhuF-like transporter
+PF06277	EutA	Ethanolamine utilisation protein EutA
+PF06278	CNDH2_N	Condensin II complex subunit CAP-H2 or CNDH2, N-terminal
+PF06279	DUF1033	Protein of unknown function (DUF1033)
+PF06280	fn3_5	Fn3-like domain
+PF06281	DUF1035	Protein of unknown function (DUF1035)
+PF06282	DUF1036	Protein of unknown function (DUF1036)
+PF06283	ThuA	Trehalose utilisation
+PF06284	Cytomega_UL84	Cytomegalovirus UL84 protein
+PF06286	Coleoptericin	Coleoptericin
+PF06287	DUF1039	Protein of unknown function (DUF1039)
+PF06288	DUF1040	Protein of unknown function (DUF1040)
+PF06289	FlbD	Flagellar protein (FlbD)
+PF06290	PsiB	Plasmid SOS inhibition protein (PsiB)
+PF06291	Lambda_Bor	Bor protein
+PF06292	DUF1041	Domain of Unknown Function (DUF1041)
+PF06293	Kdo	Lipopolysaccharide kinase (Kdo/WaaP) family
+PF06294	CH_2	CH-like domain in sperm protein
+PF06295	DUF1043	Protein of unknown function (DUF1043)
+PF06296	RelE	RelE toxin of RelE / RelB toxin-antitoxin system
+PF06297	PET	PET Domain
+PF06298	PsbY	Photosystem II protein Y (PsbY)
+PF06299	DUF1045	Protein of unknown function (DUF1045)
+PF06300	Tsp45I	Tsp45I type II restriction enzyme
+PF06301	Lambda_Kil	Bacteriophage lambda Kil protein
+PF06303	MatP	MatP N-terminal domain
+PF06304	DUF1048	Protein of unknown function (DUF1048)
+PF06305	LapA_dom	Lipopolysaccharide assembly protein A domain
+PF06306	CgtA	Beta-1,4-N-acetylgalactosaminyltransferase (CgtA)
+PF06307	Herpes_IR6	Herpesvirus IR6 protein
+PF06308	ErmC	23S rRNA methylase leader peptide (ErmC)
+PF06309	Torsin	Torsin
+PF06311	NumbF	NUMB domain
+PF06312	Neurexophilin	Neurexophilin
+PF06313	ACP53EA	Drosophila ACP53EA protein
+PF06314	ADC	Acetoacetate decarboxylase (ADC)
+PF06315	AceK	Isocitrate dehydrogenase kinase/phosphatase (AceK)
+PF06316	Ail_Lom	Enterobacterial Ail/Lom protein
+PF06317	Arena_RNA_pol	Arenavirus RNA polymerase
+PF06319	MmcB-like	DNA repair protein MmcB-like
+PF06320	GCN5L1	GCN5-like protein 1 (GCN5L1)
+PF06321	P_gingi_FimA	Major fimbrial subunit protein (FimA)
+PF06322	Phage_NinH	Phage NinH protein
+PF06323	Phage_antiter_Q	Phage antitermination protein Q
+PF06324	Pigment_DH	Pigment-dispersing hormone (PDH)
+PF06325	PrmA	Ribosomal protein L11 methyltransferase (PrmA)
+PF06326	Vesiculo_matrix	Vesiculovirus matrix protein
+PF06327	DUF1053	Domain of Unknown Function (DUF1053)
+PF06328	Lep_receptor_Ig	Ig-like C2-type domain
+PF06330	TRI5	Trichodiene synthase (TRI5)
+PF06331	Tfb5	Transcription factor TFIIH complex subunit Tfb5
+PF06333	Med13_C	Mediator complex subunit 13 C-terminal
+PF06334	Orthopox_A47	Orthopoxvirus A47 protein
+PF06335	DUF1054	Protein of unknown function (DUF1054)
+PF06336	Corona_5a	Coronavirus 5a protein
+PF06337	DUSP	DUSP domain
+PF06338	ComK	ComK protein
+PF06339	Ectoine_synth	Ectoine synthase
+PF06340	TcpF	Vibrio cholerae toxin co-regulated pilus biosynthesis protein F
+PF06341	DUF1056	Protein of unknown function (DUF1056)
+PF06342	DUF1057	Alpha/beta hydrolase of unknown function (DUF1057)
+PF06344	Parecho_VpG	Parechovirus Genome-linked protein
+PF06345	Drf_DAD	DRF Autoregulatory Domain
+PF06346	Drf_FH1	Formin Homology Region 1
+PF06347	SH3_4	Bacterial SH3 domain
+PF06348	DUF1059	Protein of unknown function (DUF1059)
+PF06350	HSL_N	Hormone-sensitive lipase (HSL) N-terminus
+PF06351	Allene_ox_cyc	Allene oxide cyclase
+PF06353	DUF1062	Protein of unknown function (DUF1062)
+PF06355	Aegerolysin	Aegerolysin
+PF06356	DUF1064	Protein of unknown function (DUF1064)
+PF06357	Omega-toxin	Omega-atracotoxin
+PF06358	DUF1065	Protein of unknown function (DUF1065)
+PF06360	E_raikovi_mat	Euplotes raikovi mating pheromone
+PF06361	RTBV_P12	Rice tungro bacilliform virus P12 protein
+PF06362	DUF1067	Protein of unknown function (DUF1067)
+PF06363	Picorna_P3A	Picornaviridae P3A protein
+PF06364	DUF1068	Protein of unknown function (DUF1068)
+PF06365	CD34_antigen	CD34/Podocalyxin family
+PF06366	FlhE	Flagellar protein FlhE
+PF06367	Drf_FH3	Diaphanous FH3 Domain
+PF06368	Met_asp_mut_E	Methylaspartate mutase E chain (MutE)
+PF06369	Anemone_cytotox	Sea anemone cytotoxic protein
+PF06370	DUF1069	Protein of unknown function (DUF1069)
+PF06371	Drf_GBD	Diaphanous GTPase-binding Domain
+PF06372	Gemin6	Gemin6 protein
+PF06373	CART	Cocaine and amphetamine regulated transcript protein (CART)
+PF06374	NDUF_C2	NADH-ubiquinone oxidoreductase subunit b14.5b (NDUFC2)
+PF06375	AP3D1	AP-3 complex subunit delta-1 
+PF06376	AGP	Arabinogalactan peptide
+PF06377	Adipokin_hormo	Adipokinetic hormone
+PF06378	DUF1071	Protein of unknown function (DUF1071)
+PF06379	RhaT	L-rhamnose-proton symport protein (RhaT)
+PF06380	DUF1072	Protein of unknown function (DUF1072)
+PF06381	DUF1073	Protein of unknown function (DUF1073)
+PF06382	DUF1074	Protein of unknown function (DUF1074)
+PF06384	ICAT	Beta-catenin-interacting protein ICAT
+PF06385	Baculo_LEF-11	Baculovirus LEF-11 protein
+PF06386	GvpL_GvpF	Gas vesicle synthesis protein GvpL/GvpF
+PF06387	Calcyon	D1 dopamine receptor-interacting protein (calcyon)
+PF06388	DUF1075	Protein of unknown function (DUF1075)
+PF06389	Filo_VP24	Filovirus membrane-associated protein VP24
+PF06390	NESP55	Neuroendocrine-specific golgi protein P55 (NESP55)
+PF06391	MAT1	CDK-activating kinase assembly factor MAT1
+PF06392	Asr	Acid shock protein repeat 
+PF06393	BID	BH3 interacting domain (BID)
+PF06394	Pepsin-I3	Pepsin inhibitor-3-like repeated domain
+PF06395	CDC24	CDC24 Calponin
+PF06396	AGTRAP	Angiotensin II, type I receptor-associated protein (AGTRAP)
+PF06397	Desulfoferrod_N	Desulfoferrodoxin, N-terminal domain
+PF06398	Pex24p	Integral peroxisomal membrane peroxin
+PF06399	GFRP	GTP cyclohydrolase I feedback regulatory protein (GFRP)
+PF06400	Alpha-2-MRAP_N	Alpha-2-macroglobulin RAP, N-terminal domain
+PF06401	Alpha-2-MRAP_C	Alpha-2-macroglobulin RAP, C-terminal domain 
+PF06403	Lamprin	Lamprin
+PF06404	PSK	Phytosulfokine precursor protein (PSK)
+PF06405	RCC_reductase	Red chlorophyll catabolite reductase (RCC reductase)
+PF06406	StbA	StbA protein
+PF06407	BDV_P40	Borna disease virus P40 protein
+PF06409	NPIP	Nuclear pore complex interacting protein (NPIP)
+PF06411	HdeA	HdeA/HdeB family
+PF06412	TraD	Conjugal transfer protein TraD
+PF06413	Neugrin	Neugrin
+PF06414	Zeta_toxin	Zeta toxin
+PF06415	iPGM_N	BPG-independent PGAM N-terminus (iPGM_N)
+PF06416	T3SS_NleG	Effector protein NleG
+PF06417	DUF1077	Protein of unknown function (DUF1077)
+PF06418	CTP_synth_N	CTP synthase N-terminus
+PF06419	COG6	Conserved oligomeric complex COG6
+PF06420	Mgm101p	Mitochondrial genome maintenance MGM101
+PF06421	LepA_C	GTP-binding protein LepA C-terminus
+PF06422	PDR_CDR	CDR ABC transporter
+PF06423	GWT1	GWT1
+PF06424	PRP1_N	PRP1 splicing factor, N-terminal
+PF06426	SATase_N	Serine acetyltransferase, N-terminal 
+PF06427	UDP-g_GGTase	UDP-glucose:Glycoprotein Glucosyltransferase
+PF06428	Sec2p	GDP/GTP exchange factor Sec2p
+PF06429	Flg_bbr_C	Flagellar basal body rod FlgEFG protein C-terminal
+PF06430	L_lactis_RepB_C	Lactococcus lactis RepB C-terminus
+PF06431	Polyoma_lg_T_C	Polyomavirus large T antigen C-terminus
+PF06432	GPI2	Phosphatidylinositol N-acetylglucosaminyltransferase
+PF06433	Me-amine-dh_H	Methylamine dehydrogenase heavy chain (MADH)
+PF06434	Aconitase_2_N	Aconitate hydratase 2 N-terminus
+PF06435	DUF1079	Repeat of unknown function (DUF1079)
+PF06436	Pneumovirus_M2	Pneumovirus matrix protein 2 (M2)
+PF06437	ISN1	IMP-specific 5'-nucleotidase
+PF06438	HasA	Heme-binding protein A (HasA)
+PF06439	DUF1080	Domain of Unknown Function (DUF1080)
+PF06440	DNA_pol3_theta	DNA polymerase III, theta subunit
+PF06441	EHN	Epoxide hydrolase N terminus
+PF06442	DHFR_2	R67 dihydrofolate reductase
+PF06443	SEF14_adhesin	SEF14-like adhesin 
+PF06444	NADH_dehy_S2_C	NADH dehydrogenase subunit 2 C-terminus
+PF06445	GyrI-like	GyrI-like small molecule binding domain
+PF06446	Hepcidin	Hepcidin
+PF06448	DUF1081	Domain of Unknown Function (DUF1081)
+PF06449	DUF1082	Mitochondrial domain of unknown function (DUF1082)
+PF06450	NhaB	Bacterial Na+/H+ antiporter B (NhaB)
+PF06451	Moricin	Moricin
+PF06452	CBM9_1	Carbohydrate family 9 binding domain-like
+PF06453	LT-IIB	Type II heat-labile enterotoxin , B subunit (LT-IIB)
+PF06454	DUF1084	Protein of unknown function (DUF1084)
+PF06455	NADH5_C	NADH dehydrogenase subunit 5 C-terminus
+PF06456	Arfaptin	Arfaptin-like domain
+PF06457	Ectatomin	Ectatomin
+PF06458	MucBP	MucBP domain
+PF06459	RR_TM4-6	Ryanodine Receptor TM 4-6
+PF06460	NSP13	Coronavirus NSP13
+PF06461	DUF1086	Domain of Unknown Function (DUF1086)
+PF06462	Hyd_WA	Propeller
+PF06463	Mob_synth_C	Molybdenum Cofactor Synthesis C
+PF06464	DMAP_binding	DMAP1-binding Domain
+PF06465	DUF1087	Domain of Unknown Function (DUF1087)
+PF06466	PCAF_N	PCAF (P300/CBP-associated factor) N-terminal domain
+PF06467	zf-FCS	MYM-type Zinc finger with FCS sequence motif
+PF06468	Spond_N	Spondin_N
+PF06469	DUF1088	Domain of Unknown Function (DUF1088)
+PF06470	SMC_hinge	SMC proteins Flexible Hinge Domain
+PF06471	NSP11	NSP11
+PF06472	ABC_membrane_2	ABC transporter transmembrane region 2
+PF06473	FGF-BP1	FGF binding protein 1 (FGF-BP1)
+PF06474	MLTD_N	MltD lipid attachment motif
+PF06475	Glycolipid_bind	Putative glycolipid-binding
+PF06476	DUF1090	Protein of unknown function (DUF1090)
+PF06477	DUF1091	Protein of unknown function (DUF1091)
+PF06478	Corona_RPol_N	Coronavirus RPol N-terminus
+PF06479	Ribonuc_2-5A	Ribonuclease 2-5A
+PF06480	FtsH_ext	FtsH Extracellular
+PF06481	COX_ARM	COX Aromatic Rich Motif
+PF06482	Endostatin	Collagenase NC10 and Endostatin
+PF06483	ChiC	Chitinase C
+PF06484	Ten_N	Teneurin Intracellular Region
+PF06485	DUF1092	Protein of unknown function (DUF1092)
+PF06486	DUF1093	Protein of unknown function (DUF1093)
+PF06487	SAP18	Sin3 associated polypeptide p18 (SAP18)
+PF06488	L_lac_phage_MSP	Phage tail tube protein
+PF06489	Orthopox_A49R	Orthopoxvirus A49R protein
+PF06490	FleQ	Flagellar regulatory protein FleQ
+PF06491	Disulph_isomer	Disulphide isomerase
+PF06493	DUF1096	Protein of unknown function (DUF1096)
+PF06495	Transformer	Fruit fly transformer protein
+PF06496	DUF1097	Protein of unknown function (DUF1097)
+PF06497	DUF1098	Protein of unknown function (DUF1098)
+PF06500	DUF1100	Alpha/beta hydrolase of unknown function (DUF1100)
+PF06501	Herpes_U55	Human herpesvirus U55 protein
+PF06502	Equine_IAV_S2	Equine infectious anaemia virus S2 protein
+PF06503	DUF1101	Protein of unknown function (DUF1101)
+PF06504	RepC	Replication protein C (RepC)
+PF06505	XylR_N	Activator of aromatic catabolism
+PF06506	PrpR_N	Propionate catabolism activator
+PF06507	Auxin_resp	Auxin response factor
+PF06508	QueC	Queuosine biosynthesis protein QueC
+PF06510	DUF1102	Protein of unknown function (DUF1102)
+PF06511	IpaD	Invasion plasmid antigen IpaD
+PF06512	Na_trans_assoc	Sodium ion transport-associated
+PF06513	DUF1103	Repeat of unknown function (DUF1103)
+PF06514	PsbU	Photosystem II 12 kDa extrinsic protein (PsbU)
+PF06515	BDV_P10	Borna disease virus P10 protein
+PF06516	NUP	Purine nucleoside permease (NUP)
+PF06517	Orthopox_A43R	Orthopoxvirus A43R protein
+PF06518	DUF1104	Protein of unknown function (DUF1104)
+PF06519	TolA	TolA C-terminal
+PF06521	PAR1	PAR1 protein
+PF06522	B12D	NADH-ubiquinone reductase complex 1 MLRQ subunit
+PF06523	DUF1106	Protein of unknown function (DUF1106)
+PF06524	NOA36	NOA36 protein
+PF06525	SoxE	Sulfocyanin (SoxE) domain
+PF06526	DUF1107	Protein of unknown function (DUF1107)
+PF06527	TniQ	TniQ
+PF06528	Phage_P2_GpE	Phage P2 GpE
+PF06529	Vert_IL3-reg_TF	Vertebrate interleukin-3 regulated transcription factor
+PF06530	Phage_antitermQ	Phage antitermination protein Q
+PF06531	DUF1108	Protein of unknown function (DUF1108)
+PF06532	DUF1109	Protein of unknown function (DUF1109)
+PF06533	DUF1110	Protein of unknown function (DUF1110)
+PF06534	RGM_C	Repulsive guidance molecule (RGM) C-terminus
+PF06535	RGM_N	Repulsive guidance molecule (RGM) N-terminus
+PF06536	Av_adeno_fibre	Avian adenovirus fibre, N-terminal
+PF06537	DHOR	Di-haem oxidoreductase, putative peroxidase
+PF06540	GMAP	Galanin message associated peptide (GMAP)
+PF06541	ABC_trans_CmpB	Putative ABC-transporter type IV
+PF06542	PHA-1	Regulator protein PHA-1
+PF06543	Lac_bphage_repr	Lactococcus bacteriophage repressor
+PF06544	DUF1115	Protein of unknown function (DUF1115)
+PF06545	DUF1116	Protein of unknown function (DUF1116)
+PF06546	Vert_HS_TF	Vertebrate heat shock transcription factor
+PF06547	DUF1117	Protein of unknown function (DUF1117)
+PF06549	DUF1118	Protein of unknown function (DUF1118)
+PF06550	SPP	Signal-peptide peptidase, presenilin aspartyl protease
+PF06551	DUF1120	Protein of unknown function (DUF1120)
+PF06552	TOM20_plant	Plant specific mitochondrial import receptor subunit TOM20
+PF06553	BNIP3	BNIP3
+PF06554	Olfactory_mark	Olfactory marker protein
+PF06556	ASFV_p27	IAP-like protein p27 C-terminus
+PF06557	DUF1122	Protein of unknown function (DUF1122)
+PF06558	SecM	Secretion monitor precursor protein (SecM)
+PF06559	DCD	2'-deoxycytidine 5'-triphosphate deaminase (DCD)
+PF06560	GPI	Glucose-6-phosphate isomerase (GPI)
+PF06563	DUF1125	Protein of unknown function (DUF1125)
+PF06564	CBP_BcsQ	Cellulose biosynthesis protein BcsQ
+PF06565	DUF1126	DUF1126 PH-like domain
+PF06566	Chon_Sulph_att	Chondroitin sulphate attachment domain
+PF06567	Neural_ProG_Cyt	Neural chondroitin sulphate proteoglycan cytoplasmic domain
+PF06568	DUF1127	Domain of unknown function (DUF1127)
+PF06569	DUF1128	Protein of unknown function (DUF1128)
+PF06570	DUF1129	Protein of unknown function (DUF1129)
+PF06572	DUF1131	Protein of unknown function (DUF1131)
+PF06573	Churchill	Churchill protein
+PF06574	FAD_syn	FAD synthetase
+PF06575	DUF1132	Protein of unknown function (DUF1132)
+PF06576	DUF1133	Protein of unknown function (DUF1133)
+PF06577	DUF1134	Protein of unknown function (DUF1134)
+PF06578	YscK	YOP proteins translocation protein K (YscK)
+PF06579	Ly-6_related	Caenorhabditis elegans ly-6-related protein
+PF06580	His_kinase	Histidine kinase
+PF06581	p31comet	Mad1 and Cdc20-bound-Mad2 binding
+PF06582	DUF1136	Repeat of unknown function (DUF1136)
+PF06583	Neogenin_C	Neogenin C-terminus
+PF06584	DIRP	DIRP
+PF06585	JHBP	Haemolymph juvenile hormone binding protein (JHBP)
+PF06586	TraK	TraK protein
+PF06587	DUF1137	Protein of unknown function (DUF1137)
+PF06588	Muskelin_N	Muskelin N-terminus
+PF06589	CRA	Circumsporozoite-related antigen (CRA)
+PF06590	PerB	PerB protein
+PF06591	Phage_T4_Ndd	T4-like phage nuclear disruption protein (Ndd)
+PF06592	DUF1138	Protein of unknown function (DUF1138)
+PF06593	RBDV_coat	Raspberry bushy dwarf virus coat protein
+PF06594	HCBP_related	Haemolysin-type calcium binding protein related domain
+PF06595	BDV_P24	Borna disease virus P24 protein
+PF06596	PsbX	Photosystem II reaction centre X protein (PsbX)
+PF06597	Clostridium_P47	Clostridium P-47 protein
+PF06598	Chlorovi_GP_rpt	Chlorovirus glycoprotein repeat
+PF06599	DUF1139	Protein of unknown function (DUF1139)
+PF06600	DUF1140	Protein of unknown function (DUF1140)
+PF06601	Orthopox_F6	Orthopoxvirus F6 protein
+PF06602	Myotub-related	Myotubularin-like phosphatase domain
+PF06603	UpxZ	UpxZ family of transcription anti-terminator antagonists
+PF06605	Prophage_tail	Prophage endopeptidase tail
+PF06607	Prokineticin	Prokineticin
+PF06608	DUF1143	Protein of unknown function (DUF1143)
+PF06609	TRI12	Fungal trichothecene efflux pump (TRI12)
+PF06610	AlaE	L-alanine exporter
+PF06611	DUF1145	Protein of unknown function (DUF1145)
+PF06612	DUF1146	Protein of unknown function (DUF1146)
+PF06613	KorB_C	KorB C-terminal beta-barrel domain
+PF06614	Neuromodulin	Neuromodulin
+PF06615	DUF1147	Protein of unknown function (DUF1147)
+PF06616	BsuBI_PstI_RE	BsuBI/PstI restriction endonuclease C-terminus
+PF06617	M-inducer_phosp	M-phase inducer phosphatase
+PF06618	DUF1148	Protein of unknown function (DUF1148)
+PF06619	DUF1149	Protein of unknown function (DUF1149)
+PF06620	DUF1150	Protein of unknown function (DUF1150)
+PF06621	SIM_C	Single-minded protein C-terminus
+PF06622	SepQ	SepQ protein
+PF06623	MHC_I_C	MHC_I C-terminus
+PF06624	RAMP4	Ribosome associated membrane protein RAMP4
+PF06625	DUF1151	Protein of unknown function (DUF1151)
+PF06626	DUF1152	Protein of unknown function (DUF1152)
+PF06627	DUF1153	Protein of unknown function (DUF1153)
+PF06628	Catalase-rel	Catalase-related immune-responsive
+PF06629	MipA	MltA-interacting protein MipA
+PF06630	Exonuc_VIII	Enterobacterial exodeoxyribonuclease VIII
+PF06631	DUF1154	Protein of unknown function (DUF1154)
+PF06632	XRCC4	DNA double-strand break repair and V(D)J recombination protein XRCC4
+PF06633	DUF1155	Protein of unknown function (DUF1155)
+PF06634	DUF1156	Protein of unknown function (DUF1156)
+PF06635	NolV	Nodulation protein NolV
+PF06636	DUF1157	Protein of unknown function (DUF1157)
+PF06637	PV-1	PV-1 protein (PLVAP)
+PF06638	Strabismus	Strabismus protein
+PF06639	BAP	Basal layer antifungal peptide (BAP)
+PF06640	P_C	P protein C-terminus
+PF06643	DUF1158	Protein of unknown function (DUF1158)
+PF06644	ATP11	ATP11 protein
+PF06645	SPC12	Microsomal signal peptidase 12 kDa subunit (SPC12)
+PF06646	Mycoplasma_p37	High affinity transport system protein p37
+PF06648	DUF1160	Protein of unknown function (DUF1160)
+PF06649	DUF1161	Protein of unknown function (DUF1161)
+PF06650	SHR-BD	SHR-binding domain of vacuolar-sorting associated protein 13
+PF06651	DUF1163	Protein of unknown function (DUF1163)
+PF06652	Methuselah_N	Methuselah N-terminus
+PF06653	Claudin_3	Tight junction protein, Claudin-like
+PF06656	Tenui_PVC2	Tenuivirus PVC2 protein
+PF06657	Cep57_MT_bd	Centrosome microtubule-binding domain of Cep57
+PF06658	DUF1168	Protein of unknown function (DUF1168)
+PF06661	VirE3	VirE3
+PF06662	C5-epim_C	D-glucuronyl C5-epimerase C-terminus
+PF06663	DUF1170	Protein of unknown function (DUF1170)
+PF06664	MIG-14_Wnt-bd	Wnt-binding factor required for Wnt secretion
+PF06666	DUF1173	Protein of unknown function (DUF1173)
+PF06667	PspB	Phage shock protein B
+PF06668	ITI_HC_C	Inter-alpha-trypsin inhibitor heavy chain C-terminus
+PF06670	Etmic-2	Microneme protein Etmic-2
+PF06671	DUF1174	Repeat of unknown function (DUF1174)
+PF06672	DUF1175	Protein of unknown function (DUF1175)
+PF06673	L_lactis_ph-MCP	Lactococcus lactis bacteriophage major capsid protein
+PF06674	DUF1176	Protein of unknown function (DUF1176)
+PF06675	DUF1177	Protein of unknown function (DUF1177)
+PF06676	DUF1178	Protein of unknown function (DUF1178)
+PF06677	Auto_anti-p27	Sjogren's syndrome/scleroderma autoantigen 1 (Autoantigen p27)
+PF06678	DUF1179	Protein of unknown function (DUF1179)
+PF06679	DUF1180	Protein of unknown function (DUF1180)
+PF06680	DUF1181	Protein of unknown function (DUF1181)
+PF06681	DUF1182	Protein of unknown function (DUF1182)
+PF06682	SARAF	SOCE-associated regulatory factor of calcium homoeostasis
+PF06683	DUF1184	Protein of unknown function (DUF1184)
+PF06684	AA_synth	Amino acid synthesis
+PF06685	DUF1186	Protein of unknown function (DUF1186)
+PF06686	SpoIIIAC	Stage III sporulation protein AC/AD protein family
+PF06687	SUR7	SUR7/PalI family
+PF06688	DUF1187	Protein of unknown function (DUF1187)
+PF06689	zf-C4_ClpX	ClpX C4-type zinc finger
+PF06690	DUF1188	Protein of unknown function (DUF1188)
+PF06691	DUF1189	Protein of unknown function (DUF1189)
+PF06692	MNSV_P7B	Melon necrotic spot virus P7B protein
+PF06693	DUF1190	Protein of unknown function (DUF1190)
+PF06694	Plant_NMP1	Plant nuclear matrix protein 1 (NMP1)
+PF06695	Sm_multidrug_ex	Putative small multi-drug export protein
+PF06696	Strep_SA_rep	Streptococcal surface antigen repeat
+PF06697	DUF1191	Protein of unknown function (DUF1191)
+PF06698	DUF1192	Protein of unknown function (DUF1192)
+PF06699	PIG-F	GPI biosynthesis protein family Pig-F
+PF06701	MIB_HERC2	Mib_herc2
+PF06702	Fam20C	Golgi casein kinase, C-terminal, Fam20
+PF06703	SPC25	Microsomal signal peptidase 25 kDa subunit (SPC25)
+PF06705	SF-assemblin	SF-assemblin/beta giardin
+PF06706	CTV_P6	Citrus tristeza virus 6-kDa protein
+PF06707	DUF1194	Protein of unknown function (DUF1194)
+PF06708	DUF1195	Protein of unknown function (DUF1195)
+PF06709	DUF1196	Protein of unknown function (DUF1196)
+PF06711	DUF1198	Protein of unknown function (DUF1198)
+PF06712	DUF1199	Protein of unknown function (DUF1199)
+PF06713	bPH_4	Bacterial PH domain
+PF06714	Gp5_OB	Gp5 N-terminal OB domain
+PF06715	Gp5_C	Gp5 C-terminal repeat (3 copies)
+PF06716	DUF1201	Protein of unknown function (DUF1201)
+PF06717	DUF1202	Protein of unknown function (DUF1202)
+PF06718	DUF1203	Protein of unknown function (DUF1203)
+PF06719	AraC_N	AraC-type transcriptional regulator N-terminus
+PF06720	Phi-29_GP16_7	Bacteriophage phi-29 early protein GP16.7
+PF06721	DUF1204	Protein of unknown function (DUF1204)
+PF06722	DUF1205	Protein of unknown function (DUF1205)
+PF06723	MreB_Mbl	MreB/Mbl protein
+PF06724	DUF1206	Domain of Unknown Function (DUF1206)
+PF06725	3D	3D domain
+PF06726	BC10	Bladder cancer-related protein BC10
+PF06727	DUF1207	Protein of unknown function (DUF1207)
+PF06728	PIG-U	GPI transamidase subunit PIG-U
+PF06729	CENP-R	Kinetochore component, CENP-R
+PF06730	FAM92	FAM92 protein
+PF06732	Pescadillo_N	Pescadillo N-terminus
+PF06733	DEAD_2	DEAD_2
+PF06734	UL97	UL97
+PF06736	DUF1211	Protein of unknown function (DUF1211)
+PF06737	Transglycosylas	Transglycosylase-like domain
+PF06738	ThrE	Putative threonine/serine exporter
+PF06739	SBBP	Beta-propeller repeat
+PF06740	DUF1213	Protein of unknown function (DUF1213)
+PF06741	LsmAD	LsmAD domain
+PF06742	DUF1214	Protein of unknown function (DUF1214)
+PF06743	FAST_1	FAST kinase-like protein, subdomain 1
+PF06744	IcmF_C	Type VI secretion protein IcmF C-terminal
+PF06745	ATPase	KaiC
+PF06746	DUF1216	Protein of unknown function (DUF1216)
+PF06747	CHCH	CHCH domain
+PF06748	DUF1217	Protein of unknown function (DUF1217)
+PF06749	DUF1218	Protein of unknown function (DUF1218)
+PF06750	DiS_P_DiS	Bacterial Peptidase A24 N-terminal domain
+PF06751	EutB	Ethanolamine ammonia lyase large subunit (EutB)
+PF06752	E_Pc_C	Enhancer of Polycomb C-terminus
+PF06753	Bradykinin	Bradykinin
+PF06754	PhnG	Phosphonate metabolism protein PhnG
+PF06755	CbtA_toxin	CbtA_toxin of type IV toxin-antitoxin system
+PF06756	S19	Chorion protein S19 C-terminal
+PF06757	Ins_allergen_rp	Insect allergen related repeat, nitrile-specifier detoxification
+PF06758	DUF1220	Repeat of unknown function (DUF1220)
+PF06760	DUF1221	Protein of unknown function (DUF1221)
+PF06761	IcmF-related	Intracellular multiplication and human macrophage-killing
+PF06762	LMF1	Lipase maturation factor
+PF06763	Minor_tail_Z	Prophage minor tail protein Z (GPZ)
+PF06764	DUF1223	Protein of unknown function (DUF1223)
+PF06766	Hydrophobin_2	Fungal hydrophobin
+PF06767	Sif	Sif protein
+PF06769	YoeB_toxin	YoeB-like toxin of bacterial type II toxin-antitoxin system
+PF06770	Arif-1	Actin-rearrangement-inducing factor (Arif-1)
+PF06771	Desmo_N	Viral Desmoplakin N-terminus
+PF06772	LtrA	Bacterial low temperature requirement A protein (LtrA)
+PF06773	Bim_N	Bim protein N-terminus
+PF06775	Seipin	Putative adipose-regulatory protein (Seipin)
+PF06776	IalB	Invasion associated locus B (IalB) protein
+PF06777	HBB	Helical and beta-bridge domain
+PF06778	Chlor_dismutase	Chlorite dismutase
+PF06779	MFS_4	Uncharacterised MFS-type transporter YbfB
+PF06780	Erp_C	Erp protein C-terminus
+PF06781	CrgA	Cell division protein CrgA
+PF06782	UPF0236	Uncharacterised protein family (UPF0236)
+PF06783	UPF0239	Uncharacterised protein family (UPF0239)
+PF06784	UPF0240	Uncharacterised protein family (UPF0240)
+PF06785	UPF0242	Uncharacterised protein family (UPF0242)
+PF06786	UPF0253	Uncharacterised protein family (UPF0253)
+PF06787	UPF0254	Uncharacterised protein family (UPF0254)
+PF06788	UPF0257	Uncharacterised protein family (UPF0257)
+PF06789	UPF0258	Uncharacterised protein family (UPF0258)
+PF06790	UPF0259	Uncharacterised protein family (UPF0259)
+PF06791	TMP_2	Prophage tail length tape measure protein
+PF06792	UPF0261	Uncharacterised protein family (UPF0261)
+PF06793	UPF0262	Uncharacterised protein family (UPF0262)
+PF06794	UPF0270	Uncharacterised protein family (UPF0270)
+PF06795	Erythrovirus_X	Erythrovirus X protein
+PF06796	NapE	Periplasmic nitrate reductase protein NapE
+PF06797	DUF1229	Protein of unknown function (DUF1229)
+PF06798	PrkA	PrkA serine protein kinase C-terminal domain
+PF06799	DUF1230	Protein of unknown function (DUF1230)
+PF06800	Sugar_transport	Sugar transport protein
+PF06802	DUF1231	Protein of unknown function (DUF1231)
+PF06803	DUF1232	Protein of unknown function (DUF1232)
+PF06804	Lipoprotein_18	NlpB/DapX lipoprotein
+PF06805	Lambda_tail_I	Bacteriophage lambda tail assembly protein I
+PF06806	DUF1233	Putative excisionase (DUF1233)
+PF06807	Clp1	Pre-mRNA cleavage complex II protein Clp1
+PF06808	DctM	Tripartite ATP-independent periplasmic transporter, DctM component
+PF06809	NPDC1	Neural proliferation differentiation control-1 protein (NPDC1)
+PF06810	Phage_GP20	Phage minor structural protein GP20
+PF06812	ImpA_N	ImpA, N-terminal, type VI secretion system
+PF06813	Nodulin-like	Nodulin-like
+PF06814	Lung_7-TM_R	Lung seven transmembrane receptor
+PF06815	RVT_connect	Reverse transcriptase connection domain
+PF06816	NOD	NOTCH protein
+PF06817	RVT_thumb	Reverse transcriptase thumb domain
+PF06818	Fez1	Fez1
+PF06819	Arc_PepC	Archaeal Peptidase A24 C-terminal Domain
+PF06820	Phage_fiber_C	Putative prophage tail fibre C-terminus
+PF06821	Ser_hydrolase	Serine hydrolase
+PF06822	DUF1235	Protein of unknown function (DUF1235)
+PF06823	DUF1236	Protein of unknown function (DUF1236)
+PF06824	Glyco_hydro_125	Metal-independent alpha-mannosidase (GH125)
+PF06825	HSBP1	Heat shock factor binding protein 1
+PF06826	Asp-Al_Ex	Predicted Permease Membrane Region
+PF06827	zf-FPG_IleRS	Zinc finger found in FPG and IleRS
+PF06830	Root_cap	Root cap
+PF06831	H2TH	Formamidopyrimidine-DNA glycosylase H2TH domain
+PF06832	BiPBP_C	Penicillin-Binding Protein C-terminus Family
+PF06833	MdcE	Malonate decarboxylase gamma subunit (MdcE)
+PF06834	TraU	TraU protein
+PF06835	LptC	Lipopolysaccharide-assembly, LptC-related
+PF06836	DUF1240	Protein of unknown function (DUF1240)
+PF06837	Fijivirus_P9-2	Fijivirus P9-2 protein
+PF06838	Met_gamma_lyase	Methionine gamma-lyase 
+PF06839	zf-GRF	GRF zinc finger
+PF06840	DUF1241	Protein of unknown function (DUF1241)
+PF06841	Phage_T4_gp19	T4-like virus tail tube protein gp19
+PF06842	DUF1242	Protein of unknown function (DUF1242)
+PF06844	DUF1244	Protein of unknown function (DUF1244)
+PF06847	Arc_PepC_II	Archaeal Peptidase A24 C-terminus Type II
+PF06848	Disaggr_repeat	Disaggregatase related repeat
+PF06849	DUF1246	Protein of unknown function (DUF1246)
+PF06850	PHB_depo_C	PHB de-polymerase C-terminus
+PF06851	DUF1247	Protein of unknown function (DUF1247)
+PF06852	DUF1248	Protein of unknown function (DUF1248)
+PF06853	DUF1249	Protein of unknown function (DUF1249)
+PF06854	Phage_Gp15	Bacteriophage Gp15 protein
+PF06855	YozE_SAM_like	YozE SAM-like fold
+PF06856	DUF1251	Protein of unknown function (DUF1251)
+PF06857	ACP	Malonate decarboxylase delta subunit (MdcD)
+PF06858	NOG1	Nucleolar GTP-binding protein 1 (NOG1)
+PF06859	Bin3	Bicoid-interacting protein 3 (Bin3)
+PF06861	BALF1	BALF1 protein
+PF06862	UTP25	Utp25, U3 small nucleolar RNA-associated SSU processome protein 25
+PF06863	DUF1254	Protein of unknown function (DUF1254)
+PF06864	PAP_PilO	Pilin accessory protein (PilO)
+PF06865	DUF1255	Protein of unknown function (DUF1255)
+PF06866	DUF1256	Protein of unknown function (DUF1256)
+PF06868	DUF1257	Protein of unknown function (DUF1257)
+PF06869	DUF1258	Protein of unknown function (DUF1258)
+PF06870	RNA_pol_I_A49	A49-like RNA polymerase I associated factor 
+PF06871	TraH_2	TraH_2
+PF06872	EspG	EspG protein
+PF06873	SerH	Cell surface immobilisation antigen SerH
+PF06874	FBPase_2	Firmicute fructose-1,6-bisphosphatase
+PF06875	PRF	Plethodontid receptivity factor PRF
+PF06876	SCRL	Plant self-incompatibility response (SCRL) protein
+PF06877	RraB	Regulator of ribonuclease activity B
+PF06878	Pkip-1	Pkip-1 protein
+PF06880	DUF1262	Protein of unknown function (DUF1262)
+PF06881	Elongin_A	RNA polymerase II transcription factor SIII (Elongin) subunit A
+PF06882	DUF1263	Protein of unknown function (DUF1263)
+PF06883	RNA_pol_Rpa2_4	RNA polymerase I, Rpa2 specific domain 
+PF06884	DUF1264	Protein of unknown function (DUF1264)
+PF06886	TPX2	Targeting protein for Xklp2 (TPX2)
+PF06887	DUF1265	Protein of unknown function (DUF1265)
+PF06888	Put_Phosphatase	Putative Phosphatase
+PF06889	DUF1266	Protein of unknown function (DUF1266)
+PF06890	Phage_Mu_Gp45	Bacteriophage Mu Gp45 protein
+PF06891	P2_Phage_GpR	P2 phage tail completion protein R (GpR)
+PF06892	Phage_CP76	Phage regulatory protein CII (CP76)
+PF06894	Phage_TAC_2	Bacteriophage lambda tail assembly chaperone, TAC, protein G
+PF06896	Phage_TAC_3	Phage tail assembly chaperone proteins, TAC
+PF06897	DUF1269	Protein of unknown function (DUF1269)
+PF06898	YqfD	Putative stage IV sporulation protein YqfD
+PF06899	WzyE	WzyE protein, O-antigen assembly polymerase
+PF06900	DUF1270	Protein of unknown function (DUF1270)
+PF06901	FrpC	RTX iron-regulated protein FrpC
+PF06902	Fer4_19	Divergent 4Fe-4S mono-cluster
+PF06903	VirK	VirK protein
+PF06904	Extensin-like_C	Extensin-like protein C-terminus
+PF06905	FAIM1	Fas apoptotic inhibitory molecule (FAIM1)
+PF06906	DUF1272	Protein of unknown function (DUF1272)
+PF06907	Latexin	Latexin
+PF06908	DUF1273	Protein of unknown function (DUF1273)
+PF06910	MEA1	Male enhanced antigen 1 (MEA1)
+PF06911	Senescence	Senescence-associated protein
+PF06912	DUF1275	Protein of unknown function (DUF1275)
+PF06916	DUF1279	Protein of unknown function (DUF1279)
+PF06917	Pectate_lyase_2	Periplasmic pectate lyase
+PF06918	DUF1280	Protein of unknown function (DUF1280)
+PF06919	Phage_T4_Gp30_7	Phage Gp30.7 protein
+PF06920	DHR-2	Dock homology region 2
+PF06922	CTV_P13	Citrus tristeza virus P13 protein
+PF06923	GutM	Glucitol operon activator protein (GutM)
+PF06924	DUF1281	Protein of unknown function (DUF1281)
+PF06925	MGDG_synth	Monogalactosyldiacylglycerol (MGDG) synthase
+PF06926	Rep_Org_C	Putative replisome organiser protein C-terminus
+PF06929	Rotavirus_VP3	Rotavirus VP3 protein
+PF06930	DUF1282	Protein of unknown function (DUF1282)
+PF06931	Adeno_E4_ORF3	Mastadenovirus E4 ORF3 protein
+PF06932	DUF1283	Protein of unknown function (DUF1283)
+PF06933	SSP160	Special lobe-specific silk protein SSP160
+PF06934	CTI	Fatty acid cis/trans isomerase (CTI)
+PF06935	DUF1284	Protein of unknown function (DUF1284)
+PF06936	Selenoprotein_S	Selenoprotein S (SelS)
+PF06937	EURL	EURL protein
+PF06938	DUF1285	Protein of unknown function (DUF1285)
+PF06939	DUF1286	Protein of unknown function (DUF1286)
+PF06940	DUF1287	Domain of unknown function (DUF1287)
+PF06941	NT5C	5' nucleotidase, deoxy (Pyrimidine), cytosolic type C protein (NT5C)
+PF06942	GlpM	GlpM protein
+PF06943	zf-LSD1	LSD1 zinc finger
+PF06945	DUF1289	Protein of unknown function (DUF1289)
+PF06946	Phage_holin_5_1	Bacteriophage A118-like holin, Hol118
+PF06947	DUF1290	Protein of unknown function (DUF1290)
+PF06949	DUF1292	Protein of unknown function (DUF1292)
+PF06950	DUF1293	Protein of unknown function (DUF1293)
+PF06951	PLA2G12	Group XII secretory phospholipase A2 precursor (PLA2G12)
+PF06952	PsiA	PsiA protein
+PF06953	ArsD	Arsenical resistance operon trans-acting repressor ArsD
+PF06954	Resistin	Resistin
+PF06955	XET_C	Xyloglucan endo-transglycosylase (XET) C-terminus
+PF06956	RtcR	Regulator of RNA terminal phosphate cyclase
+PF06957	COPI_C	Coatomer (COPI) alpha subunit C-terminus
+PF06958	Pyocin_S	S-type Pyocin
+PF06959	RecQ5	RecQ helicase protein-like 5 (RecQ5)
+PF06961	DUF1294	Protein of unknown function (DUF1294)
+PF06962	rRNA_methylase	Putative rRNA methylase
+PF06963	FPN1	Ferroportin1 (FPN1)
+PF06964	Alpha-L-AF_C	Alpha-L-arabinofuranosidase C-terminal domain
+PF06965	Na_H_antiport_1	Na+/H+ antiporter 1
+PF06966	DUF1295	Protein of unknown function (DUF1295)
+PF06967	Mo-nitro_C	Mo-dependent nitrogenase C-terminus
+PF06968	BATS	Biotin and Thiamin Synthesis associated domain
+PF06969	HemN_C	HemN C-terminal domain
+PF06970	RepA_N	Replication initiator protein A (RepA) N-terminus
+PF06971	Put_DNA-bind_N	Putative DNA-binding protein N-terminus
+PF06972	DUF1296	Protein of unknown function (DUF1296)
+PF06973	DUF1297	Domain of unknown function (DUF1297)
+PF06974	DUF1298	Protein of unknown function (DUF1298)
+PF06975	DUF1299	Protein of unknown function (DUF1299)
+PF06977	SdiA-regulated	SdiA-regulated
+PF06978	POP1	Ribonucleases P/MRP protein subunit POP1
+PF06979	TMEM70	Assembly, mitochondrial proton-transport ATP synth complex
+PF06980	DUF1302	Protein of unknown function (DUF1302)
+PF06983	3-dmu-9_3-mt	3-demethylubiquinone-9 3-methyltransferase
+PF06984	MRP-L47	Mitochondrial 39-S ribosomal protein L47 (MRP-L47)
+PF06985	HET	Heterokaryon incompatibility protein (HET)
+PF06986	TraN	Type-1V conjugative transfer system mating pair stabilisation
+PF06988	NifT	NifT/FixU protein
+PF06989	BAALC_N	BAALC N-terminus
+PF06990	Gal-3-0_sulfotr	Galactose-3-O-sulfotransferase 
+PF06991	MFAP1	Microfibril-associated/Pre-mRNA processing
+PF06992	Phage_lambda_P	Replication protein P
+PF06993	DUF1304	Protein of unknown function (DUF1304)
+PF06994	Involucrin2	Involucrin
+PF06995	Phage_P2_GpU	Phage P2 GpU
+PF06996	T6SS_TssG	Type VI secretion, TssG
+PF06998	DUF1307	Protein of unknown function (DUF1307)
+PF06999	Suc_Fer-like	Sucrase/ferredoxin-like
+PF07000	DUF1308	Protein of unknown function (DUF1308)
+PF07001	BAT2_N	BAT2 N-terminus
+PF07002	Copine	Copine
+PF07004	SHIPPO-rpt	Sperm-tail PG-rich repeat
+PF07005	DUF1537	Putative sugar-binding N-terminal domain
+PF07006	DUF1310	Protein of unknown function (DUF1310)
+PF07007	LprI	Lysozyme inhibitor LprI
+PF07009	NusG_II	NusG domain II
+PF07010	Endomucin	Endomucin
+PF07011	DUF1313	Protein of unknown function (DUF1313)
+PF07012	Curlin_rpt	Curlin associated repeat
+PF07013	DUF1314	Protein of unknown function (DUF1314)
+PF07014	Hs1pro-1_C	Hs1pro-1 protein C-terminus
+PF07015	VirC1	VirC1 protein
+PF07016	CRAM_rpt	Cysteine-rich acidic integral membrane protein precursor
+PF07017	PagP	Antimicrobial peptide resistance and lipid A acylation protein PagP
+PF07019	Rab5ip	Rab5-interacting protein (Rab5ip)
+PF07020	Orthopox_C10L	Orthopoxvirus C10L protein
+PF07021	MetW	Methionine biosynthesis protein MetW
+PF07022	Phage_CI_repr	Bacteriophage CI repressor helix-turn-helix domain
+PF07023	DUF1315	Protein of unknown function (DUF1315)
+PF07024	ImpE	ImpE protein
+PF07026	DUF1317	Protein of unknown function (DUF1317)
+PF07027	DUF1318	Protein of unknown function (DUF1318)
+PF07028	DUF1319	Protein of unknown function (DUF1319)
+PF07029	CryBP1	CryBP1 protein
+PF07030	DUF1320	Protein of unknown function (DUF1320)
+PF07032	DUF1322	Protein of unknown function (DUF1322)
+PF07033	Orthopox_B11R	Orthopoxvirus B11R protein
+PF07034	ORC3_N	Origin recognition complex (ORC) subunit 3 N-terminus
+PF07035	Mic1	Colon cancer-associated protein Mic1-like
+PF07037	DUF1323	Putative transcription regulator (DUF1323)
+PF07038	DUF1324	Protein of unknown function (DUF1324)
+PF07039	DUF1325	SGF29 tudor-like domain
+PF07040	DUF1326	Protein of unknown function (DUF1326)
+PF07041	DUF1327	Protein of unknown function (DUF1327)
+PF07042	TrfA	TrfA protein
+PF07043	DUF1328	Protein of unknown function (DUF1328)
+PF07044	DUF1329	Protein of unknown function (DUF1329)
+PF07045	DUF1330	Domain of unknown function (DUF1330)
+PF07046	CRA_rpt	Cytoplasmic repetitive antigen (CRA) like repeat
+PF07047	OPA3	Optic atrophy 3 protein (OPA3)
+PF07048	DUF1331	Protein of unknown function (DUF1331)
+PF07051	OCIA	Ovarian carcinoma immunoreactive antigen (OCIA)
+PF07052	Hep_59	Hepatocellular carcinoma-associated antigen 59
+PF07054	Pericardin_rpt	Pericardin like repeat
+PF07055	Eno-Rase_FAD_bd	Enoyl reductase FAD binding domain
+PF07056	DUF1335	Protein of unknown function (DUF1335)
+PF07057	TraI	DNA helicase TraI
+PF07058	MAP70	Microtubule-associated protein 70
+PF07059	DUF1336	Protein of unknown function (DUF1336)
+PF07061	Swi5	Swi5
+PF07062	Clc-like	Clc-like
+PF07063	DUF1338	Domain of unknown function (DUF1338)
+PF07064	RIC1	RIC1
+PF07065	D123	D123
+PF07066	DUF3882	Lactococcus phage M3 protein
+PF07067	DUF1340	Protein of unknown function (DUF1340)
+PF07068	Gp23	Major capsid protein Gp23
+PF07069	PRRSV_2b	Porcine reproductive and respiratory syndrome virus 2b 
+PF07070	Spo0M	SpoOM protein
+PF07071	KDGP_aldolase	KDGP aldolase
+PF07072	ZapD	Cell division protein
+PF07073	ROF	Modulator of Rho-dependent transcription termination (ROF)
+PF07074	TRAP-gamma	Translocon-associated protein, gamma subunit (TRAP-gamma)
+PF07075	DUF1343	Protein of unknown function (DUF1343)
+PF07076	DUF1344	Protein of unknown function (DUF1344)
+PF07077	DUF1345	Protein of unknown function (DUF1345)
+PF07078	FYTT	Forty-two-three protein
+PF07079	DUF1347	Protein of unknown function (DUF1347)
+PF07080	DUF1348	Protein of unknown function (DUF1348)
+PF07081	DUF1349	Protein of unknown function (DUF1349)
+PF07082	DUF1350	Protein of unknown function (DUF1350)
+PF07083	DUF1351	Protein of unknown function (DUF1351)
+PF07084	Spot_14	Thyroid hormone-inducible hepatic protein Spot 14
+PF07085	DRTGG	DRTGG domain
+PF07086	Jagunal	Jagunal, ER re-organisation during oogenesis
+PF07087	DUF1353	Protein of unknown function (DUF1353)
+PF07088	GvpD	GvpD gas vesicle protein
+PF07090	GATase1_like	Putative glutamine amidotransferase
+PF07091	FmrO	Ribosomal RNA methyltransferase (FmrO)
+PF07092	DUF1356	Protein of unknown function (DUF1356)
+PF07093	SGT1	SGT1 protein
+PF07094	DUF1357	Protein of unknown function (DUF1357)
+PF07095	IgaA	Intracellular growth attenuator protein IgaA
+PF07096	DUF1358	Protein of unknown function (DUF1358)
+PF07097	DUF1359	Protein of unknown function (DUF1359)
+PF07098	DUF1360	Protein of unknown function (DUF1360)
+PF07099	DUF1361	Protein of unknown function (DUF1361)
+PF07100	ASRT	Anabaena sensory rhodopsin transducer
+PF07101	DUF1363	Protein of unknown function (DUF1363)
+PF07102	DUF1364	Protein of unknown function (DUF1364)
+PF07103	DUF1365	Protein of unknown function (DUF1365)
+PF07104	DUF1366	Protein of unknown function (DUF1366)
+PF07105	DUF1367	Protein of unknown function (DUF1367)
+PF07106	TBPIP	Tat binding protein 1(TBP-1)-interacting protein (TBPIP)
+PF07107	WI12	Wound-induced protein WI12
+PF07108	PipA	PipA protein
+PF07109	Mg-por_mtran_C	Magnesium-protoporphyrin IX methyltransferase C-terminus
+PF07110	EthD	EthD domain
+PF07111	HCR	Alpha helical coiled-coil rod protein (HCR)
+PF07112	DUF1368	Protein of unknown function (DUF1368)
+PF07114	TMEM126	Transmembrane protein 126 
+PF07116	DUF1372	Protein of unknown function (DUF1372)
+PF07117	DUF1373	Protein of unknown function (DUF1373)
+PF07118	DUF1374	Protein of unknown function (DUF1374)
+PF07119	DUF1375	Protein of unknown function (DUF1375)
+PF07120	DUF1376	Protein of unknown function (DUF1376)
+PF07122	VLPT	Variable length PCR target protein (VLPT)
+PF07123	PsbW	Photosystem II reaction centre W protein (PsbW)
+PF07124	Phytoreo_P8	Phytoreovirus outer capsid protein P8
+PF07125	DUF1378	Protein of unknown function (DUF1378)
+PF07126	ZapC	Cell-division protein ZapC
+PF07127	Nodulin_late	Late nodulin protein
+PF07128	DUF1380	Protein of unknown function (DUF1380)
+PF07129	DUF1381	Protein of unknown function (DUF1381)
+PF07130	YebG	YebG protein
+PF07131	DUF1382	Protein of unknown function (DUF1382)
+PF07133	Merozoite_SPAM	Merozoite surface protein (SPAM)
+PF07134	DUF1383	Protein of unknown function (DUF1383)
+PF07136	DUF1385	Protein of unknown function (DUF1385)
+PF07137	VDE	VDE lipocalin domain
+PF07138	DUF1386	Protein of unknown function (DUF1386)
+PF07139	DUF1387	Protein of unknown function (DUF1387)
+PF07140	IFNGR1	Interferon gamma receptor (IFNGR1)
+PF07141	Phage_term_sma	Putative bacteriophage terminase small subunit
+PF07142	DUF1388	Repeat of unknown function (DUF1388)
+PF07143	CrtC	CrtC N-terminal lipocalin domain
+PF07145	PAM2	Ataxin-2 C-terminal region
+PF07146	DUF1389	Protein of unknown function (DUF1389)
+PF07147	PDCD9	Mitochondrial 28S ribosomal protein S30 (PDCD9)
+PF07148	MalM	Maltose operon periplasmic protein precursor (MalM)
+PF07149	Pes-10	Pes-10
+PF07150	DUF1390	Protein of unknown function (DUF1390)
+PF07151	DUF1391	Protein of unknown function (DUF1391)
+PF07152	YaeQ	YaeQ protein
+PF07153	Marek_SORF3	Marek's disease-like virus SORF3 protein
+PF07154	DUF1392	Protein of unknown function (DUF1392)
+PF07155	ECF-ribofla_trS	ECF-type riboflavin transporter, S component
+PF07156	Prenylcys_lyase	Prenylcysteine lyase
+PF07157	DNA_circ_N	DNA circularisation protein N-terminus
+PF07158	MatC_N	Dicarboxylate carrier protein MatC N-terminus
+PF07159	DUF1394	Protein of unknown function (DUF1394)
+PF07160	SKA1	Spindle and kinetochore-associated protein 1 
+PF07161	LppX_LprAFG	LppX_LprAFG lipoprotein
+PF07162	B9-C2	Ciliary basal body-associated, B9 protein
+PF07163	Pex26	Pex26 protein
+PF07165	DUF1397	Protein of unknown function (DUF1397)
+PF07166	DUF1398	Protein of unknown function (DUF1398)
+PF07167	PhaC_N	Poly-beta-hydroxybutyrate polymerase (PhaC) N-terminus
+PF07168	Ureide_permease	Ureide permease
+PF07171	MlrC_C	MlrC C-terminus
+PF07172	GRP	Glycine rich protein family
+PF07173	GRDP-like	Glycine-rich domain-containing protein-like 
+PF07174	FAP	Fibronectin-attachment protein (FAP)
+PF07175	Osteoregulin	Osteoregulin
+PF07176	DUF1400	Alpha/beta hydrolase of unknown function (DUF1400)
+PF07177	Neuralized	Neuralized
+PF07178	TraL	TraL protein
+PF07179	SseB	SseB protein N-terminal domain
+PF07180	CaiF_GrlA	CaiF/GrlA transcriptional regulator
+PF07181	VirC2	VirC2 protein
+PF07182	DUF1402	Protein of unknown function (DUF1402)
+PF07183	DUF1403	Protein of unknown function (DUF1403)
+PF07184	CTV_P33	Citrus tristeza virus P33 protein
+PF07185	DUF1404	Protein of unknown function (DUF1404)
+PF07187	DUF1405	Protein of unknown function (DUF1405)
+PF07188	KSHV_K8	Kaposi's sarcoma-associated herpesvirus (KSHV) K8 protein
+PF07189	SF3b10	Splicing factor 3B subunit 10 (SF3b10)
+PF07190	DUF1406	Protein of unknown function (DUF1406)
+PF07191	zinc-ribbons_6	zinc-ribbons
+PF07192	SNURF	SNURF/RPN4 protein
+PF07193	DUF1408	Protein of unknown function (DUF1408)
+PF07194	P2	P2 response regulator binding domain
+PF07195	FliD_C	Flagellar hook-associated protein 2 C-terminus
+PF07196	Flagellin_IN	Flagellin hook IN motif
+PF07197	DUF1409	Protein of unknown function (DUF1409)
+PF07198	DUF1410	Protein of unknown function (DUF1410)
+PF07199	DUF1411	Protein of unknown function (DUF1411)
+PF07200	Mod_r	Modifier of rudimentary (Mod(r)) protein
+PF07201	HrpJ	HrpJ-like domain
+PF07202	Tcp10_C	T-complex protein 10 C-terminus
+PF07203	DUF1412	Protein of unknown function (DUF1412)
+PF07204	Orthoreo_P10	Orthoreovirus membrane fusion protein p10
+PF07205	DUF1413	Domain of unknown function (DUF1413)
+PF07206	Baculo_LEF-10	Baculovirus late expression factor 10 (LEF-10)
+PF07207	Lir1	Light regulated protein Lir1
+PF07208	DUF1414	Protein of unknown function (DUF1414)
+PF07209	DUF1415	Protein of unknown function (DUF1415)
+PF07210	DUF1416	Protein of unknown function (DUF1416)
+PF07212	Hyaluronidase_1	Hyaluronidase protein (HylP)
+PF07213	DAP10	DAP10 membrane protein
+PF07214	DUF1418	Protein of unknown function (DUF1418)
+PF07215	DUF1419	Protein of unknown function (DUF1419)
+PF07216	LcrG	LcrG protein
+PF07217	Het-C	Heterokaryon incompatibility protein Het-C
+PF07218	RAP1	Rhoptry-associated protein 1 (RAP-1)
+PF07219	HemY_N	HemY protein N-terminus
+PF07220	DUF1420	Protein of unknown function (DUF1420)
+PF07221	GlcNAc_2-epim	N-acylglucosamine 2-epimerase (GlcNAc 2-epimerase)
+PF07222	PBP_sp32	Proacrosin binding protein sp32
+PF07223	DUF1421	UBA-like domain (DUF1421)
+PF07224	Chlorophyllase	Chlorophyllase
+PF07225	NDUF_B4	NADH-ubiquinone oxidoreductase B15 subunit (NDUFB4)
+PF07226	DUF1422	Protein of unknown function (DUF1422)
+PF07227	PHD_Oberon	PHD - plant homeodomain finger protein
+PF07228	SpoIIE	Stage II sporulation protein E (SpoIIE)
+PF07229	VirE2	VirE2
+PF07230	Peptidase_S80	Bacteriophage T4-like capsid assembly protein (Gp20)
+PF07231	Hs1pro-1_N	Hs1pro-1 N-terminus
+PF07232	DUF1424	Putative rep protein (DUF1424)
+PF07233	DUF1425	Protein of unknown function (DUF1425)
+PF07234	Babuvirus_MP	Movement and RNA silencing protein
+PF07235	DUF1427	Protein of unknown function (DUF1427)
+PF07236	Phytoreo_S7	Phytoreovirus S7 protein
+PF07237	DUF1428	Protein of unknown function (DUF1428)
+PF07238	PilZ	PilZ domain
+PF07239	OpcA	Outer membrane protein OpcA
+PF07240	Turandot	Stress-inducible humoral factor Turandot
+PF07242	DUF1430	Protein of unknown function (DUF1430)
+PF07243	Phlebovirus_G1	Phlebovirus glycoprotein G1
+PF07244	POTRA	Surface antigen variable number repeat
+PF07245	Phlebovirus_G2	Phlebovirus glycoprotein G2
+PF07246	Phlebovirus_NSM	Phlebovirus nonstructural protein NS-M
+PF07247	AATase	Alcohol acetyltransferase
+PF07248	DUF1431	Protein of unknown function (DUF1431)
+PF07249	Cerato-platanin	Cerato-platanin
+PF07250	Glyoxal_oxid_N	Glyoxal oxidase N-terminus
+PF07252	DUF1433	Protein of unknown function (DUF1433)
+PF07253	Gypsy	Gypsy protein
+PF07254	Cpta_toxin	Membrane-bound toxin component of toxin-antitoxin system
+PF07255	Benyvirus_14KDa	Benyvirus 14KDa protein
+PF07256	DUF1435	Protein of unknown function (DUF1435)
+PF07258	COMM_domain	COMM domain
+PF07259	ProSAAS	ProSAAS precursor
+PF07260	ANKH	Progressive ankylosis protein (ANKH)
+PF07261	DnaB_2	Replication initiation and membrane attachment
+PF07262	CdiI	CDI immunity protein
+PF07263	DMP1	Dentin matrix protein 1 (DMP1)
+PF07264	EI24	Etoposide-induced protein 2.4 (EI24)
+PF07265	TAP35_44	Tapetum specific protein TAP35/TAP44
+PF07267	Nucleo_P87	Nucleopolyhedrovirus capsid protein P87
+PF07268	EppA_BapA	Exported protein precursor (EppA/BapA)
+PF07270	DUF1438	Protein of unknown function (DUF1438)
+PF07271	Cytadhesin_P30	Cytadhesin P30/P32
+PF07272	Orthoreo_P17	Orthoreovirus P17 protein
+PF07273	DUF1439	Protein of unknown function (DUF1439)
+PF07274	DUF1440	Protein of unknown function (DUF1440)
+PF07275	ArdA	Antirestriction protein (ArdA)
+PF07276	PSGP	Apopolysialoglycoprotein (PSGP)
+PF07277	SapC	SapC
+PF07278	DUF1441	Protein of unknown function (DUF1441)
+PF07279	DUF1442	Protein of unknown function (DUF1442)
+PF07280	Ac110_PIF	Per os infectivity factor AC110
+PF07281	INSIG	Insulin-induced protein (INSIG)
+PF07282	OrfB_Zn_ribbon	Putative transposase DNA-binding domain
+PF07283	TrbH	Conjugal transfer protein TrbH
+PF07284	BCHF	2-vinyl bacteriochlorophyllide hydratase (BCHF)
+PF07285	DUF1444	Protein of unknown function (DUF1444)
+PF07286	DUF1445	Protein of unknown function (DUF1445)
+PF07287	AtuA	Acyclic terpene utilisation family protein AtuA
+PF07288	DUF1447	Protein of unknown function (DUF1447)
+PF07289	BBL5	Bardet-Biedl syndrome 5 protein 
+PF07290	DUF1449	Protein of unknown function (DUF1449)
+PF07291	MauE	Methylamine utilisation protein MauE
+PF07292	NID	Nmi/IFP 35 domain (NID)
+PF07293	DUF1450	Protein of unknown function (DUF1450)
+PF07294	Fibroin_P25	Fibroin P25
+PF07295	DUF1451	Zinc-ribbon containing domain
+PF07296	TraP	TraP protein
+PF07297	DPM2	Dolichol phosphate-mannose biosynthesis regulatory protein (DPM2)
+PF07298	NnrU	NnrU protein
+PF07299	EF-G-binding_N	Elongation factor G-binding protein, N-terminal
+PF07301	DUF1453	Protein of unknown function (DUF1453)
+PF07302	AroM	AroM protein
+PF07303	Occludin_ELL	Occludin homology domain
+PF07304	SRA1	Steroid receptor RNA activator (SRA1)
+PF07305	DUF1454	Protein of unknown function (DUF1454)
+PF07306	DUF1455	Protein of unknown function (DUF1455)
+PF07307	HEPPP_synt_1	Heptaprenyl diphosphate synthase (HEPPP synthase) subunit 1
+PF07308	DUF1456	Protein of unknown function (DUF1456)
+PF07309	FlaF	Flagellar protein FlaF
+PF07310	PAS_5	PAS domain
+PF07311	Dodecin	Dodecin
+PF07312	DUF1459	Protein of unknown function (DUF1459)
+PF07313	DUF1460	Protein of unknown function (DUF1460)
+PF07314	DUF1461	Protein of unknown function (DUF1461)
+PF07315	DUF1462	Protein of unknown function (DUF1462)
+PF07316	DUF1463	Protein of unknown function (DUF1463)
+PF07317	YcgR	Flagellar regulator YcgR
+PF07318	DUF1464	Protein of unknown function (DUF1464)
+PF07319	DnaI_N	Primosomal protein DnaI N-terminus
+PF07321	YscO	Type III secretion protein YscO
+PF07322	Seadorna_Vp10	Seadornavirus Vp10
+PF07323	DUF1465	Protein of unknown function (DUF1465)
+PF07324	DGCR6	DiGeorge syndrome critical region 6 (DGCR6) protein
+PF07325	Curto_V2	Curtovirus V2 protein
+PF07326	DUF1466	Protein of unknown function (DUF1466)
+PF07327	Neuroparsin	Neuroparsin
+PF07328	VirD1	T-DNA border endonuclease VirD1
+PF07330	DUF1467	Protein of unknown function (DUF1467)
+PF07331	TctB	Tripartite tricarboxylate transporter TctB family
+PF07332	Phage_holin_3_6	Putative Actinobacterial Holin-X, holin superfamily III
+PF07333	SLR1-BP	S locus-related glycoprotein 1 binding pollen coat protein (SLR1-BP)
+PF07334	IFP_35_N	Interferon-induced 35 kDa protein (IFP 35) N-terminus
+PF07335	Glyco_hydro_75	Fungal chitosanase of glycosyl hydrolase group 75
+PF07336	ABATE	Putative stress-induced transcription regulator
+PF07337	CagY_M	DC-EC Repeat
+PF07338	DUF1471	Protein of unknown function (DUF1471)
+PF07339	DUF1472	Protein of unknown function (DUF1472)
+PF07340	Herpes_IE1	Cytomegalovirus IE1 protein
+PF07341	DUF1473	Protein of unknown function (DUF1473)
+PF07342	DUF1474	Protein of unknown function (DUF1474)
+PF07343	DUF1475	Protein of unknown function (DUF1475)
+PF07344	Amastin	Amastin surface glycoprotein
+PF07345	DUF1476	Domain of unknown function (DUF1476)
+PF07346	DUF1477	Protein of unknown function (DUF1477)
+PF07347	CI-B14_5a	NADH:ubiquinone oxidoreductase subunit B14.5a (Complex I-B14.5a)
+PF07348	Syd	Syd protein (SUKH-2)
+PF07349	DUF1478	Protein of unknown function (DUF1478)
+PF07350	DUF1479	Protein of unknown function (DUF1479)
+PF07351	DUF1480	Protein of unknown function (DUF1480)
+PF07352	Phage_Mu_Gam	Bacteriophage Mu Gam like protein
+PF07353	Uroplakin_II	Uroplakin II
+PF07354	Sp38	Zona-pellucida-binding protein (Sp38)
+PF07355	GRDB	Glycine/sarcosine/betaine reductase selenoprotein B (GRDB)
+PF07356	DUF1481	Protein of unknown function (DUF1481)
+PF07357	DRAT	Dinitrogenase reductase ADP-ribosyltransferase (DRAT)
+PF07358	DUF1482	Protein of unknown function (DUF1482)
+PF07359	LEAP-2	Liver-expressed antimicrobial peptide 2 precursor (LEAP-2)
+PF07361	Cytochrom_B562	Cytochrome b562
+PF07362	CcdA	Post-segregation antitoxin CcdA
+PF07363	DUF1484	Protein of unknown function (DUF1484)
+PF07364	DUF1485	Metallopeptidase family M81
+PF07365	Toxin_8	Alpha conotoxin precursor
+PF07366	SnoaL	SnoaL-like polyketide cyclase
+PF07367	FB_lectin	Fungal fruit body lectin
+PF07368	DUF1487	Protein of unknown function (DUF1487)
+PF07369	DUF1488	Protein of unknown function (DUF1488)
+PF07370	DUF1489	Protein of unknown function (DUF1489)
+PF07371	DUF1490	Protein of unknown function (DUF1490)
+PF07372	DUF1491	Protein of unknown function (DUF1491)
+PF07373	CAMP_factor	CAMP factor (Cfa)
+PF07374	DUF1492	Protein of unknown function (DUF1492)
+PF07376	Prosystemin	Prosystemin
+PF07377	DUF1493	Protein of unknown function (DUF1493)
+PF07378	FlbT	Flagellar protein FlbT
+PF07379	DUF1494	Protein of unknown function (DUF1494)
+PF07380	Pneumo_M2	Pneumovirus M2 protein
+PF07381	DUF1495	Winged helix DNA-binding domain (DUF1495)
+PF07382	HC2	Histone H1-like nucleoprotein HC2
+PF07383	DUF1496	Protein of unknown function (DUF1496)
+PF07384	DUF1497	Protein of unknown function (DUF1497)
+PF07385	Lyx_isomer	D-lyxose isomerase
+PF07386	DUF1499	Protein of unknown function (DUF1499)
+PF07387	Seadorna_VP7	Seadornavirus VP7
+PF07388	A-2_8-polyST	Alpha-2,8-polysialyltransferase (POLYST)
+PF07389	DUF1500	Protein of unknown function (DUF1500)
+PF07390	P30	Mycoplasma P30 protein
+PF07391	NPR	NPR nonapeptide repeat (2 copies)
+PF07392	P19Arf_N	Cyclin-dependent kinase inhibitor 2a p19Arf N-terminus
+PF07393	Sec10	Exocyst complex component Sec10
+PF07394	DUF1501	Protein of unknown function (DUF1501)
+PF07395	Mig-14	Mig-14
+PF07396	Porin_O_P	Phosphate-selective porin O and P
+PF07397	DUF1502	Repeat of unknown function (DUF1502)
+PF07398	MDMPI_C	MDMPI C-terminal domain
+PF07399	Na_H_antiport_3	Putative Na+/H+ antiporter
+PF07400	IL11	Interleukin 11
+PF07401	Lenti_VIF_2	Bovine Lentivirus VIF protein
+PF07402	Herpes_U26	Human herpesvirus U26 protein
+PF07403	DUF1505	Protein of unknown function (DUF1505)
+PF07404	TEBP_beta	Telomere-binding protein beta subunit (TEBP beta)
+PF07405	DUF1506	Protein of unknown function (DUF1506)
+PF07406	NICE-3	NICE-3 protein
+PF07407	Seadorna_VP6	Seadornavirus VP6 protein
+PF07408	DUF1507	Protein of unknown function (DUF1507)
+PF07409	GP46	Phage protein GP46
+PF07410	Phage_Gp111	Streptococcus thermophilus bacteriophage Gp111 protein
+PF07411	DUF1508	Domain of unknown function (DUF1508)
+PF07412	Geminin	Geminin
+PF07413	Herpes_UL37_2	Betaherpesvirus immediate-early glycoprotein UL37
+PF07415	Herpes_LMP2	Gammaherpesvirus latent membrane protein (LMP2) protein
+PF07416	Crinivirus_P26	Crinivirus P26 protein
+PF07417	Crl	Transcriptional regulator Crl
+PF07418	PCEMA1	Acidic phosphoprotein precursor PCEMA1
+PF07419	PilM	PilM
+PF07420	DUF1509	Protein of unknown function (DUF1509)
+PF07421	Pro-NT_NN	Neurotensin/neuromedin N precursor
+PF07422	s48_45	Sexual stage antigen s48/45 domain
+PF07423	DUF1510	Protein of unknown function (DUF1510)
+PF07424	TrbM	TrbM
+PF07425	Pardaxin	Pardaxin
+PF07426	Dynactin_p22	Dynactin subunit p22
+PF07428	Tri3	15-O-acetyltransferase Tri3
+PF07429	Glyco_transf_56	4-alpha-L-fucosyltransferase glycosyl transferase group 56
+PF07430	PP1	Phloem filament protein PP1 cystatin-like domain
+PF07431	DUF1512	Protein of unknown function (DUF1512)
+PF07432	Hc1	Histone H1-like protein Hc1
+PF07433	DUF1513	Protein of unknown function (DUF1513)
+PF07434	CblD	CblD like pilus biogenesis initiator
+PF07435	YycH	YycH protein
+PF07436	Curto_V3	Curtovirus V3 protein
+PF07437	YfaZ	YfaZ precursor
+PF07438	DUF1514	Protein of unknown function (DUF1514)
+PF07439	DUF1515	Protein of unknown function (DUF1515)
+PF07440	Caerin_1	Caerin 1 protein
+PF07441	BofA	SigmaK-factor processing regulatory protein BofA
+PF07442	Ponericin	Ponericin
+PF07443	HARP	HepA-related protein (HARP)
+PF07444	Ycf66_N	Ycf66 protein N-terminus
+PF07445	PriC	Primosomal replication protein priC
+PF07447	VP40	Matrix protein VP40
+PF07448	Spp-24	Secreted phosphoprotein 24 (Spp-24) cystatin-like domain
+PF07449	HyaE	Hydrogenase-1 expression protein HyaE
+PF07450	HycH	Formate hydrogenlyase maturation protein HycH
+PF07451	SpoVAD	Stage V sporulation protein AD (SpoVAD)
+PF07452	CHRD	CHRD domain
+PF07453	NUMOD1	NUMOD1 domain
+PF07454	SpoIIP	Stage II sporulation protein P (SpoIIP)
+PF07455	Psu	Phage polarity suppression protein (Psu)
+PF07456	Hpre_diP_synt_I	Heptaprenyl diphosphate synthase component I
+PF07457	DUF1516	Protein of unknown function (DUF1516)
+PF07458	SPAN-X	Sperm protein associated with nucleus, mapped to X chromosome
+PF07459	CTX_RstB	CTX phage RstB protein
+PF07460	NUMOD3	NUMOD3 motif (2 copies)
+PF07461	NADase_NGA	Nicotine adenine dinucleotide glycohydrolase (NADase)
+PF07462	MSP1_C	Merozoite surface protein 1 (MSP1) C-terminus
+PF07463	NUMOD4	NUMOD4 motif
+PF07464	ApoLp-III	Apolipophorin-III precursor (apoLp-III)
+PF07465	PsaM	Photosystem I protein M (PsaM)
+PF07466	DUF1517	Protein of unknown function (DUF1517)
+PF07467	BLIP	Beta-lactamase inhibitor (BLIP)
+PF07468	Agglutinin	Agglutinin domain
+PF07469	DUF1518	Domain of unknown function (DUF1518) 
+PF07470	Glyco_hydro_88	Glycosyl Hydrolase Family 88
+PF07471	Phage_Nu1	Phage DNA packaging protein Nu1
+PF07472	PA-IIL	Fucose-binding lectin II (PA-IIL)
+PF07473	Toxin_11	Spasmodic peptide gm9a; conotoxin from Conus species
+PF07474	G2F	G2F domain
+PF07475	Hpr_kinase_C	HPr Serine kinase C-terminal domain
+PF07476	MAAL_C	Methylaspartate ammonia-lyase C-terminus
+PF07477	Glyco_hydro_67C	Glycosyl hydrolase family 67 C-terminus
+PF07478	Dala_Dala_lig_C	D-ala D-ala ligase C-terminus
+PF07479	NAD_Gly3P_dh_C	NAD-dependent glycerol-3-phosphate dehydrogenase C-terminus
+PF07481	DUF1521	Domain of Unknown Function (DUF1521)
+PF07482	DUF1522	Domain of Unknown Function (DUF1522)
+PF07483	W_rich_C	Tryptophan-rich Synechocystis species C-terminal domain
+PF07484	Collar	Phage Tail Collar Domain
+PF07485	DUF1529	Domain of Unknown Function (DUF1259)
+PF07486	Hydrolase_2	Cell Wall Hydrolase
+PF07487	SopE_GEF	SopE GEF domain
+PF07488	Glyco_hydro_67M	Glycosyl hydrolase family 67 middle domain
+PF07489	Tir_receptor_C	Translocated intimin receptor (Tir) C-terminus
+PF07490	Tir_receptor_N	Translocated intimin receptor (Tir) N-terminus
+PF07491	PPI_Ypi1	Protein phosphatase inhibitor  
+PF07492	Trehalase_Ca-bi	Neutral trehalase Ca2+ binding domain
+PF07494	Reg_prop	Two component regulator propeller
+PF07495	Y_Y_Y	Y_Y_Y domain
+PF07496	zf-CW	CW-type Zinc Finger
+PF07497	Rho_RNA_bind	Rho termination factor, RNA-binding domain
+PF07498	Rho_N	Rho termination factor, N-terminal domain
+PF07499	RuvA_C	RuvA, C-terminal domain
+PF07500	TFIIS_M	Transcription factor S-II (TFIIS), central domain
+PF07501	G5	G5 domain
+PF07502	MANEC	MANEC domain
+PF07503	zf-HYPF	HypF finger
+PF07504	FTP	Fungalysin/Thermolysin Propeptide Motif
+PF07505	DUF5131	Protein of unknown function (DUF5131)
+PF07506	RepB	RepB plasmid partitioning protein
+PF07507	WavE	WavE lipopolysaccharide synthesis
+PF07508	Recombinase	Recombinase
+PF07509	DUF1523	Protein of unknown function (DUF1523)
+PF07510	DUF1524	Protein of unknown function (DUF1524)
+PF07511	DUF1525	Protein of unknown function (DUF1525)
+PF07514	TraI_2	Putative helicase
+PF07515	TraI_2_C	Putative conjugal transfer nickase/helicase TraI C-term
+PF07516	SecA_SW	SecA Wing and Scaffold domain
+PF07517	SecA_DEAD	SecA DEAD-like domain
+PF07519	Tannase	Tannase and feruloyl esterase
+PF07520	SrfB	Virulence factor SrfB
+PF07521	RMMBL	Zn-dependent metallo-hydrolase RNA specificity domain
+PF07522	DRMBL	DNA repair metallo-beta-lactamase
+PF07523	Big_3	Bacterial Ig-like domain (group 3)
+PF07524	Bromo_TP	Bromodomain associated
+PF07525	SOCS_box	SOCS box
+PF07526	POX	Associated with HOX
+PF07527	Hairy_orange	Hairy Orange
+PF07528	DZF	DZF domain
+PF07529	HSA	HSA
+PF07530	PRE_C2HC	Associated with zinc fingers
+PF07531	TAFH	NHR1 homology to TAF
+PF07532	Big_4	Bacterial Ig-like domain (group 4)
+PF07533	BRK	BRK domain
+PF07534	TLD	TLD
+PF07535	zf-DBF	DBF zinc finger
+PF07536	HWE_HK	HWE histidine kinase
+PF07537	CamS	CamS sex pheromone cAM373 precursor
+PF07538	ChW	Clostridial hydrophobic W
+PF07539	DRIM	Down-regulated in metastasis
+PF07540	NOC3p	Nucleolar complex-associated protein
+PF07541	EIF_2_alpha	Eukaryotic translation initiation factor 2 alpha subunit
+PF07542	ATP12	ATP12 chaperone protein
+PF07543	PGA2	Protein trafficking PGA2
+PF07544	Med9	RNA polymerase II transcription mediator complex subunit 9
+PF07545	Vg_Tdu	Vestigial/Tondu family
+PF07546	EMI	EMI domain
+PF07547	RSD-2	RSD-2 N-terminal domain
+PF07548	ChlamPMP_M	Chlamydia polymorphic membrane protein middle domain
+PF07549	Sec_GG	SecD/SecF GG Motif
+PF07550	DUF1533	Protein of unknown function (DUF1533)
+PF07551	DUF1534	Protein of unknown function (DUF1534)
+PF07552	Coat_X	Spore Coat Protein X and V domain
+PF07553	Lipoprotein_Ltp	Host cell surface-exposed lipoprotein
+PF07554	FIVAR	FIVAR domain
+PF07555	NAGidase	beta-N-acetylglucosaminidase 
+PF07556	DUF1538	Protein of unknown function (DUF1538)
+PF07557	Shugoshin_C	Shugoshin C terminus
+PF07558	Shugoshin_N	Shugoshin N-terminal coiled-coil region
+PF07559	FlaE	Flagellar basal body protein FlaE
+PF07560	DUF1539	Domain of Unknown Function (DUF1539)
+PF07561	DUF1540	Domain of Unknown Function (DUF1540)
+PF07562	NCD3G	Nine Cysteines Domain of family 3 GPCR
+PF07563	DUF1541	Protein of unknown function (DUF1541)
+PF07564	DUF1542	Domain of Unknown Function (DUF1542)
+PF07565	Band_3_cyto	Band 3 cytoplasmic domain
+PF07566	DUF1543	Domain of Unknown Function (DUF1543)
+PF07568	HisKA_2	Histidine kinase
+PF07569	Hira	TUP1-like enhancer of split
+PF07571	TAF6_C	TAF6 C-terminal HEAT repeat domain
+PF07572	BCNT	Bucentaur or craniofacial development
+PF07573	AreA_N	Nitrogen regulatory protein AreA N terminus
+PF07574	SMC_Nse1	Nse1 non-SMC component of SMC5-6 complex
+PF07575	Nucleopor_Nup85	Nup85 Nucleoporin
+PF07576	BRAP2	BRCA1-associated protein 2
+PF07577	DUF1547	Domain of Unknown Function (DUF1547)
+PF07578	LAB_N	Lipid A Biosynthesis N-terminal domain
+PF07579	DUF1548	Domain of Unknown Function (DUF1548)
+PF07580	Peptidase_M26_C	M26 IgA1-specific Metallo-endopeptidase C-terminal region
+PF07581	Glug	The GLUG motif
+PF07582	AP_endonuc_2_N	AP endonuclease family 2 C terminus
+PF07583	PSCyt2	Protein of unknown function (DUF1549)
+PF07584	BatA	Aerotolerance regulator N-terminal
+PF07585	BBP7	Putative beta barrel porin-7 (BBP7)
+PF07586	HXXSHH	Protein of unknown function (DUF1552)
+PF07587	PSD1	Protein of unknown function (DUF1553)
+PF07588	DUF1554	Protein of unknown function (DUF1554)
+PF07589	VPEP	PEP-CTERM motif
+PF07590	DUF1556	Protein of unknown function (DUF1556)
+PF07591	PT-HINT	Pretoxin HINT domain
+PF07592	DDE_Tnp_ISAZ013	Rhodopirellula transposase DDE domain
+PF07593	UnbV_ASPIC	ASPIC and UnbV
+PF07595	Planc_extracel	Planctomycete extracellular
+PF07596	SBP_bac_10	Protein of unknown function (DUF1559)
+PF07597	DUF1560	Protein of unknown function (DUF1560)
+PF07598	DUF1561	Protein of unknown function (DUF1561)
+PF07599	DUF1563	Protein of unknown function (DUF1563)
+PF07600	DUF1564	Protein of unknown function (DUF1564)
+PF07602	DUF1565	Protein of unknown function (DUF1565)
+PF07603	DUF1566	Protein of unknown function (DUF1566)
+PF07606	DUF1569	Protein of unknown function (DUF1569)
+PF07607	DUF1570	Protein of unknown function (DUF1570)
+PF07608	DUF1571	Protein of unknown function (DUF1571)
+PF07609	DUF1572	Protein of unknown function (DUF1572)
+PF07610	DUF1573	Protein of unknown function (DUF1573)
+PF07611	DUF1574	Protein of unknown function (DUF1574)
+PF07613	DUF1576	Protein of unknown function (DUF1576)
+PF07614	DUF1577	Protein of unknown function (DUF1577)
+PF07615	Ykof	YKOF-related Family
+PF07617	DUF1579	Protein of unknown function (DUF1579)
+PF07618	DUF1580	Protein of unknown function (DUF1580)
+PF07619	DUF1581	Protein of unknown function (DUF1581)
+PF07621	DUF1582	Protein of unknown function (DUF1582)
+PF07622	DUF1583	Protein of unknown function (DUF1583)
+PF07623	PEGSRP	Protein of unknown function (DUF1584)
+PF07624	PSD2	Protein of unknown function (DUF1585)
+PF07625	DUF1586	Protein of unknown function (DUF1586)
+PF07626	PSD3	Protein of unknown function (DUF1587)
+PF07627	PSCyt3	Protein of unknown function (DUF1588)
+PF07628	DUF1589	Protein of unknown function (DUF1589)
+PF07629	DUF1590	Protein of unknown function (DUF1590)
+PF07631	PSD4	Protein of unknown function (DUF1592)
+PF07632	DUF1593	Protein of unknown function (DUF1593)
+PF07634	RtxA	RtxA repeat
+PF07635	PSCyt1	Planctomycete cytochrome C
+PF07636	PSRT	PSRT
+PF07637	PSD5	Protein of unknown function (DUF1595)
+PF07638	Sigma70_ECF	ECF sigma factor
+PF07639	YTV	YTV
+PF07640	QPP	QPP
+PF07642	BBP2	Putative beta-barrel porin-2, OmpL-like. bbp2
+PF07643	DUF1598	Protein of unknown function (DUF1598)
+PF07644	PGAMP	Planctomycete PGAMP
+PF07645	EGF_CA	Calcium-binding EGF domain
+PF07646	Kelch_2	Kelch motif
+PF07647	SAM_2	SAM domain (Sterile alpha motif)
+PF07648	Kazal_2	Kazal-type serine protease inhibitor domain
+PF07650	KH_2	KH domain
+PF07651	ANTH	ANTH domain
+PF07652	Flavi_DEAD	Flavivirus DEAD domain 
+PF07653	SH3_2	Variant SH3 domain
+PF07654	C1-set	Immunoglobulin C1-set domain
+PF07655	Secretin_N_2	Secretin N-terminal domain
+PF07657	MNNL	N terminus of Notch ligand
+PF07659	DUF1599	Domain of Unknown Function (DUF1599)
+PF07660	STN	Secretin and TonB N terminus short domain
+PF07661	MORN_2	MORN repeat variant
+PF07662	Nucleos_tra2_C	Na+ dependent nucleoside transporter C-terminus
+PF07663	EIIBC-GUT_C	Sorbitol phosphotransferase enzyme II C-terminus
+PF07664	FeoB_C	Ferrous iron transport protein B C terminus
+PF07666	MpPF26	M penetrans paralogue family 26
+PF07667	DUF1600	Protein of unknown function (DUF1600)
+PF07668	MpPF1	M penetrans paralogue family 1
+PF07669	Eco57I	Eco57I restriction-modification methylase
+PF07670	Gate	Nucleoside recognition
+PF07671	DUF1601	Protein of unknown function (DUF1601)
+PF07672	MFS_Mycoplasma	Mycoplasma MFS transporter
+PF07675	Cleaved_Adhesin	Cleaved Adhesin Domain
+PF07676	PD40	WD40-like Beta Propeller Repeat
+PF07677	A2M_recep	A-macroglobulin receptor
+PF07678	A2M_comp	A-macroglobulin complement component
+PF07679	I-set	Immunoglobulin I-set domain
+PF07680	DoxA	TQO small subunit DoxA
+PF07681	DoxX	DoxX
+PF07682	SOR	Sulphur oxygenase reductase
+PF07683	CobW_C	Cobalamin synthesis protein cobW C-terminal domain
+PF07684	NODP	NOTCH protein
+PF07685	GATase_3	CobB/CobQ-like glutamine amidotransferase domain
+PF07686	V-set	Immunoglobulin V-set domain
+PF07687	M20_dimer	Peptidase dimerisation domain
+PF07688	KaiA	KaiA C-terminal domain
+PF07689	KaiB	KaiB domain
+PF07690	MFS_1	Major Facilitator Superfamily
+PF07691	PA14	PA14 domain
+PF07692	Fea1	Low iron-inducible periplasmic protein
+PF07693	KAP_NTPase	KAP family P-loop domain
+PF07694	5TM-5TMR_LYT	5TMR of 5TMR-LYT
+PF07695	7TMR-DISM_7TM	7TM diverse intracellular signalling
+PF07696	7TMR-DISMED2	7TMR-DISM extracellular 2
+PF07697	7TMR-HDED	7TM-HD extracellular
+PF07698	7TM-7TMR_HD	7TM receptor with intracellular HD hydrolase
+PF07699	Ephrin_rec_like	Putative ephrin-receptor like 
+PF07700	HNOB	Haem-NO-binding
+PF07701	HNOBA	Heme NO binding associated
+PF07702	UTRA	UTRA domain
+PF07703	A2M_N_2	Alpha-2-macroglobulin family N-terminal region
+PF07704	PSK_trans_fac	Rv0623-like transcription factor
+PF07705	CARDB	CARDB
+PF07706	TAT_ubiq	Aminotransferase ubiquitination site
+PF07707	BACK	BTB And C-terminal Kelch
+PF07708	Tash_PEST	Tash protein PEST motif
+PF07709	SRR	Seven Residue Repeat
+PF07710	P53_tetramer	P53 tetramerisation motif
+PF07711	RabGGT_insert	Rab geranylgeranyl transferase alpha-subunit, insert domain 
+PF07712	SURNod19	Stress up-regulated Nod 19
+PF07713	DUF1604	Protein of unknown function (DUF1604)
+PF07714	Pkinase_Tyr	Protein tyrosine kinase
+PF07715	Plug	TonB-dependent Receptor Plug Domain
+PF07716	bZIP_2	Basic region leucine zipper
+PF07717	OB_NTP_bind	Oligonucleotide/oligosaccharide-binding (OB)-fold
+PF07718	Coatamer_beta_C	Coatomer beta C-terminal region
+PF07719	TPR_2	Tetratricopeptide repeat
+PF07720	TPR_3	Tetratricopeptide repeat
+PF07721	TPR_4	Tetratricopeptide repeat
+PF07722	Peptidase_C26	Peptidase C26
+PF07723	LRR_2	Leucine Rich Repeat
+PF07724	AAA_2	AAA domain (Cdc48 subfamily)
+PF07725	LRR_3	Leucine Rich Repeat
+PF07726	AAA_3	ATPase family associated with various cellular activities (AAA)
+PF07727	RVT_2	Reverse transcriptase (RNA-dependent DNA polymerase)
+PF07728	AAA_5	AAA domain (dynein-related subfamily)
+PF07729	FCD	FCD domain
+PF07730	HisKA_3	Histidine kinase
+PF07731	Cu-oxidase_2	Multicopper oxidase
+PF07732	Cu-oxidase_3	Multicopper oxidase
+PF07733	DNA_pol3_alpha	Bacterial DNA polymerase III alpha subunit
+PF07734	FBA_1	F-box associated
+PF07735	FBA_2	F-box associated
+PF07736	CM_1	Chorismate mutase type I
+PF07737	ATLF	Anthrax toxin lethal factor, N- and C-terminal domain
+PF07738	Sad1_UNC	Sad1 / UNC-like C-terminal 
+PF07739	TipAS	TipAS antibiotic-recognition domain
+PF07740	Toxin_12	Ion channel inhibitory toxin
+PF07741	BRF1	Brf1-like TBP-binding domain
+PF07742	BTG	BTG family
+PF07743	HSCB_C	HSCB C-terminal oligomerisation domain
+PF07744	SPOC	SPOC domain
+PF07745	Glyco_hydro_53	Glycosyl hydrolase family 53
+PF07746	LigA	Aromatic-ring-opening dioxygenase LigAB, LigA subunit
+PF07747	MTH865	MTH865-like family
+PF07748	Glyco_hydro_38C	Glycosyl hydrolases family 38 C-terminal domain
+PF07749	ERp29	Endoplasmic reticulum protein ERp29, C-terminal domain
+PF07750	GcrA	GcrA cell cycle regulator
+PF07751	Abi_2	Abi-like protein
+PF07752	S-layer	S-layer protein
+PF07753	DUF1609	Protein of unknown function (DUF1609)
+PF07754	DUF1610	Domain of unknown function (DUF1610)
+PF07755	DUF1611	Domain of unknown function (DUF1611_C) P-loop domain
+PF07756	DUF1612	Protein of unknown function (DUF1612)
+PF07757	AdoMet_MTase	Predicted AdoMet-dependent methyltransferase
+PF07758	DUF1614	Protein of unknown function (DUF1614)
+PF07759	DUF1615	Protein of unknown function (DUF1615)
+PF07760	DUF1616	Protein of unknown function (DUF1616)
+PF07761	DUF1617	Protein of unknown function (DUF1617)
+PF07762	DUF1618	Protein of unknown function (DUF1618)
+PF07763	FEZ	FEZ-like protein
+PF07764	Omega_Repress	Omega Transcriptional Repressor
+PF07765	KIP1	KIP1-like protein
+PF07766	LETM1	LETM1-like protein
+PF07767	Nop53	Nop53 (60S ribosomal biogenesis)
+PF07768	PVL_ORF50	PVL ORF-50-like family
+PF07769	PsiF_repeat	psiF repeat
+PF07771	TSGP1	Tick salivary peptide group 1
+PF07773	DUF1619	Protein of unknown function (DUF1619)
+PF07774	DUF1620	Protein of unknown function (DUF1620)
+PF07775	PaRep2b	PaRep2b protein
+PF07776	zf-AD	Zinc-finger associated domain (zf-AD)  
+PF07777	MFMR	G-box binding protein MFMR
+PF07778	CENP-I	Mis6 
+PF07779	Cas1_AcylT	10 TM Acyl Transferase domain found in Cas1p
+PF07780	Spb1_C	Spb1 C-terminal domain
+PF07781	Reovirus_Mu2	Reovirus minor core protein Mu-2
+PF07782	DC_STAMP	DC-STAMP-like protein
+PF07784	DUF1622	Protein of unknown function (DUF1622)
+PF07785	DUF1623	Protein of unknown function (DUF1623)
+PF07786	DUF1624	Protein of unknown function (DUF1624)
+PF07787	TMEM43	Transmembrane protein 43
+PF07788	PDDEXK_10	PD-(D/E)XK nuclease superfamily
+PF07789	DUF1627	Protein of unknown function (DUF1627)
+PF07790	Pilin_N	Archaeal Type IV pilin, N-terminal 
+PF07791	DUF1629	Protein of unknown function (DUF1629)
+PF07792	Afi1	Docking domain of Afi1 for Arf3 in vesicle trafficking
+PF07793	DUF1631	Protein of unknown function (DUF1631)
+PF07794	DUF1633	Protein of unknown function (DUF1633)
+PF07795	DUF1635	Protein of unknown function (DUF1635)
+PF07796	DUF1638	Protein of unknown function (DUF1638)
+PF07797	DUF1639	Protein of unknown function (DUF1639)
+PF07798	DUF1640	Protein of unknown function (DUF1640)
+PF07799	DUF1643	Protein of unknown function (DUF1643)
+PF07800	DUF1644	Protein of unknown function (DUF1644)
+PF07801	DUF1647	Protein of unknown function (DUF1647)
+PF07802	GCK	GCK domain
+PF07803	GSG-1	GSG1-like protein
+PF07804	HipA_C	HipA-like C-terminal domain
+PF07806	Nod_GRP	Nodule-specific GRP repeat
+PF07807	RED_C	RED-like protein C-terminal region
+PF07808	RED_N	RED-like protein N-terminal region
+PF07809	RTP801_C	RTP801 C-terminal region
+PF07810	TMC	TMC domain
+PF07811	TadE	TadE-like protein
+PF07812	TfuA	TfuA-like protein
+PF07813	LTXXQ	LTXXQ motif family protein
+PF07814	WAPL	Wings apart-like protein regulation of heterochromatin
+PF07815	Abi_HHR	Abl-interactor HHR
+PF07816	DUF1645	Protein of unknown function (DUF1645)
+PF07817	GLE1	GLE1-like protein
+PF07818	HCNGP	HCNGP-like protein
+PF07819	PGAP1	PGAP1-like protein
+PF07820	TraC	TraC-like protein
+PF07821	Alpha-amyl_C2	Alpha-amylase C-terminal beta-sheet domain
+PF07822	Toxin_13	Neurotoxin B-IV-like protein
+PF07823	CPDase	Cyclic phosphodiesterase-like protein
+PF07824	Chaperone_III	Type III secretion chaperone domain
+PF07825	Exc	Excisionase-like protein
+PF07826	IMP_cyclohyd	IMP cyclohydrolase-like protein
+PF07827	KNTase_C	KNTase C-terminal domain
+PF07828	PA-IL	PA-IL-like protein
+PF07829	Toxin_14	Alpha-A conotoxin PIVA-like protein
+PF07830	PP2C_C	Protein serine/threonine phosphatase 2C, C-terminal domain
+PF07831	PYNP_C	Pyrimidine nucleoside phosphorylase C-terminal domain
+PF07832	Bse634I	Cfr10I/Bse634I restriction endonuclease
+PF07833	Cu_amine_oxidN1	Copper amine oxidase N-terminal domain
+PF07834	RanGAP1_C	RanGAP1 C-terminal domain
+PF07835	COX4_pro_2	Bacterial aa3 type cytochrome c oxidase subunit IV
+PF07836	DmpG_comm	DmpG-like communication domain
+PF07837	FTCD_N	Formiminotransferase domain, N-terminal subdomain
+PF07839	CaM_binding	Plant calmodulin-binding domain
+PF07840	FadR_C	FadR C-terminal domain
+PF07841	DM4_12	DM4/DM12 family
+PF07842	GCFC	GC-rich sequence DNA-binding factor-like protein
+PF07843	DUF1634	Protein of unknown function (DUF1634)
+PF07845	DUF1636	Protein of unknown function (DUF1636)
+PF07846	Metallothio_Cad	Metallothionein family
+PF07847	PCO_ADO	PCO_ADO
+PF07848	PaaX	PaaX-like protein
+PF07849	DUF1641	Protein of unknown function (DUF1641)
+PF07850	Renin_r	Renin receptor-like protein
+PF07851	TMPIT	TMPIT-like protein
+PF07852	DUF1642	Protein of unknown function (DUF1642)
+PF07853	DUF1648	Protein of unknown function (DUF1648)
+PF07854	DUF1646	Protein of unknown function (DUF1646)
+PF07855	ATG101	Autophagy-related protein 101
+PF07856	Orai-1	Mediator of CRAC channel activity
+PF07857	TMEM144	Transmembrane family, TMEM144 of transporters
+PF07858	LEH	Limonene-1,2-epoxide hydrolase catalytic domain
+PF07859	Abhydrolase_3	alpha/beta hydrolase fold
+PF07860	CCD	WisP family C-Terminal Region
+PF07861	WND	WisP family N-Terminal Region
+PF07862	Nif11	Nif11 domain
+PF07863	CtnDOT_TraJ	Homologues of TraJ from Bacteroides conjugative transposon
+PF07864	DUF1651	Protein of unknown function (DUF1651)
+PF07865	DUF1652	Protein of unknown function (DUF1652)
+PF07866	DUF1653	Protein of unknown function (DUF1653)
+PF07867	DUF1654	Protein of unknown function (DUF1654)
+PF07868	DUF1655	Protein of unknown function (DUF1655)
+PF07869	DUF1656	Protein of unknown function (DUF1656)
+PF07870	DUF1657	Protein of unknown function (DUF1657)
+PF07871	DUF1658	Protein of unknown function (DUF1658)
+PF07872	DUF1659	Protein of unknown function (DUF1659)
+PF07873	YabP	YabP family
+PF07874	DUF1660	Prophage protein (DUF1660)
+PF07875	Coat_F	Coat F domain
+PF07876	Dabb	Stress responsive A/B Barrel Domain
+PF07877	DUF1661	Protein of unknown function (DUF1661)
+PF07878	RHH_5	CopG-like RHH_1 or ribbon-helix-helix domain, RHH_5
+PF07879	PHB_acc_N	PHB/PHA accumulation regulator DNA-binding domain
+PF07880	T4_gp9_10	Bacteriophage T4 gp9/10-like protein
+PF07881	Fucose_iso_N1	L-fucose isomerase, first N-terminal domain
+PF07882	Fucose_iso_N2	L-fucose isomerase, second N-terminal domain
+PF07883	Cupin_2	Cupin domain
+PF07884	VKOR	Vitamin K epoxide reductase family
+PF07885	Ion_trans_2	Ion channel
+PF07886	BA14K	BA14K-like protein
+PF07887	Calmodulin_bind	Calmodulin binding protein-like
+PF07888	CALCOCO1	Calcium binding and coiled-coil domain (CALCOCO1) like
+PF07889	DUF1664	Protein of unknown function (DUF1664)
+PF07890	Rrp15p	Rrp15p
+PF07891	DUF1666	Protein of unknown function (DUF1666)
+PF07892	DUF1667	Protein of unknown function (DUF1667)
+PF07893	DUF1668	Protein of unknown function (DUF1668)
+PF07894	DUF1669	Protein of unknown function (DUF1669)
+PF07895	DUF1673	Protein of unknown function (DUF1673)
+PF07896	DUF1674	Protein of unknown function (DUF1674)
+PF07897	EAR	Ethylene-responsive binding factor-associated repression
+PF07898	DUF1676	Protein of unknown function (DUF1676)
+PF07899	Frigida	Frigida-like protein
+PF07900	DUF1670	Protein of unknown function (DUF1670)
+PF07901	DUF1672	Protein of unknown function (DUF1672)
+PF07902	Gp58	gp58-like protein
+PF07903	PaRep2a	PaRep2a protein
+PF07904	Eaf7	Chromatin modification-related protein EAF7
+PF07905	PucR	Purine catabolism regulatory protein-like family
+PF07906	Toxin_15	ShET2 enterotoxin, N-terminal region
+PF07907	YibE_F	YibE/F-like protein
+PF07909	DUF1663	Protein of unknown function (DUF1663)
+PF07910	Peptidase_C78	Peptidase family C78
+PF07911	DUF1677	Protein of unknown function (DUF1677)
+PF07912	ERp29_N	ERp29, N-terminal domain
+PF07913	DUF1678	Protein of unknown function (DUF1678)
+PF07914	DUF1679	Protein of unknown function (DUF1679)
+PF07915	PRKCSH	Glucosidase II beta subunit-like protein
+PF07916	TraG_N	TraG-like protein, N-terminal region
+PF07918	CAP160	CAP160 repeat
+PF07919	Gryzun	Gryzun, putative trafficking through Golgi
+PF07920	DUF1684	Protein of unknown function (DUF1684)
+PF07921	Fibritin_C	Fibritin C-terminal region
+PF07922	Glyco_transf_52	Glycosyltransferase family 52
+PF07923	N1221	N1221-like protein
+PF07924	NuiA	Nuclease A inhibitor-like protein
+PF07925	RdRP_5	Reovirus RNA-dependent RNA polymerase lambda 3
+PF07926	TPR_MLP1_2	TPR/MLP1/MLP2-like protein
+PF07927	HicA_toxin	HicA toxin of bacterial toxin-antitoxin, 
+PF07928	Vps54	Vps54-like protein
+PF07929	PRiA4_ORF3	Plasmid pRiA4b ORF-3-like protein
+PF07930	DAP_B	D-aminopeptidase, domain B
+PF07931	CPT	Chloramphenicol phosphotransferase-like protein
+PF07933	DUF1681	Protein of unknown function (DUF1681)
+PF07934	OGG_N	8-oxoguanine DNA glycosylase, N-terminal domain
+PF07935	SSV1_ORF_D-335	ORF D-335-like protein
+PF07936	Defensin_4	Potassium-channel blocking toxin
+PF07937	DUF1686	Protein of unknown function (DUF1686)
+PF07938	Fungal_lectin	Fungal fucose-specific lectin
+PF07939	DUF1685	Protein of unknown function (DUF1685)
+PF07940	Hepar_II_III	Heparinase II/III-like protein
+PF07941	K_channel_TID	Potassium channel Kv1.4 tandem inactivation domain
+PF07942	N2227	N2227-like protein
+PF07943	PBP5_C	Penicillin-binding protein 5, C-terminal domain
+PF07944	Glyco_hydro_127	Beta-L-arabinofuranosidase, GH127
+PF07945	Toxin_16	Janus-atracotoxin
+PF07946	DUF1682	Protein of unknown function (DUF1682)
+PF07947	YhhN	YhhN family
+PF07948	Nairovirus_M	Nairovirus M polyprotein-like
+PF07949	YbbR	YbbR-like protein
+PF07950	DUF1691	Protein of unknown function (DUF1691)
+PF07951	Toxin_R_bind_C	Clostridium neurotoxin, C-terminal receptor binding
+PF07952	Toxin_trans	Clostridium neurotoxin, Translocation domain
+PF07953	Toxin_R_bind_N	Clostridium neurotoxin, N-terminal receptor binding
+PF07954	DUF1689	Protein of unknown function (DUF1689) 
+PF07955	DUF1687	Protein of unknown function (DUF1687) 
+PF07956	DUF1690	Protein of Unknown function (DUF1690) 
+PF07957	DUF3294	Protein of unknown function (DUF3294)
+PF07958	DUF1688	Protein of unknown function (DUF1688)
+PF07959	Fucokinase	L-fucokinase
+PF07960	CBP4	CBP4
+PF07961	MBA1	MBA1-like protein
+PF07962	Swi3	Replication Fork Protection Component Swi3
+PF07963	N_methyl	Prokaryotic N-terminal methylation motif
+PF07964	Red1	Rec10 / Red1
+PF07965	Integrin_B_tail	Integrin beta tail domain
+PF07966	A1_Propeptide	A1 Propeptide 
+PF07967	zf-C3HC	C3HC zinc finger-like 
+PF07968	Leukocidin	Leukocidin/Hemolysin toxin family
+PF07969	Amidohydro_3	Amidohydrolase family
+PF07970	COPIIcoated_ERV	Endoplasmic reticulum vesicle transporter 
+PF07971	Glyco_hydro_92	Glycosyl hydrolase family 92
+PF07972	Flavodoxin_NdrI	NrdI Flavodoxin like 
+PF07973	tRNA_SAD	Threonyl and Alanyl tRNA synthetase second additional domain
+PF07974	EGF_2	EGF-like domain
+PF07975	C1_4	TFIIH C1-like domain
+PF07976	Phe_hydrox_dim	Phenol hydroxylase, C-terminal dimerisation domain 
+PF07977	FabA	FabA-like domain
+PF07978	NIPSNAP	NIPSNAP 
+PF07979	Intimin_C	Intimin C-type lectin domain
+PF07980	SusD_RagB	SusD family
+PF07981	Plasmod_MYXSPDY	Plasmodium repeat_MYXSPDY
+PF07982	Herpes_UL74	Herpes UL74 glycoproteins 
+PF07983	X8	X8 domain
+PF07984	NTP_transf_7	Nucleotidyltransferase 
+PF07985	SRR1	SRR1
+PF07986	TBCC	Tubulin binding cofactor C
+PF07987	DUF1775	Domain of unkown function (DUF1775)
+PF07988	LMSTEN	LMSTEN motif
+PF07989	Cnn_1N	Centrosomin N-terminal motif 1
+PF07990	NABP	Nucleic acid binding protein NABP
+PF07991	IlvN	Acetohydroxy acid isomeroreductase, NADPH-binding domain
+PF07992	Pyr_redox_2	Pyridine nucleotide-disulphide oxidoreductase
+PF07993	NAD_binding_4	Male sterility protein
+PF07994	NAD_binding_5	Myo-inositol-1-phosphate synthase
+PF07995	GSDH	Glucose / Sorbosone dehydrogenase
+PF07996	T4SS	Type IV secretion system proteins
+PF07997	DUF1694	Protein of unknown function (DUF1694)
+PF07998	Peptidase_M54	Peptidase family M54
+PF07999	RHSP	Retrotransposon hot spot protein
+PF08000	bPH_1	Bacterial PH domain
+PF08001	CMV_US	CMV US
+PF08002	DUF1697	Protein of unknown function (DUF1697)
+PF08003	Methyltransf_9	Protein of unknown function (DUF1698)
+PF08004	DUF1699	Protein of unknown function (DUF1699)
+PF08005	PHR	PHR domain 
+PF08006	DUF1700	Protein of unknown function (DUF1700)
+PF08007	Cupin_4	Cupin superfamily protein
+PF08008	Viral_cys_rich	Viral cysteine rich
+PF08009	CDP-OH_P_tran_2	CDP-alcohol phosphatidyltransferase 2
+PF08010	Phage_30_3	Bacteriophage protein GP30.3
+PF08011	PDDEXK_9	PD-(D/E)XK nuclease superfamily
+PF08012	DUF1702	Protein of unknown function (DUF1702)
+PF08013	Tagatose_6_P_K	Tagatose 6 phosphate kinase
+PF08014	DUF1704	Domain of unknown function (DUF1704)
+PF08015	Pheromone	Fungal mating-type pheromone
+PF08016	PKD_channel	Polycystin cation channel
+PF08017	Fibrinogen_BP	Fibrinogen binding protein 
+PF08018	Antimicrobial_1	Frog antimicrobial peptide 
+PF08019	DUF1705	Domain of unknown function (DUF1705)
+PF08020	DUF1706	Protein of unknown function (DUF1706)   
+PF08021	FAD_binding_9	Siderophore-interacting FAD-binding domain
+PF08022	FAD_binding_8	FAD-binding domain
+PF08023	Antimicrobial_2	Frog antimicrobial peptide 
+PF08024	Antimicrobial_4	Ant antimicrobial peptide
+PF08025	Antimicrobial_3	Spider antimicrobial peptide
+PF08026	Antimicrobial_5	Bee antimicrobial peptide
+PF08027	Albumin_I	Albumin I chain b
+PF08028	Acyl-CoA_dh_2	Acyl-CoA dehydrogenase, C-terminal domain
+PF08029	HisG_C	HisG, C-terminal domain
+PF08030	NAD_binding_6	Ferric reductase NAD binding domain
+PF08031	BBE	Berberine and berberine like 
+PF08032	SpoU_sub_bind	RNA 2'-O ribose methyltransferase substrate binding
+PF08033	Sec23_BS	Sec23/Sec24 beta-sandwich domain
+PF08034	TES	Trematode eggshell synthesis protein
+PF08035	Op_neuropeptide	Opioids neuropeptide
+PF08036	Antimicrobial_6	Diapausin family of antimicrobial peptide
+PF08037	Attractin	Attractin family
+PF08038	Tom7	TOM7 family
+PF08039	Mit_proteolip	Mitochondrial proteolipid
+PF08040	NADH_oxidored	MNLL subunit
+PF08041	PetM	PetM family of cytochrome b6f complex subunit 7
+PF08042	PqqA	PqqA family
+PF08043	Xin	Xin repeat
+PF08044	DUF1707	Domain of unknown function (DUF1707)
+PF08045	CDC14	Cell division control protein 14, SIN component
+PF08046	IlvGEDA_leader	IlvGEDA operon leader peptide
+PF08047	His_leader	Histidine operon leader peptide
+PF08048	RepA1_leader	Tap RepA1 leader peptide
+PF08049	IlvB_leader	IlvB leader peptide
+PF08050	Tet_res_leader	Tetracycline resistance leader peptide
+PF08051	Ery_res_leader1	Erythromycin resistance leader peptide
+PF08052	PyrBI_leader	PyrBI operon leader peptide
+PF08053	Tna_leader	Tryptophanase operon leader peptide
+PF08054	Leu_leader	Leucine operon leader peptide
+PF08055	Trp_leader1	Tryptophan leader peptide
+PF08056	Trp_leader2	Tryptophan operon leader peptide
+PF08057	Ery_res_leader2	Erythromycin resistance leader peptide
+PF08058	NPCC	Nuclear pore complex component
+PF08059	SEP	SEP domain
+PF08061	P68HR	P68HR (NUC004) repeat
+PF08062	P120R	P120R (NUC006) repeat
+PF08063	PADR1	PADR1 (NUC008) domain
+PF08064	UME	UME (NUC010) domain
+PF08065	K167R	K167R (NUC007) repeat
+PF08066	PMC2NT	PMC2NT (NUC016) domain
+PF08067	ROKNT	ROKNT (NUC014) domain
+PF08068	DKCLD	DKCLD (NUC011) domain
+PF08069	Ribosomal_S13_N	Ribosomal S13/S15 N-terminal domain
+PF08070	DTHCT	DTHCT (NUC029) region
+PF08071	RS4NT	RS4NT (NUC023) domain
+PF08072	BDHCT	BDHCT (NUC031) domain
+PF08073	CHDNT	CHDNT (NUC034) domain
+PF08074	CHDCT2	CHDCT2 (NUC038) domain
+PF08075	NOPS	NOPS (NUC059) domain
+PF08076	TetM_leader	Tetracycline resistance determinant leader peptide
+PF08077	Cm_res_leader	Chloramphenicol resistance gene leader peptide
+PF08078	PsaX	PsaX family
+PF08079	Ribosomal_L30_N	Ribosomal L30 N-terminal domain
+PF08080	zf-RNPHF	RNPHF zinc finger
+PF08081	RBM1CTR	RBM1CTR (NUC064) family
+PF08082	PRO8NT	PRO8NT (NUC069), PrP8 N-terminal domain
+PF08083	PROCN	PROCN (NUC071) domain
+PF08084	PROCT	PROCT (NUC072) domain
+PF08085	Entericidin	Entericidin EcnA/B family
+PF08086	Toxin_17	Ergtoxin family
+PF08087	Toxin_18	Conotoxin O-superfamily
+PF08088	Toxin_19	Conotoxin I-superfamily
+PF08089	Toxin_20	Huwentoxin-II family
+PF08090	Enterotoxin_HS1	Heat stable E.coli enterotoxin 1
+PF08091	Toxin_21	Spider insecticidal peptide
+PF08092	Toxin_22	Magi peptide toxin family 
+PF08093	Toxin_23	Magi 5 toxic peptide family
+PF08094	Toxin_24	Conotoxin TVIIA/GS family
+PF08095	Toxin_25	Hefutoxin family
+PF08096	Bombolitin	Bombolitin family
+PF08097	Toxin_26	Conotoxin T-superfamily
+PF08098	ATX_III	Anemonia sulcata toxin III family
+PF08099	Toxin_27	Scorpion calcine family
+PF08100	Dimerisation	Dimerisation domain
+PF08101	DUF1708	Domain of unknown function (DUF1708)
+PF08102	Antimicrobial_7	Scorpion antimicrobial peptide 
+PF08103	Antimicrobial_8	Uperin family
+PF08104	Antimicrobial_9	Ponericin L family
+PF08105	Antimicrobial10	Metchnikowin family
+PF08106	Antimicrobial11	Formaecin family
+PF08107	Antimicrobial12	Pleurocidin family
+PF08108	Antimicrobial13	Halocidin family
+PF08109	Antimicrobial14	Lactocin 705 family
+PF08110	Antimicrobial15	Ocellatin family
+PF08111	Pea-VEAacid	Pea-VEAacid family
+PF08112	ATP-synt_E_2	ATP synthase epsilon subunit
+PF08113	CoxIIa	Cytochrome c oxidase subunit IIa family
+PF08114	PMP1_2	ATPase proteolipid family
+PF08115	Toxin_28	SFI toxin family
+PF08116	Toxin_29	PhTx neurotoxin family
+PF08117	Toxin_30	Ptu family
+PF08118	MDM31_MDM32	Yeast mitochondrial distribution and morphology (MDM) proteins 
+PF08119	Toxin_31	Scorpion acidic alpha-KTx toxin family
+PF08120	Toxin_32	Tamulustoxin family
+PF08121	Toxin_33	Waglerin family
+PF08122	NDUF_B12	NADH-ubiquinone oxidoreductase B12 subunit family
+PF08123	DOT1	Histone methylation protein DOT1 
+PF08124	Lyase_8_N	Polysaccharide lyase family 8, N terminal alpha-helical domain
+PF08125	Mannitol_dh_C	Mannitol dehydrogenase C-terminal domain
+PF08126	Propeptide_C25	Propeptide_C25
+PF08127	Propeptide_C1	Peptidase family C1 propeptide
+PF08129	Antimicrobial17	Alpha/beta enterocin family
+PF08130	Antimicrobial18	Type A lantibiotic family
+PF08131	Defensin_3	Defensin-like peptide family
+PF08132	AdoMetDC_leader	S-adenosyl-l-methionine decarboxylase leader peptide
+PF08133	Nuclease_act	Anticodon nuclease activator family
+PF08134	cIII	cIII protein family
+PF08135	EPV_E5	Major transforming protein E5 family
+PF08136	Ribosomal_S22	30S ribosomal protein subunit S22 family
+PF08137	DVL	DVL family
+PF08138	Sex_peptide	Sex peptide (SP) family
+PF08139	LPAM_1	Prokaryotic membrane lipoprotein lipid attachment site
+PF08140	Cuticle_1	Crustacean cuticle protein repeat
+PF08141	SspH	Small acid-soluble spore protein H family
+PF08142	AARP2CN	AARP2CN (NUC121) domain
+PF08143	CBFNT	CBFNT (NUC161) domain
+PF08144	CPL	CPL (NUC119) domain
+PF08145	BOP1NT	BOP1NT (NUC169) domain
+PF08146	BP28CT	BP28CT (NUC211) domain
+PF08147	DBP10CT	DBP10CT (NUC160) domain
+PF08148	DSHCT	DSHCT (NUC185) domain
+PF08149	BING4CT	BING4CT (NUC141) domain
+PF08150	FerB	FerB (NUC096) domain
+PF08151	FerI	FerI (NUC094) domain
+PF08152	GUCT	GUCT (NUC152) domain
+PF08153	NGP1NT	NGP1NT (NUC091) domain
+PF08154	NLE	NLE (NUC135) domain
+PF08155	NOGCT	NOGCT (NUC087) domain
+PF08156	NOP5NT	NOP5NT (NUC127) domain
+PF08157	NUC129	NUC129 domain
+PF08158	NUC130_3NT	NUC130/3NT domain
+PF08159	NUC153	NUC153 domain
+PF08161	NUC173	NUC173 domain
+PF08163	NUC194	NUC194 domain
+PF08164	TRAUB	Apoptosis-antagonizing transcription factor, C-terminal
+PF08165	FerA	FerA (NUC095) domain
+PF08166	NUC202	NUC202 domain
+PF08167	RIX1	rRNA processing/ribosome biogenesis
+PF08168	NUC205	NUC205 domain
+PF08169	RBB1NT	RBB1NT (NUC162) domain
+PF08170	POPLD	POPLD (NUC188) domain
+PF08171	Mad3_BUB1_II	Mad3/BUB1 homology region 2
+PF08172	CASP_C	CASP C terminal
+PF08173	YbgT_YccB	Membrane bound YbgT-like protein
+PF08174	Anillin	Cell division protein anillin
+PF08175	SspO	Small acid-soluble spore protein O family
+PF08176	SspK	Small acid-soluble spore protein K family
+PF08177	SspN	Small acid-soluble spore protein N family
+PF08178	GnsAB_toxin	GnsA/GnsB toxin of bacterial toxin-antitoxin system
+PF08179	SspP	Small acid-soluble spore protein P family
+PF08180	BAGE	B melanoma antigen family
+PF08181	DegQ	DegQ (SacQ) family
+PF08182	Pedibin	Pedibin/Hym-346 family
+PF08183	SpoV	Stage V sporulation protein family
+PF08184	Cuticle_2	Cuticle protein 7 isoform family
+PF08186	Wound_ind	Wound-inducible basic protein family
+PF08187	Tetradecapep	Myoactive tetradecapeptides family
+PF08188	Protamine_3	Spermatozal protamine family
+PF08189	Meleagrin	Meleagrin/Cygnin family
+PF08190	PIH1	pre-RNA processing PIH1/Nop17
+PF08191	LRR_adjacent	LRR adjacent
+PF08192	Peptidase_S64	Peptidase family S64
+PF08193	INO80_Ies4	INO80 complex subunit Ies4
+PF08194	DIM	DIM protein
+PF08195	TRI9	TRI9 protein
+PF08196	UL2	UL2 protein
+PF08197	TT_ORF2a	pORF2a truncated protein
+PF08198	Thymopoietin	Thymopoietin protein
+PF08199	E2	Bacteriophage E2-like protein
+PF08200	Phage_1_1	Bacteriophage 1.1 Protein 
+PF08201	BssC_TutF	BssC/TutF protein
+PF08202	MIS13	Mis12-Mtw1 protein family
+PF08203	RNA_polI_A14	Yeast RNA polymerase I subunit RPA14
+PF08204	V-set_CD47	CD47 immunoglobulin-like domain
+PF08205	C2-set_2	CD80-like C2-set immunoglobulin domain 
+PF08206	OB_RNB	Ribonuclease B OB domain
+PF08207	EFP_N	Elongation factor P (EF-P) KOW-like domain
+PF08208	RNA_polI_A34	DNA-directed RNA polymerase I subunit RPA34.5
+PF08209	Sgf11	Sgf11 (transcriptional regulation protein)
+PF08210	APOBEC_N	APOBEC-like N-terminal domain
+PF08211	dCMP_cyt_deam_2	Cytidine and deoxycytidylate deaminase zinc-binding region 
+PF08212	Lipocalin_2	Lipocalin-like domain
+PF08213	DUF1713	Mitochondrial domain of unknown function (DUF1713)
+PF08214	HAT_KAT11	Histone acetylation protein
+PF08216	CTNNBL	Catenin-beta-like, Arm-motif containing nuclear
+PF08217	DUF1712	Fungal domain of unknown function (DUF1712)
+PF08218	Citrate_ly_lig	Citrate lyase ligase C-terminal domain
+PF08219	TOM13	Outer membrane protein TOM13
+PF08220	HTH_DeoR	DeoR-like helix-turn-helix domain
+PF08221	HTH_9	RNA polymerase III subunit RPC82 helix-turn-helix domain
+PF08222	HTH_CodY	CodY helix-turn-helix domain
+PF08223	PaaX_C	PaaX-like protein C-terminal domain
+PF08224	DUF1719	Domain of unknown function (DUF1719)
+PF08225	Antimicrobial19	Pseudin antimicrobial peptide
+PF08226	DUF1720	Domain of unknown function (DUF1720)
+PF08227	DASH_Hsk3	DASH complex subunit Hsk3 like
+PF08228	RNase_P_pop3	RNase P subunit Pop3
+PF08229	SHR3_chaperone	ER membrane protein SH3 
+PF08230	CW_7	CW_7 repeat
+PF08231	SYF2	SYF2 splicing factor
+PF08232	Striatin	Striatin family
+PF08234	Spindle_Spc25	Chromosome segregation protein Spc25
+PF08235	LNS2	LNS2 (Lipin/Ned1/Smp2)
+PF08236	SRI	SRI (Set2 Rpb1 interacting) domain
+PF08237	PE-PPE	PE-PPE domain
+PF08238	Sel1	Sel1 repeat
+PF08239	SH3_3	Bacterial SH3 domain
+PF08240	ADH_N	Alcohol dehydrogenase GroES-like domain
+PF08241	Methyltransf_11	Methyltransferase domain
+PF08242	Methyltransf_12	Methyltransferase domain
+PF08243	SPT2	SPT2 chromatin protein
+PF08244	Glyco_hydro_32C	Glycosyl hydrolases family 32 C terminal
+PF08245	Mur_ligase_M	Mur ligase middle domain
+PF08246	Inhibitor_I29	Cathepsin propeptide inhibitor domain (I29)
+PF08247	ENOD40	ENOD40 protein
+PF08248	Tryp_FSAP	Tryptophyllin-3 skin active peptide
+PF08249	Mastoparan	Mastoparan protein
+PF08250	Sperm_act_pep	Sperm-activating peptides
+PF08251	Mastoparan_2	Mastoparan peptide
+PF08252	Leader_CPA1	arg-2/CPA1 leader peptide 
+PF08253	Leader_Erm	Erm Leader peptide 
+PF08254	Leader_Thr	Threonine leader peptide
+PF08255	Leader_Trp	Trp-operon Leader Peptide
+PF08256	Antimicrobial20	Aurein-like antibiotic peptide
+PF08257	Sulfakinin	Sulfakinin family
+PF08258	WWamide	WWamide peptide
+PF08259	Periviscerokin	Periviscerokinin family
+PF08260	Kinin	Insect kinin peptide
+PF08261	Carcinustatin	Carcinustatin peptide
+PF08262	Lem_TRP	Leucophaea maderae tachykinin-related peptide 
+PF08263	LRRNT_2	Leucine rich repeat N-terminal domain
+PF08264	Anticodon_1	Anticodon-binding domain of tRNA
+PF08265	YL1_C	YL1 nuclear protein C-terminal domain
+PF08266	Cadherin_2	Cadherin-like
+PF08267	Meth_synt_1	Cobalamin-independent synthase, N-terminal domain
+PF08268	FBA_3	F-box associated domain
+PF08269	dCache_2	Cache domain
+PF08270	PRD_Mga	M protein trans-acting positive regulator (MGA) PRD domain
+PF08271	TF_Zn_Ribbon	TFIIB zinc-binding
+PF08272	Topo_Zn_Ribbon	Topoisomerase I zinc-ribbon-like 
+PF08273	Prim_Zn_Ribbon	Zinc-binding domain of primase-helicase
+PF08274	PhnA_Zn_Ribbon	PhnA Zinc-Ribbon 
+PF08275	Toprim_N	DNA primase catalytic core, N-terminal domain
+PF08276	PAN_2	PAN-like domain
+PF08277	PAN_3	PAN-like domain
+PF08278	DnaG_DnaB_bind	DNA primase DnaG DnaB-binding 
+PF08279	HTH_11	HTH domain
+PF08280	HTH_Mga	M protein trans-acting positive regulator (MGA) HTH domain
+PF08281	Sigma70_r4_2	Sigma-70, region 4
+PF08282	Hydrolase_3	haloacid dehalogenase-like hydrolase
+PF08283	Gemini_AL1_M	Geminivirus rep protein central domain
+PF08284	RVP_2	Retroviral aspartyl protease
+PF08285	DPM3	Dolichol-phosphate mannosyltransferase subunit 3 (DPM3)
+PF08286	Spc24	Spc24 subunit of Ndc80
+PF08287	DASH_Spc19	Spc19
+PF08288	PIGA	PIGA (GPI anchor biosynthesis)
+PF08289	Flu_M1_C	Influenza Matrix protein (M1) C-terminal domain
+PF08290	Hep_core_N	Hepatitis core protein, putative zinc finger
+PF08291	Peptidase_M15_3	Peptidase M15 
+PF08292	RNA_pol_Rbc25	RNA polymerase III subunit Rpc25
+PF08293	MRP-S33	Mitochondrial ribosomal subunit S27
+PF08294	TIM21	TIM21
+PF08295	Sin3_corepress	Sin3 family co-repressor
+PF08297	U3_snoRNA_assoc	U3 snoRNA associated
+PF08298	AAA_PrkA	PrkA AAA domain
+PF08299	Bac_DnaA_C	Bacterial dnaA protein helix-turn-helix
+PF08300	HCV_NS5a_1a	Hepatitis C virus non-structural 5a zinc finger domain
+PF08301	HCV_NS5a_1b	Hepatitis C virus non-structural 5a domain 1b
+PF08302	tRNA_lig_CPD	Fungal tRNA ligase phosphodiesterase domain
+PF08303	tRNA_lig_kinase	tRNA ligase kinase domain
+PF08305	NPCBM	NPCBM/NEW2 domain
+PF08306	Glyco_hydro_98M	Glycosyl hydrolase family 98
+PF08307	Glyco_hydro_98C	Glycosyl hydrolase family 98 C-terminal domain
+PF08308	PEGA	PEGA domain
+PF08309	LVIVD	LVIVD repeat
+PF08310	LGFP	LGFP repeat
+PF08311	Mad3_BUB1_I	Mad3/BUB1 homology region 1
+PF08312	cwf21	cwf21 domain
+PF08313	SCA7	SCA7, zinc-binding domain
+PF08314	Sec39	Secretory pathway protein Sec39
+PF08315	cwf18	cwf18 pre-mRNA splicing factor 
+PF08316	Pal1	Pal1 cell morphology protein
+PF08317	Spc7	Spc7 kinetochore protein
+PF08318	COG4	COG4 transport protein
+PF08320	PIG-X	PIG-X / PBN1
+PF08321	PPP5	PPP5 TPR repeat region
+PF08323	Glyco_transf_5	Starch synthase catalytic domain
+PF08324	PUL	PUL domain
+PF08325	WLM	WLM domain
+PF08326	ACC_central	Acetyl-CoA carboxylase, central region
+PF08327	AHSA1	Activator of Hsp90 ATPase homolog 1-like protein
+PF08328	ASL_C	Adenylosuccinate lyase C-terminal
+PF08329	ChitinaseA_N	Chitinase A, N-terminal domain
+PF08331	DUF1730	Domain of unknown function (DUF1730)
+PF08332	CaMKII_AD	Calcium/calmodulin dependent protein kinase II association domain
+PF08333	DUF1725	Protein of unknown function (DUF1725)
+PF08334	T2SSG	Type II secretion system (T2SS), protein G
+PF08335	GlnD_UR_UTase	GlnD PII-uridylyltransferase
+PF08336	P4Ha_N	Prolyl 4-Hydroxylase alpha-subunit, N-terminal region
+PF08337	Plexin_cytopl	Plexin cytoplasmic RasGAP domain
+PF08338	DUF1731	Domain of unknown function (DUF1731)
+PF08339	RTX_C	RTX C-terminal domain
+PF08340	DUF1732	Domain of unknown function (DUF1732)
+PF08341	TED	Thioester domain
+PF08343	RNR_N	Ribonucleotide reductase N-terminal
+PF08344	TRP_2	Transient receptor ion channel II
+PF08345	YscJ_FliF_C	Flagellar M-ring protein C-terminal
+PF08346	AntA	AntA/AntB antirepressor
+PF08347	CTNNB1_binding	N-terminal CTNNB1 binding
+PF08348	PAS_6	YheO-like PAS domain
+PF08349	DUF1722	Protein of unknown function (DUF1722)
+PF08350	DUF1724	Domain of unknown function (DUF1724)
+PF08351	DUF1726	Domain of unknown function (DUF1726)
+PF08352	oligo_HPY	Oligopeptide/dipeptide transporter, C-terminal region
+PF08353	DUF1727	Domain of unknown function (DUF1727)
+PF08354	DUF1729	Domain of unknown function (DUF1729)
+PF08355	EF_assoc_1	EF hand associated
+PF08356	EF_assoc_2	EF hand associated
+PF08357	SEFIR	SEFIR domain
+PF08358	Flexi_CP_N	Carlavirus coat
+PF08359	TetR_C_4	YsiA-like protein, C-terminal region
+PF08360	TetR_C_5	QacR-like protein, C-terminal region
+PF08361	TetR_C_2	MAATS-type transcriptional repressor, C-terminal region
+PF08362	TetR_C_3	YcdC-like protein, C-terminal region
+PF08363	GbpC	Glucan-binding protein C
+PF08364	IF2_assoc	Bacterial translation initiation factor IF-2 associated region
+PF08365	IGF2_C	Insulin-like growth factor II E-peptide
+PF08366	LLGL	LLGL2
+PF08367	M16C_assoc	Peptidase M16C associated
+PF08368	FAST_2	FAST kinase-like protein, subdomain 2
+PF08369	PCP_red	Proto-chlorophyllide reductase 57 kD subunit
+PF08370	PDR_assoc	Plant PDR ABC transporter associated
+PF08372	PRT_C	Plant phosphoribosyltransferase C-terminal
+PF08373	RAP	RAP domain
+PF08374	Protocadherin	Protocadherin
+PF08375	Rpn3_C	Proteasome regulatory subunit C-terminal
+PF08376	NIT	Nitrate and nitrite sensing
+PF08377	MAP2_projctn	MAP2/Tau projection domain
+PF08378	NERD	Nuclease-related domain
+PF08379	Bact_transglu_N	Bacterial transglutaminase-like N-terminal region
+PF08381	BRX	Transcription factor regulating root and shoot growth via Pin3
+PF08383	Maf_N	Maf N-terminal region
+PF08384	NPP	Pro-opiomelanocortin, N-terminal region
+PF08385	DHC_N1	Dynein heavy chain, N-terminal region 1
+PF08386	Abhydrolase_4	TAP-like protein
+PF08387	FBD	FBD
+PF08388	GIIM	Group II intron, maturase-specific domain
+PF08389	Xpo1	Exportin 1-like protein
+PF08390	TRAM1	TRAM1-like protein
+PF08391	Ly49	Ly49-like protein, N-terminal region
+PF08392	FAE1_CUT1_RppA	FAE1/Type III polyketide synthase-like protein
+PF08393	DHC_N2	Dynein heavy chain, N-terminal region 2
+PF08394	Arc_trans_TRASH	Archaeal TRASH domain
+PF08395	7tm_7	7tm Chemosensory receptor
+PF08396	Toxin_34	Spider toxin omega agatoxin/Tx1 family
+PF08397	IMD	IRSp53/MIM homology domain
+PF08398	Parvo_coat_N	Parvovirus coat protein VP1
+PF08399	VWA_N	VWA N-terminal
+PF08400	phage_tail_N	Prophage tail fibre N-terminal
+PF08401	DUF1738	Domain of unknown function (DUF1738)
+PF08402	TOBE_2	TOBE domain
+PF08403	AA_permease_N	Amino acid permease N-terminal
+PF08404	Baculo_p74_N	Baculoviridae P74 N-terminal
+PF08405	Calici_PP_N	Viral polyprotein N-terminal
+PF08406	CbbQ_C	CbbQ/NirQ/NorQ C-terminal 
+PF08407	Chitin_synth_1N	Chitin synthase N-terminal
+PF08408	DNA_pol_B_3	DNA polymerase family B viral insert
+PF08409	DUF1736	Domain of unknown function (DUF1736)
+PF08410	DUF1737	Domain of unknown function (DUF1737)
+PF08411	Exonuc_X-T_C	Exonuclease C-terminal
+PF08412	Ion_trans_N	Ion transport protein N-terminal
+PF08414	NADPH_Ox	Respiratory burst NADPH oxidase
+PF08416	PTB	Phosphotyrosine-binding domain
+PF08417	PaO	Pheophorbide a oxygenase
+PF08418	Pol_alpha_B_N	DNA polymerase alpha subunit B N-terminal
+PF08421	Methyltransf_13	Putative zinc binding domain
+PF08423	Rad51	Rad51
+PF08424	NRDE-2	NRDE-2, necessary for RNA interference
+PF08426	ICE2	ICE2
+PF08427	DUF1741	Domain of unknown function (DUF1741)
+PF08428	Rib	Rib/alpha-like repeat
+PF08429	PLU-1	PLU-1-like protein
+PF08430	Forkhead_N	Forkhead N-terminal region
+PF08432	Vfa1	AAA-ATPase Vps4-associated protein 1
+PF08433	KTI12	Chromatin associated protein KTI12 
+PF08434	CLCA	Calcium-activated chloride channel N terminal
+PF08435	Calici_coat_C	Calicivirus coat protein C-terminal
+PF08436	DXP_redisom_C	1-deoxy-D-xylulose 5-phosphate reductoisomerase C-terminal
+PF08437	Glyco_transf_8C	Glycosyl transferase family 8 C-terminal
+PF08438	MMR_HSR1_C	GTPase of unknown function C-terminal
+PF08439	Peptidase_M3_N	Oligopeptidase F
+PF08440	Poty_PP	Potyviridae polyprotein
+PF08441	Integrin_alpha2	Integrin alpha
+PF08442	ATP-grasp_2	ATP-grasp domain
+PF08443	RimK	RimK-like ATP-grasp domain
+PF08444	Gly_acyl_tr_C	Aralkyl acyl-CoA:amino acid N-acyltransferase, C-terminal region
+PF08445	FR47	FR47-like protein
+PF08446	PAS_2	PAS fold
+PF08447	PAS_3	PAS fold
+PF08448	PAS_4	PAS fold
+PF08449	UAA	UAA transporter family
+PF08450	SGL	SMP-30/Gluconolaconase/LRE-like region
+PF08451	A_deaminase_N	Adenosine/AMP deaminase N-terminal
+PF08452	DNAP_B_exo_N	DNA polymerase family B exonuclease domain, N-terminal
+PF08453	Peptidase_M9_N	Peptidase family M9 N-terminal
+PF08454	RIH_assoc	RyR and IP3R Homology associated
+PF08455	SNF2_assoc	Bacterial SNF2 helicase associated
+PF08456	Vmethyltransf_C	Viral methyltransferase C-terminal
+PF08457	Sfi1	Sfi1 spindle body protein
+PF08458	PH_2	Plant pleckstrin homology-like region
+PF08459	UvrC_HhH_N	UvrC Helix-hairpin-helix N-terminal
+PF08460	SH3_5	Bacterial SH3 domain
+PF08461	HTH_12	Ribonuclease R winged-helix domain
+PF08462	Carmo_coat_C	Carmovirus coat protein
+PF08463	EcoEI_R_C	EcoEI R protein C-terminal
+PF08464	Gemini_AC4_5_2	Geminivirus AC4/5 conserved region
+PF08465	Herpes_TK_C	Thymidine kinase from Herpesvirus C-terminal
+PF08466	IRK_N	Inward rectifier potassium channel N-terminal
+PF08467	Luteo_P1-P2	Luteovirus RNA polymerase P1-P2/replicase
+PF08468	MTS_N	Methyltransferase small domain N-terminal
+PF08469	NPHI_C	Nucleoside triphosphatase I C-terminal
+PF08470	NTNH_C	Nontoxic nonhaemagglutinin C-terminal
+PF08471	Ribonuc_red_2_N	Class II vitamin B12-dependent ribonucleotide reductase
+PF08472	S6PP_C	Sucrose-6-phosphate phosphohydrolase C-terminal
+PF08473	VGCC_alpha2	Neuronal voltage-dependent calcium channel alpha 2acd
+PF08474	MYT1	Myelin transcription factor 1
+PF08475	Baculo_VP91_N	Viral capsid protein 91 N-terminal
+PF08476	VD10_N	Viral D10 N-terminal
+PF08477	Roc	Ras of Complex, Roc, domain of DAPkinase
+PF08478	POTRA_1	POTRA domain, FtsQ-type
+PF08479	POTRA_2	POTRA domain, ShlB-type
+PF08480	Disaggr_assoc	Disaggregatase related
+PF08481	GBS_Bsp-like	GBS Bsp-like repeat
+PF08482	HrpB_C	ATP-dependent helicase C-terminal
+PF08483	IstB_IS21_ATP	IstB-like ATP binding N-terminal
+PF08484	Methyltransf_14	C-methyltransferase C-terminal domain
+PF08485	Polysacc_syn_2C	Polysaccharide biosynthesis protein C-terminal
+PF08486	SpoIID	Stage II sporulation protein
+PF08487	VIT	Vault protein inter-alpha-trypsin domain
+PF08488	WAK	Wall-associated kinase
+PF08489	DUF1743	Domain of unknown function (DUF1743)
+PF08490	DUF1744	Domain of unknown function (DUF1744)
+PF08491	SE	Squalene epoxidase
+PF08492	SRP72	SRP72 RNA-binding domain
+PF08493	AflR	Aflatoxin regulatory protein
+PF08494	DEAD_assoc	DEAD/H associated
+PF08495	FIST	FIST N domain
+PF08496	Peptidase_S49_N	Peptidase family S49 N-terminal
+PF08497	Radical_SAM_N	Radical SAM N-terminal
+PF08498	Sterol_MT_C	Sterol methyltransferase C-terminal
+PF08499	PDEase_I_N	3'5'-cyclic nucleotide phosphodiesterase N-terminal
+PF08500	Tombus_P33	Tombusvirus p33 
+PF08501	Shikimate_dh_N	Shikimate dehydrogenase substrate binding domain
+PF08502	LeuA_dimer	LeuA allosteric (dimerisation) domain
+PF08503	DapH_N	Tetrahydrodipicolinate succinyltransferase N-terminal
+PF08504	RunxI	Runx inhibition domain
+PF08505	MMR1	Mitochondrial Myo2 receptor-related protein
+PF08506	Cse1	Cse1
+PF08507	COPI_assoc	COPI associated protein
+PF08508	DUF1746	Fungal domain of unknown function (DUF1746)
+PF08509	Ad_cyc_g-alpha	Adenylate cyclase G-alpha binding domain
+PF08510	PIG-P	PIG-P
+PF08511	COQ9	COQ9
+PF08512	Rtt106	Histone chaperone Rttp106-like
+PF08513	LisH	LisH
+PF08514	STAG	STAG domain  
+PF08515	TGF_beta_GS	Transforming growth factor beta type I GS-motif
+PF08516	ADAM_CR	ADAM cysteine-rich
+PF08517	AXH	Ataxin-1 and HBP1 module (AXH)
+PF08518	GIT_SHD	Spa2 homology domain (SHD) of GIT
+PF08519	RFC1	Replication factor RFC1 C terminal domain
+PF08520	DUF1748	Fungal protein of unknown function (DUF1748)
+PF08521	2CSK_N	Two-component sensor kinase N-terminal
+PF08522	DUF1735	Domain of unknown function (DUF1735)
+PF08523	MBF1	Multiprotein bridging factor 1
+PF08524	rRNA_processing	rRNA processing
+PF08525	OapA_N	Opacity-associated protein A N-terminal motif
+PF08526	PAD_N	Protein-arginine deiminase (PAD) N-terminal domain
+PF08527	PAD_M	Protein-arginine deiminase (PAD) middle domain
+PF08528	Whi5	Whi5 like
+PF08529	NusA_N	NusA N-terminal domain
+PF08530	PepX_C	X-Pro dipeptidyl-peptidase C-terminal non-catalytic domain
+PF08531	Bac_rhamnosid_N	Alpha-L-rhamnosidase N-terminal domain
+PF08532	Glyco_hydro_42M	Beta-galactosidase trimerisation domain
+PF08533	Glyco_hydro_42C	Beta-galactosidase C-terminal domain
+PF08534	Redoxin	Redoxin
+PF08535	KorB	KorB domain
+PF08536	Whirly	Whirly transcription factor
+PF08537	NBP1	Fungal Nap binding protein NBP1
+PF08538	DUF1749	Protein of unknown function (DUF1749)
+PF08539	HbrB	HbrB-like
+PF08540	HMG_CoA_synt_C	Hydroxymethylglutaryl-coenzyme A synthase C terminal
+PF08541	ACP_syn_III_C	3-Oxoacyl-[acyl-carrier-protein (ACP)] synthase III C terminal  
+PF08542	Rep_fac_C	Replication factor C C-terminal domain
+PF08543	Phos_pyr_kin	Phosphomethylpyrimidine kinase
+PF08544	GHMP_kinases_C	GHMP kinases C terminal 
+PF08545	ACP_syn_III	3-Oxoacyl-[acyl-carrier-protein (ACP)] synthase III
+PF08546	ApbA_C	Ketopantoate reductase PanE/ApbA C terminal
+PF08547	CIA30	Complex I intermediate-associated protein 30 (CIA30)
+PF08548	Peptidase_M10_C	Peptidase M10 serralysin C terminal
+PF08549	SWI-SNF_Ssr4	Fungal domain of unknown function (DUF1750)
+PF08550	DUF1752	Fungal protein of unknown function (DUF1752)
+PF08551	DUF1751	Eukaryotic integral membrane protein (DUF1751)
+PF08552	Kei1	Inositolphosphorylceramide synthase subunit Kei1
+PF08553	VID27	VID27 cytoplasmic protein
+PF08555	DUF1754	Eukaryotic family of unknown function (DUF1754)
+PF08557	Lipid_DES	Sphingolipid Delta4-desaturase (DES)
+PF08558	TRF	Telomere repeat binding factor (TRF)
+PF08559	Cut8	Cut8, nuclear proteasome tether protein
+PF08560	DUF1757	Protein of unknown function (DUF1757)
+PF08561	Ribosomal_L37	Mitochondrial ribosomal protein L37
+PF08562	Crisp	Crisp
+PF08563	P53_TAD	P53 transactivation motif
+PF08564	CDC37_C	Cdc37 C terminal domain
+PF08565	CDC37_M	Cdc37 Hsp90 binding domain
+PF08566	Pam17	Mitochondrial import protein Pam17
+PF08567	PH_TFIIH	TFIIH p62 subunit, N-terminal domain
+PF08568	Kinetochor_Ybp2	Uncharacterised protein family, YAP/Alf4/glomulin
+PF08569	Mo25	Mo25-like
+PF08570	DUF1761	Protein of unknown function (DUF1761)
+PF08571	Yos1	Yos1-like
+PF08572	PRP3	pre-mRNA processing factor 3 (PRP3)
+PF08573	SAE2	DNA repair protein endonuclease SAE2/CtIP C-terminus
+PF08574	Iwr1	Transcription factor Iwr1 
+PF08576	DUF1764	Eukaryotic protein of unknown function (DUF1764)
+PF08577	PI31_Prot_C	PI31 proteasome regulator 
+PF08578	DUF1765	Protein of unknown function (DUF1765)
+PF08579	RPM2	Mitochondrial ribonuclease P subunit (RPM2)
+PF08580	KAR9	Yeast cortical protein KAR9
+PF08581	Tup_N	Tup N-terminal
+PF08583	Cmc1	Cytochrome c oxidase biogenesis protein Cmc1 like
+PF08584	Ribonuc_P_40	Ribonuclease P 40kDa (Rpp40) subunit
+PF08585	RMI1_N	RecQ mediated genome instability protein
+PF08586	Rsc14	RSC complex, Rsc14/Ldb7 subunit
+PF08587	UBA_2	Ubiquitin associated domain (UBA) 
+PF08588	DUF1769	Protein of unknown function (DUF1769)
+PF08589	DUF1770	Fungal protein of unknown function (DUF1770)
+PF08590	DUF1771	Domain of unknown function (DUF1771)
+PF08591	RNR_inhib	Ribonucleotide reductase inhibitor
+PF08592	DUF1772	Domain of unknown function (DUF1772)
+PF08593	DUF1773	Domain of unknown function
+PF08594	UPF0300	Uncharacterised protein family (UPF0300)
+PF08595	RXT2_N	RXT2-like, N-terminal
+PF08596	Lgl_C	Lethal giant larvae(Lgl) like, C-terminal
+PF08597	eIF3_subunit	Translation initiation factor eIF3 subunit
+PF08598	Sds3	Sds3-like
+PF08599	Nbs1_C	DNA damage repair protein Nbs1
+PF08600	Rsm1	Rsm1-like
+PF08601	PAP1	Transcription factor PAP1
+PF08602	Mgr1	Mgr1-like, i-AAA protease complex subunit
+PF08603	CAP_C	Adenylate cyclase associated (CAP) C terminal
+PF08604	Nup153	Nucleoporin Nup153-like
+PF08605	Rad9_Rad53_bind	Fungal Rad9-like Rad53-binding
+PF08606	Prp19	Prp19/Pso4-like
+PF08608	Wyosine_form	Wyosine base formation
+PF08609	Fes1	Nucleotide exchange factor Fes1
+PF08610	Pex16	Peroxisomal membrane protein (Pex16)
+PF08611	DUF1774	Fungal protein of unknown function (DUF1774)
+PF08612	Med20	TATA-binding related factor (TRF) of subunit 20 of Mediator complex
+PF08613	Cyclin	Cyclin
+PF08614	ATG16	Autophagy protein 16 (ATG16)
+PF08615	RNase_H2_suC	Ribonuclease H2 non-catalytic subunit (Ylr154p-like)
+PF08616	SPA	Stabilization of polarity axis
+PF08617	CGI-121	Kinase binding protein CGI-121
+PF08618	Opi1	Transcription factor Opi1
+PF08619	Nha1_C	Alkali metal cation/H+ antiporter Nha1 C terminus
+PF08620	RPAP1_C	RPAP1-like, C-terminal
+PF08621	RPAP1_N	RPAP1-like, N-terminal
+PF08622	Svf1	Svf1-like N-terminal lipocalin domain
+PF08623	TIP120	TATA-binding protein interacting (TIP20)
+PF08624	CRC_subunit	Chromatin remodelling complex Rsc7/Swp82 subunit
+PF08625	Utp13	Utp13 specific WD40 associated domain
+PF08626	TRAPPC9-Trs120	Transport protein Trs120 or TRAPPC9, TRAPP II complex subunit
+PF08627	CRT-like	CRT-like, chloroquine-resistance transporter-like
+PF08628	Nexin_C	Sorting nexin C terminal
+PF08629	PDE8	PDE8 phosphodiesterase
+PF08630	Dfp1_Him1_M	Dfp1/Him1, central region
+PF08631	SPO22	Meiosis protein SPO22/ZIP4 like
+PF08632	Zds_C	Activator of mitotic machinery Cdc14 phosphatase activation C-term
+PF08633	Rox3	Rox3 mediator complex subunit
+PF08634	Pet127	Mitochondrial protein Pet127
+PF08635	ox_reductase_C	Putative oxidoreductase C terminal
+PF08636	Pkr1	ER protein Pkr1
+PF08637	NCA2	ATP synthase regulation protein NCA2
+PF08638	Med14	Mediator complex subunit MED14
+PF08639	SLD3	DNA replication regulator SLD3
+PF08640	U3_assoc_6	U3 small nucleolar RNA-associated protein 6
+PF08641	Mis14	Kinetochore protein Mis14 like
+PF08642	Rxt3	Histone deacetylation protein Rxt3
+PF08643	DUF1776	Fungal family of unknown function (DUF1776)
+PF08644	SPT16	FACT complex subunit (SPT16/CDC68)
+PF08645	PNK3P	Polynucleotide kinase 3 phosphatase
+PF08646	Rep_fac-A_C	Replication factor-A C terminal domain
+PF08647	BRE1	BRE1 E3 ubiquitin ligase
+PF08648	DUF1777	Protein of unknown function (DUF1777)
+PF08649	DASH_Dad1	DASH complex subunit Dad1
+PF08650	DASH_Dad4	DASH complex subunit Dad4
+PF08651	DASH_Duo1	DASH complex subunit Duo1
+PF08652	RAI1	RAI1 like PD-(D/E)XK nuclease
+PF08653	DASH_Dam1	DASH complex subunit Dam1
+PF08654	DASH_Dad2	DASH complex subunit Dad2
+PF08655	DASH_Ask1	DASH complex subunit Ask1
+PF08656	DASH_Dad3	DASH complex subunit Dad3
+PF08657	DASH_Spc34	DASH complex subunit Spc34 
+PF08658	Rad54_N	Rad54 N terminal
+PF08659	KR	KR domain
+PF08660	Alg14	Oligosaccharide biosynthesis protein Alg14 like
+PF08661	Rep_fac-A_3	Replication factor A protein 3
+PF08662	eIF2A	Eukaryotic translation initiation factor eIF2A
+PF08663	HalX	HalX domain
+PF08664	YcbB	YcbB domain
+PF08665	PglZ	PglZ domain
+PF08666	SAF	SAF domain
+PF08667	BetR	BetR domain
+PF08668	HDOD	HDOD domain
+PF08669	GCV_T_C	Glycine cleavage T-protein C-terminal barrel domain
+PF08670	MEKHLA	MEKHLA domain
+PF08671	SinI	Anti-repressor SinI
+PF08672	ANAPC2	Anaphase promoting complex (APC) subunit 2
+PF08673	RsbU_N	Phosphoserine phosphatase RsbU, N-terminal domain
+PF08674	AChE_tetra	Acetylcholinesterase tetramerisation domain
+PF08675	RNA_bind	RNA binding domain
+PF08676	MutL_C	MutL C terminal dimerisation domain
+PF08677	GP11	GP11 baseplate wedge protein
+PF08678	Rsbr_N	Rsbr N terminal
+PF08679	DsrD	Dissimilatory sulfite reductase D (DsrD)
+PF08680	DUF1779	TATA-box binding
+PF08681	DUF1778	Protein of unknown function (DUF1778)
+PF08682	DUF1780	Putative endonuclease, protein of unknown function (DUF1780)
+PF08683	CAMSAP_CKK	Microtubule-binding calmodulin-regulated spectrin-associated
+PF08684	ocr	DNA mimic ocr
+PF08685	GON	GON domain
+PF08686	PLAC	PLAC (protease and lacunin) domain
+PF08687	ASD2	Apx/Shroom domain ASD2
+PF08688	ASD1	Apx/Shroom domain ASD1
+PF08689	Med5	Mediator complex subunit Med5
+PF08690	GET2	GET complex subunit GET2
+PF08691	Nse5	DNA repair proteins Nse5 and Nse6
+PF08692	Pet20	Mitochondrial protein Pet20
+PF08693	SKG6	Transmembrane alpha-helix domain
+PF08694	UFC1	Ubiquitin-fold modifier-conjugating enzyme 1
+PF08695	Coa1	Cytochrome oxidase complex assembly protein 1
+PF08696	Dna2	DNA replication factor Dna2
+PF08698	Fcf2	Fcf2 pre-rRNA processing
+PF08699	ArgoL1	Argonaute linker 1 domain
+PF08700	Vps51	Vps51/Vps67
+PF08701	GN3L_Grn1	GNL3L/Grn1 putative GTPase
+PF08702	Fib_alpha	Fibrinogen alpha/beta chain family
+PF08703	PLC-beta_C	PLC-beta C terminal
+PF08704	GCD14	tRNA methyltransferase complex GCD14 subunit
+PF08705	Gag_p6	Gag protein p6
+PF08706	D5_N	D5 N terminal like
+PF08707	PriCT_2	Primase C terminal 2 (PriCT-2)   
+PF08708	PriCT_1	Primase C terminal 1 (PriCT-1)
+PF08709	Ins145_P3_rec	Inositol 1,4,5-trisphosphate/ryanodine receptor
+PF08710	nsp9	nsp9 replicase
+PF08711	Med26	TFIIS helical bundle-like domain
+PF08712	Nfu_N	Scaffold protein Nfu/NifU N terminal
+PF08713	DNA_alkylation	DNA alkylation repair enzyme
+PF08714	Fae	Formaldehyde-activating enzyme (Fae)
+PF08715	Viral_protease	Papain like viral protease
+PF08716	nsp7	nsp7 replicase
+PF08717	nsp8	nsp8 replicase
+PF08718	GLTP	Glycolipid transfer protein (GLTP)
+PF08719	DUF1768	Domain of unknown function (DUF1768)
+PF08720	Hema_stalk	Influenza C hemagglutinin stalk
+PF08721	Tn7_Tnp_TnsA_C	TnsA endonuclease C terminal
+PF08722	Tn7_Tnp_TnsA_N	TnsA endonuclease N terminal
+PF08723	Gag_p15	Gag protein p15
+PF08724	Rep_N	Rep protein catalytic domain like
+PF08725	Integrin_b_cyt	Integrin beta cytoplasmic domain
+PF08726	EFhand_Ca_insen	Ca2+ insensitive EF hand
+PF08727	P3A	Poliovirus 3A protein like
+PF08728	CRT10	CRT10
+PF08729	HUN	HPC2 and ubinuclein domain
+PF08730	Rad33	Rad33
+PF08731	AFT	Transcription factor AFT
+PF08732	HIM1	HIM1
+PF08733	PalH	PalH/RIM21
+PF08734	GYD	GYD domain
+PF08735	DUF1786	Putative pyruvate format-lyase activating enzyme (DUF1786)
+PF08736	FA	FERM adjacent (FA)
+PF08737	Rgp1	Rgp1
+PF08738	Gon7	Gon7 family
+PF08740	BCS1_N	BCS1 N terminal
+PF08741	YwhD	YwhD family
+PF08742	C8	C8 domain
+PF08743	Nse4_C	Nse4 C-terminal
+PF08744	NOZZLE	Plant transcription factor NOZZLE
+PF08745	PIN_5	PINc domain ribonuclease
+PF08746	zf-RING-like	RING-like domain
+PF08747	DUF1788	Domain of unknown function (DUF1788)
+PF08748	Phage_TAC_4	Phage tail assembly chaperone
+PF08750	CNP1	CNP1-like family
+PF08751	TrwC	TrwC relaxase
+PF08752	COP-gamma_platf	Coatomer gamma subunit appendage platform subdomain
+PF08753	NikR_C	NikR C terminal nickel binding domain
+PF08755	YccV-like	Hemimethylated DNA-binding protein YccV like
+PF08756	YfkB	YfkB-like domain
+PF08757	CotH	CotH kinase protein
+PF08758	Cadherin_pro	Cadherin prodomain like
+PF08759	GT-D	Glycosyltransferase GT-D fold
+PF08760	DUF1793	Domain of unknown function (DUF1793)
+PF08761	dUTPase_2	dUTPase
+PF08762	CRPV_capsid	CRPV capsid protein like
+PF08763	Ca_chan_IQ	Voltage gated calcium channel IQ domain
+PF08764	Coagulase	Staphylococcus aureus coagulase
+PF08765	Mor	Mor transcription activator family
+PF08766	DEK_C	DEK C terminal domain
+PF08767	CRM1_C	CRM1 C terminal
+PF08768	DUF1794	Domain of unknown function (DUF1794)
+PF08769	Spo0A_C	Sporulation initiation factor Spo0A C terminal
+PF08770	SoxZ	Sulphur oxidation protein SoxZ
+PF08771	FRB_dom	FKBP12-rapamycin binding domain 
+PF08772	NOB1_Zn_bind	Nin one binding (NOB1) Zn-ribbon like
+PF08773	CathepsinC_exc	Cathepsin C exclusion domain
+PF08774	VRR_NUC	VRR-NUC domain
+PF08775	ParB	ParB family
+PF08776	VASP_tetra	VASP tetramerisation domain
+PF08777	RRM_3	RNA binding motif
+PF08778	HIF-1a_CTAD	HIF-1 alpha C terminal transactivation domain
+PF08779	SARS_X4	SARS coronavirus X4 like
+PF08780	NTase_sub_bind	Nucleotidyltransferase substrate binding protein like
+PF08781	DP	Transcription factor DP
+PF08782	c-SKI_SMAD_bind	c-SKI Smad4 binding domain
+PF08783	DWNN	DWNN domain
+PF08784	RPA_C	Replication protein A C terminal
+PF08785	Ku_PK_bind	Ku C terminal domain like
+PF08786	DcrB	DcrB
+PF08787	Alginate_lyase2	Alginate lyase
+PF08788	NHR2	NHR2 domain like
+PF08789	PBCV_basic_adap	PBCV-specific basic adaptor domain
+PF08790	zf-LYAR	LYAR-type C2HC zinc finger 
+PF08792	A2L_zn_ribbon	A2L zinc ribbon domain
+PF08793	2C_adapt	2-cysteine adaptor domain
+PF08794	Lipoprot_C	Lipoprotein GNA1870 C terminal like
+PF08795	DUF1796	Putative papain-like cysteine peptidase (DUF1796)
+PF08796	DUF1797	Protein of unknown function (DUF1797)
+PF08797	HIRAN	HIRAN domain
+PF08798	CRISPR_assoc	CRISPR associated protein
+PF08799	PRP4	pre-mRNA processing factor 4 (PRP4) like
+PF08800	VirE_N	VirE N-terminal domain
+PF08801	Nucleoporin_N	Nup133 N terminal like
+PF08802	CytB6-F_Fe-S	Cytochrome B6-F complex Fe-S subunit 
+PF08803	ydhR	Putative mono-oxygenase ydhR
+PF08804	gp32	gp32 DNA binding protein like
+PF08805	PilS	PilS N terminal
+PF08806	Sep15_SelM	Sep15/SelM redox domain
+PF08807	DUF1798	Bacterial domain of unknown function (DUF1798)
+PF08808	RES	RES domain
+PF08809	DUF1799	Phage related hypothetical protein (DUF1799)
+PF08810	KapB	Kinase associated protein B
+PF08811	DUF1800	Protein of unknown function (DUF1800)
+PF08812	YtxC	YtxC-like family
+PF08813	Phage_tail_3	Phage tail tube protein, TTP
+PF08814	XisH	XisH protein
+PF08815	Nuc_rec_co-act	Nuclear receptor coactivator
+PF08816	Ivy	Inhibitor of vertebrate lysozyme (Ivy)
+PF08817	YukD	WXG100 protein secretion system (Wss), protein YukD
+PF08818	DUF1801	Domain of unknown function (DU1801)
+PF08819	DUF1802	Domain of unknown function (DUF1802)
+PF08820	DUF1803	Domain of unknown function (DUF1803)
+PF08821	CGGC	CGGC domain
+PF08822	DUF1804	Protein of unknown function (DUF1804)
+PF08823	PG_binding_2	Putative peptidoglycan binding domain
+PF08824	Serine_rich	Serine rich protein interaction domain
+PF08825	E2_bind	E2 binding domain
+PF08826	DMPK_coil	DMPK coiled coil domain like
+PF08827	DUF1805	Domain of unknown function (DUF1805)
+PF08828	DSX_dimer	Doublesex dimerisation domain
+PF08829	AlphaC_N	Alpha C protein N terminal
+PF08830	DUF1806	Protein of unknown function (DUF1806)
+PF08831	MHCassoc_trimer	Class II MHC-associated invariant chain trimerisation domain
+PF08832	SRC-1	Steroid receptor coactivator
+PF08833	Axin_b-cat_bind	Axin beta-catenin binding domain
+PF08837	DUF1810	Protein of unknown function (DUF1810)
+PF08838	DUF1811	Protein of unknown function (DUF1811)
+PF08839	CDT1	DNA replication factor CDT1 like
+PF08840	BAAT_C	BAAT / Acyl-CoA thioester hydrolase C terminal
+PF08841	DDR	Diol dehydratase reactivase ATPase-like domain
+PF08842	Mfa2	Fimbrillin-A associated anchor proteins Mfa1 and Mfa2
+PF08843	AbiEii	Nucleotidyl transferase AbiEii toxin, Type IV TA system
+PF08844	DUF1815	Domain of unknown function (DUF1815)
+PF08845	SymE_toxin	Toxin SymE, type I toxin-antitoxin system
+PF08846	DUF1816	Domain of unknown function (DUF1816)
+PF08847	Crr6	Chlororespiratory reduction 6
+PF08848	DUF1818	Domain of unknown function (DUF1818)
+PF08849	DUF1819	Putative inner membrane protein (DUF1819)
+PF08850	DUF1820	Domain of unknown function (DUF1820)
+PF08852	DUF1822	Protein of unknown function (DUF1822)
+PF08853	DUF1823	Domain of unknown function (DUF1823)
+PF08854	DUF1824	Domain of unknown function (DUF1824)
+PF08855	DUF1825	Domain of unknown function (DUF1825)
+PF08856	DUF1826	Protein of unknown function (DUF1826)
+PF08857	ParBc_2	Putative ParB-like nuclease
+PF08858	IDEAL	IDEAL domain
+PF08859	DGC	DGC domain
+PF08860	DUF1827	Domain of unknown function (DUF1827)
+PF08861	DUF1828	Domain of unknown function DUF1828
+PF08862	DUF1829	Domain of unknown function DUF1829
+PF08863	YolD	YolD-like protein
+PF08864	UPF0302	UPF0302 domain
+PF08865	DUF1830	Domain of unknown function (DUF1830)
+PF08866	DUF1831	Putative amino acid metabolism
+PF08867	FRG	FRG domain
+PF08868	YugN	YugN-like family
+PF08869	XisI	XisI protein
+PF08870	DndE	DNA sulphur modification protein DndE
+PF08872	KGK	KGK domain
+PF08873	DUF1834	Domain of unknown function (DUF1834)
+PF08874	DUF1835	Domain of unknown function (DUF1835)
+PF08875	DUF1833	Domain of unknown function (DUF1833)
+PF08876	DUF1836	Domain of unknown function (DUF1836)
+PF08877	MepB	MepB protein
+PF08878	DUF1837	Domain of unknown function (DUF1837)
+PF08879	WRC	WRC
+PF08880	QLQ	QLQ
+PF08881	CVNH	CVNH domain
+PF08882	Acetone_carb_G	Acetone carboxylase gamma subunit
+PF08883	DOPA_dioxygen	Dopa 4,5-dioxygenase family
+PF08884	Flagellin_D3	Flagellin D3 domain
+PF08885	GSCFA	GSCFA family
+PF08886	GshA	Glutamate-cysteine ligase
+PF08887	GAD-like	GAD-like domain
+PF08888	HopJ	HopJ type III effector protein
+PF08889	WbqC	WbqC-like protein family
+PF08890	Phage_TAC_5	Phage XkdN-like tail assembly chaperone protein, TAC
+PF08891	YfcL	YfcL protein
+PF08892	YqcI_YcgG	YqcI/YcgG family
+PF08893	DUF1839	Domain of unknown function (DUF1839)
+PF08894	DUF1838	Protein of unknown function (DUF1838)
+PF08895	DUF1840	Domain of unknown function (DUF1840)
+PF08896	DUF1842	Domain of unknown function (DUF1842)
+PF08897	DUF1841	Domain of unknown function (DUF1841)
+PF08898	DUF1843	Domain of unknown function (DUF1843)
+PF08899	DUF1844	Domain of unknown function (DUF1844)
+PF08900	DUF1845	Domain of unknown function (DUF1845)
+PF08901	DUF1847	Protein of unknown function (DUF1847)
+PF08902	DUF1848	Domain of unknown function (DUF1848)
+PF08903	DUF1846	Domain of unknown function (DUF1846)
+PF08904	DUF1849	Domain of unknown function (DUF1849)
+PF08905	DUF1850	Domain of unknown function (DUF1850)
+PF08906	DUF1851	Domain of unknown function (DUF1851)
+PF08907	DUF1853	Domain of unknown function (DUF1853)
+PF08908	DUF1852	Domain of unknown function (DUF1852)
+PF08909	DUF1854	Domain of unknown function (DUF1854)
+PF08910	Aida_N	Aida N-terminus
+PF08911	NUP50	NUP50 (Nucleoporin 50 kDa)
+PF08912	Rho_Binding	Rho Binding
+PF08913	VBS	Vinculin Binding Site
+PF08914	Myb_DNA-bind_2	Rap1 Myb domain
+PF08915	tRNA-Thr_ED	Archaea-specific editing domain of threonyl-tRNA synthetase
+PF08916	Phe_ZIP	Phenylalanine zipper
+PF08917	ecTbetaR2	Transforming growth factor beta receptor 2 ectodomain
+PF08918	PhoQ_Sensor	PhoQ Sensor
+PF08919	F_actin_bind	F-actin binding
+PF08920	SF3b1	Splicing factor 3B subunit 1
+PF08921	DUF1904	Domain of unknown function (DUF1904)
+PF08922	DUF1905	Domain of unknown function (DUF1905)
+PF08923	MAPKK1_Int	Mitogen-activated protein kinase kinase 1 interacting
+PF08924	DUF1906	Domain of unknown function (DUF1906)
+PF08925	DUF1907	Domain of Unknown Function (DUF1907)
+PF08926	DUF1908	Domain of unknown function (DUF1908)
+PF08928	DUF1910	Domain of unknown function (DUF1910)
+PF08929	DUF1911	Domain of unknown function (DUF1911)
+PF08930	DUF1912	Domain of unknown function (DUF1912)
+PF08931	Caudo_bapla_RBP	Receptor-binding protein of phage tail base-plate Siphoviridae, head
+PF08933	DUF1864	Domain of unknown function (DUF1864)
+PF08934	Rb_C	Rb C-terminal domain
+PF08935	VP4_2	Viral protein VP4 subunit
+PF08936	CsoSCA	Carboxysome Shell Carbonic Anhydrase
+PF08937	DUF1863	MTH538 TIR-like domain (DUF1863)
+PF08938	HBS1_N	HBS1 N-terminus
+PF08939	DUF1917	Domain of unknown function (DUF1917)
+PF08940	DUF1918	Domain of unknown function (DUF1918)
+PF08941	USP8_interact	USP8 interacting
+PF08942	DUF1919	Domain of unknown function (DUF1919)
+PF08943	CsiD	CsiD
+PF08944	p47_phox_C	NADPH oxidase subunit p47Phox, C terminal domain
+PF08945	Bclx_interact	Bcl-x interacting, BH3 domain
+PF08946	Osmo_CC	Osmosensory transporter coiled coil
+PF08947	BPS	BPS (Between PH and SH2) 
+PF08948	DUF1859	Domain of unknown function (DUF1859)
+PF08949	DUF1860	Domain of unknown function (DUF1860)
+PF08950	DUF1861	Protein of unknown function (DUF1861)
+PF08951	EntA_Immun	Enterocin A Immunity
+PF08952	DUF1866	Domain of unknown function (DUF1866) 
+PF08953	DUF1899	Domain of unknown function (DUF1899)
+PF08954	Trimer_CC	Trimerisation motif
+PF08955	BofC_C	BofC C-terminal domain
+PF08956	DUF1869	Domain of unknown function (DUF1869)
+PF08958	DUF1871	Domain of unknown function (DUF1871)
+PF08960	DUF1874	Domain of unknown function (DUF1874)
+PF08961	NRBF2	Nuclear receptor-binding factor 2, autophagy regulator
+PF08962	DUF1876	Domain of unknown function (DUF1876)
+PF08963	DUF1878	Protein of unknown function (DUF1878)
+PF08964	Crystall_3	Beta/Gamma crystallin
+PF08965	DUF1870	Domain of unknown function (DUF1870)
+PF08966	DUF1882	Domain of unknown function (DUF1882)
+PF08967	DUF1884	Domain of unknown function (DUF1884)
+PF08968	DUF1885	Domain of unknown function (DUF1885)
+PF08969	USP8_dimer	USP8 dimerisation domain
+PF08970	Sda	Sporulation inhibitor A
+PF08971	GlgS	Glycogen synthesis protein
+PF08972	DUF1902	Domain of unknown function (DUF1902)
+PF08973	TM1506	Domain of unknown function (DUF1893)
+PF08974	DUF1877	Domain of unknown function (DUF1877)
+PF08975	2H-phosphodiest	Domain of unknown function (DUF1868)
+PF08976	EF-hand_11	EF-hand domain
+PF08977	BOFC_N	Bypass of Forespore C, N terminal
+PF08978	Reoviridae_Vp9	Reoviridae VP9
+PF08979	DUF1894	Domain of unknown function (DUF1894)
+PF08980	DUF1883	Domain of unknown function (DUF1883)
+PF08982	DUF1857	Domain of unknown function (DUF1857)
+PF08983	DUF1856	Domain of unknown function (DUF1856)
+PF08984	DUF1858	Domain of unknown function (DUF1858)
+PF08985	DP-EP	DP-EP family
+PF08986	DUF1889	Domain of unknown function (DUF1889)
+PF08987	DUF1892	Protein of unknown function (DUF1892)
+PF08988	T3SS_needle_E	Type III secretion system, cytoplasmic E component of needle
+PF08989	DUF1896	Domain of unknown function (DUF1896)
+PF08990	Docking	Erythronolide synthase docking
+PF08991	MTCP1	Mature-T-Cell Proliferation I type
+PF08992	QH-AmDH_gamma	Quinohemoprotein amine dehydrogenase, gamma subunit
+PF08993	T4_Gp59_N	T4 gene Gp59 loader of gp41 DNA helicase
+PF08994	T4_Gp59_C	T4 gene Gp59 loader of gp41 DNA helicase C-term
+PF08995	NIP_1	Necrosis inducing protein-1
+PF08996	zf-DNA_Pol	DNA Polymerase alpha zinc finger
+PF08997	UCR_6-4kD	Ubiquinol-cytochrome C reductase complex, 6.4kD protein
+PF08998	Epsilon_antitox	Bacterial epsilon antitoxin
+PF08999	SP_C-Propep	Surfactant protein C, N terminal propeptide
+PF09000	Cytotoxic	Cytotoxic
+PF09001	DUF1890	Domain of unknown function (DUF1890)
+PF09002	DUF1887	Domain of unknown function (DUF1887)
+PF09003	Arm-DNA-bind_1	Bacteriophage lambda integrase, Arm DNA-binding domain 
+PF09004	DUF1891	Domain of unknown function (DUF1891)
+PF09005	DUF1897	Domain of unknown function (DUF1897)
+PF09006	Surfac_D-trimer	Lung surfactant protein D coiled-coil trimerisation
+PF09007	EBP50_C	EBP50, C-terminal
+PF09008	Head_binding	Head binding
+PF09009	Exotox-A_cataly	Exotoxin A catalytic
+PF09010	AsiA	Anti-Sigma Factor A
+PF09011	HMG_box_2	HMG-box domain
+PF09012	FeoC	FeoC like transcriptional regulator
+PF09013	YopH_N	YopH, N-terminal
+PF09014	Sushi_2	Beta-2-glycoprotein-1 fifth domain
+PF09015	NgoMIV_restric	NgoMIV restriction enzyme
+PF09016	Pas_Saposin	Pas factor saposin fold
+PF09017	Transglut_prok	Microbial transglutaminase
+PF09018	Phage_Capsid_P3	P3 major capsid protein
+PF09019	EcoRII-C	EcoRII C terminal
+PF09020	YopE_N	YopE, N terminal
+PF09021	HutP	HutP
+PF09022	Staphostatin_A	Staphostatin A
+PF09023	Staphostatin_B	Staphostatin B
+PF09025	T3SS_needle_reg	YopR, type III needle-polymerisation regulator
+PF09026	CENP-B_dimeris	Centromere protein B dimerisation domain
+PF09027	GTPase_binding	GTPase binding
+PF09028	Mac-1	Mac 1
+PF09029	Preseq_ALAS	5-aminolevulinate synthase presequence
+PF09030	Creb_binding	Creb binding
+PF09032	Siah-Interact_N	Siah interacting protein, N terminal 
+PF09033	DFF-C	DNA Fragmentation factor 45kDa, C terminal domain
+PF09034	TRADD_N	TRADD, N-terminal domain
+PF09035	Tn916-Xis	Excisionase from transposon Tn916
+PF09036	Bcr-Abl_Oligo	Bcr-Abl oncoprotein oligomerisation domain
+PF09037	Sulphotransf	Stf0 sulphotransferase
+PF09038	53-BP1_Tudor	Tumour suppressor p53-binding protein-1 Tudor
+PF09039	HTH_Tnp_Mu_2	Mu DNA binding, I gamma subdomain
+PF09040	H-K_ATPase_N	Gastric H+/K+-ATPase, N terminal domain
+PF09041	Aurora-A_bind	Aurora-A binding 
+PF09042	Titin_Z	Titin Z
+PF09043	Lys-AminoMut_A	D-Lysine 5,6-aminomutase TIM-barrel domain of alpha subunit
+PF09044	Kp4	Kp4
+PF09045	L27_2	L27_2
+PF09046	AvrPtoB-E3_ubiq	AvrPtoB E3 ubiquitin ligase
+PF09047	MEF2_binding	MEF2 binding
+PF09048	Cro	Cro
+PF09049	SNN_transmemb	Stannin transmembrane
+PF09050	SNN_linker	Stannin unstructured linker
+PF09051	SNN_cytoplasm	Stannin cytoplasmic
+PF09052	SipA	Salmonella invasion protein A
+PF09053	CagZ	CagZ
+PF09055	Sod_Ni	Nickel-containing superoxide dismutase
+PF09056	Phospholip_A2_3	Prokaryotic phospholipase A2
+PF09057	Smac_DIABLO	Second Mitochondria-derived Activator of Caspases
+PF09058	L27_1	L27_1
+PF09059	TyeA	TyeA
+PF09060	L27_N	L27_N
+PF09061	Stirrup	Stirrup
+PF09062	Endonuc_subdom	PI-PfuI Endonuclease subdomain
+PF09063	Phage_coat	Phage PP7 coat protein
+PF09064	Tme5_EGF_like	Thrombomodulin like fifth domain, EGF-like
+PF09065	Haemadin	Haemadin
+PF09066	B2-adapt-app_C	Beta2-adaptin appendage, C-terminal sub-domain
+PF09067	EpoR_lig-bind	Erythropoietin receptor, ligand binding
+PF09068	EF-hand_2	EF hand
+PF09069	EF-hand_3	EF-hand
+PF09070	PFU	PFU (PLAA family ubiquitin binding)
+PF09071	Alpha-amyl_C	Alpha-amylase, C terminal
+PF09072	TMA7	Translation machinery associated TMA7
+PF09073	BUD22	BUD22
+PF09074	Mer2	Mer2
+PF09075	STb_secrete	Heat-stable enterotoxin B, secretory
+PF09076	Crystall_2	Beta/Gamma crystallin
+PF09077	Phage-MuB_C	Mu B transposition protein, C terminal 
+PF09078	CheY-binding	CheY binding
+PF09079	Cdc6_C	CDC6, C terminal winged helix domain
+PF09080	K-cyclin_vir_C	K cyclin, C terminal
+PF09081	DUF1921	Domain of unknown function (DUF1921)
+PF09082	DUF1922	Domain of unknown function (DUF1922)
+PF09083	DUF1923	Domain of unknown function (DUF1923)
+PF09084	NMT1	NMT1/THI5 like
+PF09085	Adhes-Ig_like	Adhesion molecule, immunoglobulin-like
+PF09086	DUF1924	Domain of unknown function (DUF1924)
+PF09087	Cyc-maltodext_N	Cyclomaltodextrinase, N-terminal
+PF09088	MIF4G_like	MIF4G like
+PF09089	gp12-short_mid	Phage short tail fibre protein gp12, middle domain
+PF09090	MIF4G_like_2	MIF4G like
+PF09092	Lyase_N	Lyase, N terminal
+PF09093	Lyase_catalyt	Lyase, catalytic
+PF09094	DUF1925	Domain of unknown function (DUF1925)
+PF09095	DUF1926	Domain of unknown function (DUF1926)
+PF09096	Phage-tail_2	Baseplate structural protein, domain 2
+PF09097	Phage-tail_1	Baseplate structural protein, domain 1
+PF09098	Dehyd-heme_bind	Quinohemoprotein amine dehydrogenase A, alpha subunit, haem binding
+PF09099	Qn_am_d_aIII	Quinohemoprotein amine dehydrogenase, alpha subunit domain III
+PF09100	Qn_am_d_aIV	Quinohemoprotein amine dehydrogenase, alpha subunit domain IV
+PF09101	Exotox-A_bind	Exotoxin A binding
+PF09102	Exotox-A_target	Exotoxin A, targeting
+PF09103	BRCA-2_OB1	BRCA2, oligonucleotide/oligosaccharide-binding, domain 1
+PF09104	BRCA-2_OB3	BRCA2, oligonucleotide/oligosaccharide-binding, domain 3
+PF09105	SelB-wing_1	Elongation factor SelB, winged helix 
+PF09106	SelB-wing_2	Elongation factor SelB, winged helix 
+PF09107	SelB-wing_3	Elongation factor SelB, winged helix 
+PF09108	Xol-1_N	Switch protein XOL-1, N-terminal
+PF09109	Xol-1_GHMP-like	Switch protein XOL-1, GHMP-like
+PF09110	HAND	HAND
+PF09111	SLIDE	SLIDE
+PF09112	N-glycanase_N	Peptide-N-glycosidase F, N terminal
+PF09113	N-glycanase_C	Peptide-N-glycosidase F, C terminal
+PF09114	MotA_activ	Transcription factor MotA, activation domain
+PF09115	DNApol3-delta_C	DNA polymerase III, delta subunit, C terminal
+PF09116	gp45-slide_C	gp45 sliding clamp, C terminal
+PF09117	MiAMP1	MiAMP1
+PF09118	DUF1929	Domain of unknown function (DUF1929)
+PF09119	SicP-binding	SicP binding
+PF09121	Tower	Tower
+PF09122	DUF1930	Domain of unknown function (DUF1930)
+PF09123	DUF1931	Domain of unknown function (DUF1931)
+PF09124	Endonuc-dimeris	T4 recombination endonuclease VII, dimerisation
+PF09125	COX2-transmemb	Cytochrome C oxidase subunit II, transmembrane
+PF09126	NaeI	Restriction endonuclease NaeI 
+PF09127	Leuk-A4-hydro_C	Leukotriene A4 hydrolase, C-terminal
+PF09128	RGS-like	Regulator of G protein signalling-like domain
+PF09129	Chol_subst-bind	Cholesterol oxidase, substrate-binding
+PF09130	DUF1932	Domain of unknown function (DUF1932)
+PF09131	Endotoxin_mid	Bacillus thuringiensis delta-Endotoxin, middle domain
+PF09132	BmKX	BmKX
+PF09133	SANTA	SANTA (SANT Associated)
+PF09134	Invasin_D3	Invasin, domain 3
+PF09135	Alb1	Alb1
+PF09136	Glucodextran_B	Glucodextranase, domain B
+PF09137	Glucodextran_N	Glucodextranase, domain N
+PF09138	Urm1	Urm1 (Ubiquitin related modifier)
+PF09139	Mmp37	Mitochondrial matrix Mmp37
+PF09140	MipZ	ATPase MipZ
+PF09141	Talin_middle	Talin, middle domain
+PF09142	TruB_C	tRNA Pseudouridine synthase II, C terminal
+PF09143	AvrPphF-ORF-2	AvrPphF-ORF-2
+PF09144	YpM	Yersinia pseudo-tuberculosis mitogen
+PF09145	Ubiq-assoc	Ubiquitin-associated
+PF09147	DUF1933	Domain of unknown function (DUF1933)
+PF09148	DUF1934	Domain of unknown function (DUF1934)
+PF09149	DUF1935	Domain of unknown function (DUF1935)
+PF09150	Carot_N	Orange carotenoid protein, N-terminal 
+PF09151	DUF1936	Domain of unknown function (DUF1936)
+PF09152	DUF1937	Domain of unknown function (DUF1937)
+PF09153	DUF1938	Domain of unknown function (DUF1938)
+PF09154	DUF1939	Domain of unknown function (DUF1939)
+PF09155	DUF1940	Domain of unknown function (DUF1940)
+PF09156	Anthrax-tox_M	Anthrax toxin lethal factor, middle domain
+PF09157	TruB-C_2	Pseudouridine synthase II TruB, C-terminal
+PF09158	MotCF	Bacteriophage T4 MotA, C-terminal
+PF09159	Ydc2-catalyt	Mitochondrial resolvase Ydc2 / RNA splicing MRS1
+PF09160	FimH_man-bind	FimH, mannose binding
+PF09162	Tap-RNA_bind	Tap, RNA-binding
+PF09163	Form-deh_trans	Formate dehydrogenase N, transmembrane
+PF09164	VitD-bind_III	Vitamin D binding protein, domain III
+PF09165	Ubiq-Cytc-red_N	Ubiquinol-cytochrome c reductase 8 kDa, N-terminal
+PF09166	Biliv-reduc_cat	Biliverdin reductase, catalytic
+PF09167	DUF1942	Domain of unknown function (DUF1942)
+PF09168	PepX_N	X-Prolyl dipeptidyl aminopeptidase PepX, N-terminal
+PF09169	BRCA-2_helical	BRCA2, helical
+PF09170	STN1_2	CST, Suppressor of cdc thirteen homolog, complex subunit STN1
+PF09171	AGOG	N-glycosylase/DNA lyase
+PF09172	DUF1943	Domain of unknown function (DUF1943)
+PF09173	eIF2_C	Initiation factor eIF2 gamma, C terminal
+PF09174	Maf1	Maf1 regulator
+PF09175	DUF1944	Domain of unknown function (DUF1944)
+PF09176	Mpt_N	Methylene-tetrahydromethanopterin dehydrogenase, N-terminal
+PF09177	Syntaxin-6_N	Syntaxin 6, N-terminal
+PF09178	DUF1945	Domain of unknown function (DUF1945)
+PF09179	TilS	TilS substrate binding domain
+PF09180	ProRS-C_1	Prolyl-tRNA synthetase, C-terminal
+PF09181	ProRS-C_2	Prolyl-tRNA synthetase, C-terminal
+PF09182	PuR_N	Bacterial purine repressor, N-terminal
+PF09183	DUF1947	Domain of unknown function (DUF1947)
+PF09184	PPP4R2	PPP4R2
+PF09185	DUF1948	Domain of unknown function (DUF1948)
+PF09186	DUF1949	Domain of unknown function (DUF1949)
+PF09187	RdDM_RDM1	RNA-directed DNA methylation 1
+PF09188	DUF1951	Domain of unknown function (DUF1951)
+PF09189	DUF1952	Domain of unknown function (DUF1952)
+PF09190	DALR_2	DALR domain
+PF09191	CD4-extracel	CD4, extracellular
+PF09192	Act-Frag_cataly	Actin-fragmin kinase, catalytic
+PF09193	CholecysA-Rec_N	Cholecystokinin A receptor, N-terminal
+PF09194	Endonuc-BsobI	Restriction endonuclease BsobI
+PF09195	Endonuc-BglII	Restriction endonuclease BglII
+PF09196	DUF1953	Domain of unknown function (DUF1953)
+PF09197	Rap1-DNA-bind	Rap1, DNA-binding
+PF09198	T4-Gluco-transf	Bacteriophage T4 beta-glucosyltransferase
+PF09199	SSL_OB	Staphylococcal superantigen-like OB-fold domain 
+PF09200	Monellin	Monellin
+PF09201	SRX	SRX, signal recognition particle receptor alpha subunit
+PF09202	Rio2_N	Rio2, N-terminal
+PF09203	MspA	MspA
+PF09204	Colicin_immun	Bacterial self-protective colicin-like immunity
+PF09205	DUF1955	Domain of unknown function (DUF1955)
+PF09206	ArabFuran-catal	Alpha-L-arabinofuranosidase B, catalytic
+PF09207	Yeast-kill-tox	Yeast killer toxin
+PF09208	Endonuc-MspI	Restriction endonuclease MspI 
+PF09209	DUF1956	Domain of unknown function (DUF1956)
+PF09210	DUF1957	Domain of unknown function (DUF1957)
+PF09211	DUF1958	Domain of unknown function (DUF1958)
+PF09212	CBM27	Carbohydrate binding module 27
+PF09213	M3	M3
+PF09214	Prd1-P2	Bacteriophage Prd1, adsorption protein P2
+PF09215	Phage-Gp8	Bacteriophage T4, Gp8
+PF09216	Pfg27	Pfg27
+PF09217	EcoRII-N	Restriction endonuclease EcoRII, N-terminal
+PF09218	DUF1959	Domain of unknown function (DUF1959)
+PF09220	LA-virus_coat	L-A virus, major coat protein
+PF09221	Bacteriocin_IId	Bacteriocin class IId cyclical uberolysin-like
+PF09222	Fim-adh_lectin	Fimbrial adhesin F17-AG, lectin domain
+PF09223	ZinT	ZinT (YodA) periplasmic lipocalin-like zinc-recruitment
+PF09224	DUF1961	Domain of unknown function (DUF1961)
+PF09225	Endonuc-PvuII	Restriction endonuclease PvuII
+PF09226	Endonuc-HincII	Restriction endonuclease HincII
+PF09227	DUF1962	Domain of unknown function (DUF1962)
+PF09228	Prok-TraM	Prokaryotic Transcriptional repressor TraM
+PF09229	Aha1_N	Activator of Hsp90 ATPase, N-terminal
+PF09230	DFF40	DNA fragmentation factor 40 kDa
+PF09231	RDV-p3	Rice dwarf virus p3
+PF09232	Caenor_Her-1	Caenorhabditis elegans Her-1
+PF09233	Endonuc-EcoRV	Restriction endonuclease EcoRV
+PF09234	DUF1963	Domain of unknown function (DUF1963)
+PF09235	Ste50p-SAM	Ste50p, sterile alpha motif
+PF09236	AHSP	Alpha-haemoglobin stabilising protein
+PF09237	GAGA	GAGA factor
+PF09238	IL4Ra_N	Interleukin-4 receptor alpha chain, N-terminal
+PF09239	Topo-VIb_trans	Topoisomerase VI B subunit, transducer
+PF09240	IL6Ra-bind	Interleukin-6 receptor alpha chain, binding
+PF09241	Herp-Cyclin	Herpesviridae viral cyclin
+PF09242	FCSD-flav_bind	Flavocytochrome c sulphide dehydrogenase, flavin-binding
+PF09243	Rsm22	Mitochondrial small ribosomal subunit Rsm22
+PF09244	DUF1964	Domain of unknown function (DUF1964)
+PF09245	MA-Mit	Mycoplasma arthritidis-derived mitogen
+PF09246	PHAT	PHAT
+PF09247	TBP-binding	TATA box-binding protein binding
+PF09248	DUF1965	Domain of unknown function (DUF1965)
+PF09249	tRNA_NucTransf2	tRNA nucleotidyltransferase, second domain
+PF09250	Prim-Pol	Bifunctional DNA primase/polymerase, N-terminal
+PF09251	PhageP22-tail	Salmonella phage P22 tail-spike
+PF09252	Feld-I_B	Allergen Fel d I-B chain
+PF09253	Ole-e-6	Pollen allergen ole e 6
+PF09254	Endonuc-FokI_C	Restriction endonuclease FokI, C terminal
+PF09255	Antig_Caf1	Caf1 Capsule antigen
+PF09256	BaffR-Tall_bind	BAFF-R, TALL-1 binding
+PF09257	BCMA-Tall_bind	BCMA, TALL-1 binding
+PF09258	Glyco_transf_64	Glycosyl transferase family 64 domain
+PF09259	Fve	Fungal immunomodulatory protein Fve
+PF09260	DUF1966	Domain of unknown function (DUF1966)
+PF09261	Alpha-mann_mid	Alpha mannosidase middle domain
+PF09262	PEX-1N	Peroxisome biogenesis factor 1, N-terminal 
+PF09263	PEX-2N	Peroxisome biogenesis factor 1, N-terminal 
+PF09264	Sial-lect-inser	Vibrio cholerae sialidase, lectin insertion
+PF09265	Cytokin-bind	Cytokinin dehydrogenase 1, FAD and cytokinin binding
+PF09266	VirDNA-topo-I_N	Viral DNA topoisomerase I, N-terminal
+PF09267	Dict-STAT-coil	Dictyostelium STAT, coiled coil
+PF09268	Clathrin-link	Clathrin, heavy-chain linker
+PF09269	DUF1967	Domain of unknown function (DUF1967)
+PF09270	BTD	Beta-trefoil DNA-binding domain
+PF09271	LAG1-DNAbind	LAG1, DNA binding
+PF09272	Hepsin-SRCR	Hepsin, SRCR
+PF09273	Rubis-subs-bind	Rubisco LSMT substrate-binding
+PF09274	ParG	ParG
+PF09275	Pertus-S4-tox	Pertussis toxin S4 subunit
+PF09276	Pertus-S5-tox	Pertussis toxin S5 subunit 
+PF09277	Erythro-docking	Erythronolide synthase, docking
+PF09278	MerR-DNA-bind	MerR, DNA binding
+PF09279	EF-hand_like	Phosphoinositide-specific phospholipase C, efhand-like
+PF09280	XPC-binding	XPC-binding domain
+PF09281	Taq-exonuc	Taq polymerase, exonuclease
+PF09282	Mago-bind	Mago binding
+PF09284	RhgB_N	Rhamnogalacturonan lyase B, N-terminal
+PF09285	Elong-fact-P_C	Elongation factor P, C-terminal
+PF09286	Pro-kuma_activ	Pro-kumamolisin, activation domain 
+PF09287	CEP1-DNA_bind	CEP-1, DNA binding
+PF09288	UBA_3	Fungal ubiquitin-associated domain 
+PF09289	FOLN	Follistatin/Osteonectin-like EGF domain
+PF09290	AcetDehyd-dimer	Prokaryotic acetaldehyde dehydrogenase, dimerisation
+PF09291	DUF1968	Domain of unknown function (DUF1968)
+PF09292	Neil1-DNA_bind	Endonuclease VIII-like 1, DNA bind
+PF09293	RNaseH_C	T4 RNase H, C terminal
+PF09294	Interfer-bind	Interferon-alpha/beta receptor, fibronectin type III
+PF09295	ChAPs	ChAPs (Chs5p-Arf1p-binding proteins)
+PF09296	NUDIX-like	NADH pyrophosphatase-like rudimentary NUDIX domain
+PF09297	zf-NADH-PPase	NADH pyrophosphatase zinc ribbon domain
+PF09298	FAA_hydrolase_N	Fumarylacetoacetase N-terminal
+PF09299	Mu-transpos_C	Mu transposase, C-terminal
+PF09300	Tecti-min-caps	Tectiviridae, minor capsid
+PF09301	DUF1970	Domain of unknown function (DUF1970)
+PF09302	XLF	XLF-Cernunnos, XRcc4-like factor, NHEJ component
+PF09303	KcnmB2_inactiv	KCNMB2, ball and chain domain
+PF09304	Cortex-I_coil	Cortexillin I, coiled coil
+PF09305	TACI-CRD2	TACI, cysteine-rich domain
+PF09306	Phage-scaffold	Bacteriophage, scaffolding protein
+PF09307	MHC2-interact	CLIP, MHC2 interacting
+PF09308	LuxQ-periplasm	LuxQ, periplasmic
+PF09309	FCP1_C	FCP1, C-terminal
+PF09310	PD-C2-AF1	POU domain, class 2, associating factor 1
+PF09311	Rab5-bind	Rabaptin-like protein
+PF09312	SurA_N	SurA N-terminal domain
+PF09313	DUF1971	Domain of unknown function (DUF1971)
+PF09314	DUF1972	Domain of unknown function (DUF1972)
+PF09316	Cmyb_C	C-myb, C-terminal
+PF09317	DUF1974	Domain of unknown function (DUF1974)
+PF09318	Glyco_trans_A_1	Glycosyl transferase 1 domain A
+PF09320	DUF1977	Domain of unknown function (DUF1977)
+PF09321	DUF1978	Domain of unknown function (DUF1978)
+PF09322	DUF1979	Domain of unknown function (DUF1979)
+PF09323	DUF1980	Domain of unknown function (DUF1980)
+PF09324	DUF1981	Domain of unknown function (DUF1981)
+PF09325	Vps5	Vps5 C terminal like
+PF09326	NADH_dhqG_C	NADH-ubiquinone oxidoreductase subunit G, C-terminal
+PF09327	DUF1983	Domain of unknown function (DUF1983)
+PF09328	Phytochelatin_C	Domain of unknown function (DUF1984)
+PF09329	zf-primase	Primase zinc finger
+PF09330	Lact-deh-memb	D-lactate dehydrogenase, membrane binding
+PF09331	DUF1985	Domain of unknown function (DUF1985)
+PF09332	Mcm10	Mcm10 replication factor
+PF09333	ATG_C	Autophagy-related protein C terminal domain
+PF09334	tRNA-synt_1g	tRNA synthetases class I (M)
+PF09335	SNARE_assoc	SNARE associated Golgi protein
+PF09336	Vps4_C	Vps4 C terminal oligomerisation domain
+PF09337	zf-H2C2	His(2)-Cys(2) zinc finger
+PF09338	Gly_reductase	Glycine/sarcosine/betaine reductase component B subunits
+PF09339	HTH_IclR	IclR helix-turn-helix domain
+PF09340	NuA4	Histone acetyltransferase subunit NuA4
+PF09341	Pcc1	Transcription factor Pcc1
+PF09342	DUF1986	Domain of unknown function (DUF1986)
+PF09343	DUF2460	Conserved hypothetical protein 2217 (DUF2460)
+PF09344	Cas_CT1975	CT1975-like protein
+PF09345	DUF1987	Domain of unknown function (DUF1987)
+PF09346	SMI1_KNR4	SMI1 / KNR4 family (SUKH-1)
+PF09347	DUF1989	Domain of unknown function (DUF1989)
+PF09348	DUF1990	Domain of unknown function (DUF1990)
+PF09349	OHCU_decarbox	OHCU decarboxylase
+PF09350	DUF1992	Domain of unknown function (DUF1992)
+PF09351	DUF1993	Domain of unknown function (DUF1993)
+PF09353	DUF1995	Domain of unknown function (DUF1995)
+PF09354	HNF_C	HNF3 C-terminal domain
+PF09355	Phage_Gp19	Phage protein Gp19/Gp15/Gp42
+PF09356	Phage_BR0599	Phage conserved hypothetical protein BR0599
+PF09357	RteC	RteC protein
+PF09358	E1_UFD	Ubiquitin fold domain
+PF09359	VTC	VTC domain
+PF09360	zf-CDGSH	Iron-binding zinc finger CDGSH type
+PF09361	Phasin_2	Phasin protein
+PF09362	DUF1996	Domain of unknown function (DUF1996)
+PF09363	XFP_C	XFP C-terminal domain
+PF09364	XFP_N	XFP N-terminal domain
+PF09365	DUF2461	Conserved hypothetical protein (DUF2461)
+PF09366	DUF1997	Protein of unknown function (DUF1997)
+PF09367	CpeS	CpeS-like protein
+PF09368	Sas10	Sas10 C-terminal domain
+PF09369	DUF1998	Domain of unknown function (DUF1998)
+PF09370	PEP_hydrolase	Phosphoenolpyruvate hydrolase-like
+PF09371	Tex_N	Tex-like protein N-terminal domain
+PF09372	PRANC	PRANC domain
+PF09373	PMBR	Pseudomurein-binding repeat
+PF09374	PG_binding_3	Predicted Peptidoglycan domain
+PF09375	Peptidase_M75	Imelysin
+PF09376	NurA	NurA domain
+PF09377	SBDS_C	SBDS protein C-terminal domain
+PF09378	HAS-barrel	HAS barrel domain
+PF09379	FERM_N	FERM N-terminal domain 
+PF09380	FERM_C	FERM C-terminal PH-like domain
+PF09381	Porin_OmpG	Outer membrane protein G (OmpG)
+PF09382	RQC	RQC domain
+PF09383	NIL	NIL domain
+PF09384	UTP15_C	UTP15 C terminal
+PF09385	HisK_N	Histidine kinase N terminal
+PF09386	ParD	Antitoxin ParD
+PF09387	MRP	Mitochondrial RNA binding protein MRP
+PF09388	SpoOE-like	Spo0E like sporulation regulatory protein
+PF09390	DUF1999	Protein of unknown function (DUF1999)
+PF09391	DUF2000	Protein of unknown function (DUF2000)
+PF09392	T3SS_needle_F	Type III secretion needle MxiH, YscF, SsaG, EprI, PscF, EscF
+PF09393	DUF2001	Phage tail tube protein
+PF09394	Inhibitor_I42	Chagasin family peptidase inhibitor I42
+PF09396	Thrombin_light	Thrombin light chain
+PF09397	Ftsk_gamma	Ftsk gamma domain
+PF09398	FOP_dimer	FOP N terminal dimerisation domain
+PF09399	SARS_lipid_bind	SARS lipid binding protein
+PF09400	DUF2002	Protein of unknown function (DUF2002)
+PF09401	NSP10	RNA synthesis protein NSP10
+PF09402	MSC	Man1-Src1p-C-terminal domain
+PF09403	FadA	Adhesion protein FadA
+PF09404	DUF2003	Eukaryotic protein of unknown function (DUF2003)
+PF09405	Btz	CASC3/Barentsz eIF4AIII binding
+PF09406	DUF2004	Protein of unknown function (DUF2004)
+PF09407	AbiEi_1	AbiEi antitoxin C-terminal domain
+PF09408	Spike_rec_bind	Spike receptor binding domain
+PF09409	PUB	PUB domain
+PF09411	PagL	Lipid A 3-O-deacylase (PagL)
+PF09412	XendoU	Endoribonuclease XendoU
+PF09413	DUF2007	Putative prokaryotic signal transducing protein 
+PF09414	RNA_ligase	RNA ligase
+PF09415	CENP-X	CENP-S associating Centromere protein X
+PF09416	UPF1_Zn_bind	RNA helicase (UPF2 interacting domain)
+PF09418	DUF2009	Protein of unknown function (DUF2009)
+PF09419	PGP_phosphatase	Mitochondrial PGP phosphatase
+PF09420	Nop16	Ribosome biogenesis protein Nop16
+PF09421	FRQ	Frequency clock protein
+PF09422	WTX	WTX protein
+PF09423	PhoD	PhoD-like phosphatase
+PF09424	YqeY	Yqey-like protein
+PF09425	CCT_2	Divergent CCT motif
+PF09426	Nyv1_N	Vacuolar R-SNARE Nyv1 N terminal
+PF09427	DUF2014	Domain of unknown function (DUF2014) 
+PF09428	DUF2011	Fungal protein of unknown function (DUF2011)
+PF09429	Wbp11	WW domain binding protein 11
+PF09430	DUF2012	Protein of unknown function (DUF2012)
+PF09431	DUF2013	Protein of unknown function (DUF2013)
+PF09432	THP2	Tho complex subunit THP2
+PF09435	DUF2015	Fungal protein of unknown function (DUF2015)
+PF09436	DUF2016	Domain of unknown function (DUF2016)
+PF09437	Pombe_5TM	Pombe specific 5TM protein
+PF09438	DUF2017	Domain of unknown function (DUF2017)
+PF09439	SRPRB	Signal recognition particle receptor beta subunit
+PF09440	eIF3_N	eIF3 subunit 6 N terminal domain
+PF09441	Abp2	ARS binding protein 2
+PF09442	DUF2018	Domain of unknown function (DUF2018)
+PF09443	CFC	Cripto_Frl-1_Cryptic (CFC)
+PF09444	MRC1	MRC1-like domain
+PF09445	Methyltransf_15	RNA cap guanine-N2 methyltransferase
+PF09446	VMA21	VMA21-like domain
+PF09447	Cnl2_NKP2	Cnl2/NKP2 family protein
+PF09448	MmlI	Methylmuconolactone methyl-isomerase 
+PF09449	DUF2020	Domain of unknown function (DUF2020)
+PF09450	DUF2019	Domain of unknown function (DUF2019)
+PF09451	ATG27	Autophagy-related protein 27
+PF09452	Mvb12	ESCRT-I subunit Mvb12
+PF09453	HIRA_B	HIRA B motif
+PF09454	Vps23_core	Vps23 core domain
+PF09455	Cas_DxTHG	CRISPR-associated (Cas) DxTHG family
+PF09456	RcsC	RcsC Alpha-Beta-Loop (ABL)
+PF09457	RBD-FIP	FIP domain 
+PF09458	H_lectin	H-type lectin domain
+PF09459	EB_dh	Ethylbenzene dehydrogenase
+PF09460	Saf-Nte_pilin	Saf-pilin pilus formation protein
+PF09461	PcF	Phytotoxin PcF protein
+PF09462	Mus7	Mus7/MMS22 family
+PF09463	Opy2	Opy2 protein
+PF09465	LBR_tudor	Lamin-B receptor of TUDOR domain
+PF09466	Yqai	Hypothetical protein Yqai
+PF09467	Yopt	Hypothetical protein Yopt
+PF09468	RNase_H2-Ydr279	Ydr279p protein family (RNase H2 complex component)
+PF09469	Cobl	Cordon-bleu ubiquitin-like domain
+PF09470	Telethonin	Telethonin protein
+PF09471	Peptidase_M64	IgA Peptidase M64
+PF09472	MtrF	Tetrahydromethanopterin S-methyltransferase, F subunit (MtrF)
+PF09474	Type_III_YscX	Type III secretion system YscX (type_III_YscX)
+PF09475	Dot_icm_IcmQ	Dot/Icm secretion system protein (dot_icm_IcmQ)
+PF09476	Pilus_CpaD	Pilus biogenesis CpaD protein (pilus_cpaD)
+PF09477	Type_III_YscG	Bacterial type II secretion system chaperone protein (type_III_yscG)
+PF09478	CBM49	Carbohydrate binding domain CBM49
+PF09479	Flg_new	Listeria-Bacteroides repeat domain (List_Bact_rpt)
+PF09480	PrgH	Type III secretion system protein PrgH-EprH (PrgH)
+PF09481	CRISPR_Cse1	CRISPR-associated protein Cse1 (CRISPR_cse1)
+PF09482	OrgA_MxiK	Bacterial type III secretion apparatus protein (OrgA_MxiK)
+PF09483	HpaP	Type III secretion protein (HpaP)
+PF09484	Cas_TM1802	CRISPR-associated protein TM1802 (cas_TM1802)
+PF09485	CRISPR_Cse2	CRISPR-associated protein Cse2 (CRISPR_cse2)
+PF09486	HrpB7	Bacterial type III secretion protein (HrpB7)
+PF09487	HrpB2	Bacterial type III secretion protein (HrpB2)
+PF09488	Osmo_MPGsynth	Mannosyl-3-phosphoglycerate synthase (osmo_MPGsynth)
+PF09489	CbtB	Probable cobalt transporter subunit (CbtB)
+PF09490	CbtA	Probable cobalt transporter subunit (CbtA)
+PF09491	RE_AlwI	AlwI restriction endonuclease
+PF09492	Pec_lyase	Pectic acid lyase
+PF09493	DUF2389	Tryptophan-rich protein (DUF2389)
+PF09494	Slx4	Slx4 endonuclease
+PF09495	DUF2462	Protein of unknown function (DUF2462)
+PF09496	CENP-O	Cenp-O kinetochore centromere component
+PF09497	Med12	Transcription mediator complex subunit Med12
+PF09498	DUF2388	Protein of unknown function (DUF2388)
+PF09499	RE_ApaLI	ApaLI-like restriction endonuclease
+PF09500	YiiD_C	Putative thioesterase (yiiD_Cterm)
+PF09501	Bac_small_YrzI	Probable sporulation protein (Bac_small_yrzI)
+PF09502	HrpB4	Bacterial type III secretion protein (HrpB4)
+PF09504	RE_Bsp6I	Bsp6I restriction endonuclease
+PF09505	Dimeth_Pyl	Dimethylamine methyltransferase (Dimeth_PyL)
+PF09506	Salt_tol_Pase	Glucosylglycerol-phosphate phosphatase (Salt_tol_Pase)
+PF09507	CDC27	DNA polymerase subunit Cdc27
+PF09508	Lact_bio_phlase	Lacto-N-biose phosphorylase N-terminal TIM barrel domain
+PF09509	Hypoth_Ymh	Protein of unknown function (Hypoth_ymh)
+PF09510	Rtt102p	Rtt102p-like transcription regulator protein
+PF09511	RNA_lig_T4_1	RNA ligase
+PF09512	ThiW	Thiamine-precursor transporter protein (ThiW)
+PF09514	SSXRD	SSXRD motif
+PF09515	Thia_YuaJ	Thiamine transporter protein (Thia_YuaJ)
+PF09516	RE_CfrBI	CfrBI restriction endonuclease
+PF09517	RE_Eco29kI	Eco29kI restriction endonuclease
+PF09518	RE_HindIII	HindIII restriction endonuclease
+PF09519	RE_HindVP	HindVP restriction endonuclease
+PF09520	RE_TdeIII	Type II restriction endonuclease, TdeIII
+PF09521	RE_NgoPII	NgoPII restriction endonuclease
+PF09522	RE_R_Pab1	R.Pab1 restriction endonuclease
+PF09523	DUF2390	Protein of unknown function (DUF2390)
+PF09524	Phg_2220_C	Conserved phage C-terminus (Phg_2220_C)
+PF09526	DUF2387	Probable metal-binding protein (DUF2387)
+PF09527	ATPase_gene1	Putative F0F1-ATPase subunit Ca2+/Mg2+ transporter
+PF09528	Ehrlichia_rpt	Ehrlichia tandem repeat (Ehrlichia_rpt)
+PF09529	Intg_mem_TP0381	Integral membrane protein (intg_mem_TP0381)
+PF09531	Ndc1_Nup	Nucleoporin protein Ndc1-Nup
+PF09532	FDF	FDF domain
+PF09533	DUF2380	Predicted lipoprotein of unknown function (DUF2380)
+PF09534	Trp_oprn_chp	Tryptophan-associated transmembrane protein (Trp_oprn_chp)
+PF09535	Gmx_para_CXXCG	Protein of unknown function (Gmx_para_CXXCG)
+PF09536	DUF2378	Protein of unknown function (DUF2378)
+PF09537	DUF2383	Domain of unknown function (DUF2383)
+PF09538	FYDLN_acid	Protein of unknown function (FYDLN_acid)
+PF09539	DUF2385	Protein of unknown function (DUF2385)
+PF09543	DUF2379	Protein of unknown function (DUF2379)
+PF09544	DUF2381	Protein of unknown function (DUF2381)
+PF09545	RE_AccI	AccI restriction endonuclease
+PF09546	Spore_III_AE	Stage III sporulation protein AE (spore_III_AE)
+PF09547	Spore_IV_A	Stage IV sporulation protein A (spore_IV_A)
+PF09548	Spore_III_AB	Stage III sporulation protein AB (spore_III_AB)
+PF09549	RE_Bpu10I	Bpu10I restriction endonuclease
+PF09550	Phage_TAC_6	Phage tail assembly chaperone protein, TAC
+PF09551	Spore_II_R	Stage II sporulation protein R (spore_II_R)
+PF09552	RE_BstXI	BstXI restriction endonuclease
+PF09553	RE_Eco47II	Eco47II restriction endonuclease
+PF09554	RE_HaeII	HaeII restriction endonuclease
+PF09556	RE_HaeIII	HaeIII restriction endonuclease
+PF09557	DUF2382	Domain of unknown function (DUF2382)
+PF09558	DUF2375	Protein of unknown function (DUF2375)
+PF09559	Cas6	Cas6 Crispr
+PF09560	Spore_YunB	Sporulation protein YunB (Spo_YunB)
+PF09561	RE_HpaII	HpaII restriction endonuclease
+PF09562	RE_LlaMI	LlaMI restriction endonuclease
+PF09563	RE_LlaJI	LlaJI restriction endonuclease
+PF09564	RE_NgoBV	NgoBV restriction endonuclease
+PF09565	RE_NgoFVII	NgoFVII restriction endonuclease
+PF09566	RE_SacI	SacI restriction endonuclease
+PF09567	RE_MamI	MamI restriction endonuclease
+PF09568	RE_MjaI	MjaI restriction endonuclease
+PF09569	RE_ScaI	ScaI restriction endonuclease
+PF09570	RE_SinI	SinI restriction endonuclease
+PF09571	RE_XcyI	XcyI restriction endonuclease
+PF09572	RE_XamI	XamI restriction endonuclease
+PF09573	RE_TaqI	TaqI restriction endonuclease
+PF09574	DUF2374	Protein  of unknown function (Duf2374)
+PF09575	Spore_SspJ	Small spore protein J (Spore_SspJ)
+PF09577	Spore_YpjB	Sporulation protein YpjB (SpoYpjB)
+PF09578	Spore_YabQ	Spore cortex protein YabQ (Spore_YabQ)
+PF09579	Spore_YtfJ	Sporulation protein YtfJ (Spore_YtfJ)
+PF09580	Spore_YhcN_YlaJ	Sporulation lipoprotein YhcN/YlaJ (Spore_YhcN_YlaJ)
+PF09581	Spore_III_AF	Stage III sporulation protein AF (Spore_III_AF)
+PF09582	AnfO_nitrog	Iron only nitrogenase protein AnfO (AnfO_nitrog)
+PF09583	Phageshock_PspG	Phage shock protein G (Phageshock_PspG)
+PF09584	Phageshock_PspD	Phage shock protein PspD (Phageshock_PspD)
+PF09585	Lin0512_fam	Conserved hypothetical protein (Lin0512_fam)
+PF09586	YfhO	Bacterial membrane protein YfhO
+PF09587	PGA_cap	Bacterial capsule synthesis protein PGA_cap
+PF09588	YqaJ	YqaJ-like viral recombinase domain
+PF09589	HrpA_pilin	HrpA pilus formation protein
+PF09590	Env-gp36	Lentivirus surface glycoprotein
+PF09591	DUF2463	Protein of unknown function (DUF2463)
+PF09592	DUF2031	Protein of unknown function (DUF2031)
+PF09593	Pathogen_betaC1	Beta-satellite pathogenicity beta C1 protein
+PF09594	GT87	Glycosyltransferase family 87
+PF09595	Metaviral_G	Metaviral_G glycoprotein
+PF09596	MamL-1	MamL-1 domain
+PF09597	IGR	IGR protein motif
+PF09598	Stm1_N	Stm1
+PF09599	IpaC_SipC	Salmonella-Shigella invasin protein C (IpaC_SipC)
+PF09600	Cyd_oper_YbgE	Cyd operon protein YbgE (Cyd_oper_YbgE)
+PF09601	DUF2459	Protein of unknown function (DUF2459)
+PF09602	PhaP_Bmeg	Polyhydroxyalkanoic acid inclusion protein (PhaP_Bmeg)
+PF09603	Fib_succ_major	Fibrobacter succinogenes major domain (Fib_succ_major)
+PF09604	Potass_KdpF	F subunit of K+-transporting ATPase (Potass_KdpF)
+PF09605	Trep_Strep	Hypothetical bacterial integral membrane protein (Trep_Strep)
+PF09606	Med15	ARC105 or Med15 subunit of Mediator complex non-fungal
+PF09607	BrkDBD	Brinker DNA-binding domain
+PF09608	Alph_Pro_TM	Putative transmembrane protein (Alph_Pro_TM)
+PF09609	Cas_GSU0054	CRISPR-associated protein, GSU0054 family (Cas_GSU0054)
+PF09610	Myco_arth_vir_N	Mycoplasma virulence signal region (Myco_arth_vir_N)
+PF09611	Cas_Csy1	CRISPR-associated protein (Cas_Csy1)
+PF09612	HtrL_YibB	Bacterial protein of unknown function (HtrL_YibB)
+PF09613	HrpB1_HrpK	Bacterial type III secretion protein (HrpB1_HrpK)
+PF09614	Cas_Csy2	CRISPR-associated protein (Cas_Csy2)
+PF09615	Cas_Csy3	CRISPR-associated protein (Cas_Csy3)
+PF09617	Cas_GSU0053	CRISPR-associated protein GSU0053 (Cas_GSU0053)
+PF09618	Cas_Csy4	CRISPR-associated protein (Cas_Csy4)
+PF09619	YscW	Type III secretion system lipoprotein chaperone (YscW)
+PF09620	Cas_csx3	CRISPR-associated protein (Cas_csx3)
+PF09621	LcrR	Type III secretion system regulator (LcrR)
+PF09622	DUF2391	Putative integral membrane protein (DUF2391)
+PF09623	Cas_NE0113	CRISPR-associated protein NE0113 (Cas_NE0113)
+PF09624	DUF2393	Protein of unknown function (DUF2393)
+PF09625	VP9	VP9 protein
+PF09626	DHC	Dihaem cytochrome c
+PF09627	PrgU	PrgU-like protein
+PF09628	YvfG	YvfG protein
+PF09629	YorP	YorP protein
+PF09630	DUF2024	Domain of unknown function (DUF2024)
+PF09631	Sen15	Sen15 protein
+PF09632	Rac1	Rac1-binding domain
+PF09633	DUF2023	Protein of unknown function (DUF2023)
+PF09634	DUF2025	Protein of unknown function (DUF2025)
+PF09635	MetRS-N	MetRS-N binding domain
+PF09636	XkdW	XkdW protein
+PF09637	Med18	Med18 protein
+PF09638	Ph1570	Ph1570 protein
+PF09639	YjcQ	YjcQ protein
+PF09640	DUF2027	Domain of unknown function (DUF2027)
+PF09641	DUF2026	Protein of unknown function (DUF2026)
+PF09642	YonK	YonK protein
+PF09643	YopX	YopX protein
+PF09644	Mg296	Mg296 protein
+PF09645	F-112	F-112 protein
+PF09646	Gp37	Gp37 protein
+PF09648	YycI	YycH protein
+PF09649	CHZ	Histone chaperone domain CHZ
+PF09650	PHA_gran_rgn	Putative polyhydroxyalkanoic acid system protein (PHA_gran_rgn)
+PF09651	Cas_APE2256	CRISPR-associated protein (Cas_APE2256)
+PF09652	Cas_VVA1548	Putative CRISPR-associated protein (Cas_VVA1548)
+PF09654	DUF2396	Protein of unknown function (DUF2396)
+PF09655	Nitr_red_assoc	Conserved nitrate reductase-associated protein (Nitr_red_assoc)
+PF09656	PGPGW	Putative transmembrane protein (PGPGW)
+PF09657	Cas_Csx8	CRISPR-associated protein Csx8 (Cas_Csx8)
+PF09658	Cas_Csx9	CRISPR-associated protein (Cas_Csx9)
+PF09659	Cas_Csm6	CRISPR-associated protein (Cas_Csm6)
+PF09660	DUF2397	Protein of unknown function (DUF2397)
+PF09661	DUF2398	Protein of unknown function (DUF2398)
+PF09662	Phenyl_P_gamma	Phenylphosphate carboxylase gamma subunit (Phenyl_P_gamma)
+PF09663	Amido_AtzD_TrzD	Amidohydrolase ring-opening protein (Amido_AtzD_TrzD)
+PF09664	DUF2399	Protein of unknown function C-terminus (DUF2399)
+PF09665	RE_Alw26IDE	Type II restriction endonuclease (RE_Alw26IDE)
+PF09666	Sororin	Sororin protein
+PF09667	DUF2028	Domain of unknown function (DUF2028)
+PF09668	Asp_protease	Aspartyl protease
+PF09669	Phage_pRha	Phage regulatory protein Rha (Phage_pRha)
+PF09670	Cas_Cas02710	CRISPR-associated protein (Cas_Cas02710)
+PF09671	Spore_GerQ	Spore coat protein (Spore_GerQ)
+PF09673	TrbC_Ftype	Type-F conjugative transfer system pilin assembly protein
+PF09674	DUF2400	Protein of unknown function (DUF2400)
+PF09675	Chlamy_scaf	Chlamydia-phage Chp2 scaffold (Chlamy_scaf)
+PF09676	TraV	Type IV conjugative transfer system lipoprotein (TraV)
+PF09677	TrbI_Ftype	Type-F conjugative transfer system protein (TrbI_Ftype)
+PF09678	Caa3_CtaG	Cytochrome c oxidase caa3 assembly factor (Caa3_CtaG)
+PF09679	TraQ	Type-F conjugative transfer system pilin chaperone (TraQ)
+PF09680	Tiny_TM_bacill	Protein of unknown function (Tiny_TM_bacill)
+PF09681	Phage_rep_org_N	N-terminal phage replisome organiser (Phage_rep_org_N)
+PF09682	Phage_holin_6_1	Bacteriophage holin of superfamily 6 (Holin_LLH)
+PF09683	Lactococcin_972	Bacteriocin (Lactococcin_972)
+PF09684	Tail_P2_I	Phage tail protein (Tail_P2_I)
+PF09685	DUF4870	Domain of unknown function (DUF4870) 
+PF09686	Plasmid_RAQPRD	Plasmid protein of unknown function (Plasmid_RAQPRD)
+PF09687	PRESAN	Plasmodium RESA N-terminal
+PF09688	Wx5_PLAF3D7	Protein of unknown function (Wx5_PLAF3D7)
+PF09689	PY_rept_46	Plasmodium yoelii repeat (PY_rept_46)
+PF09690	PYST-C1	Plasmodium yoelii subtelomeric region (PYST-C1)
+PF09691	T2SS_PulS_OutS	Type II secretion system pilotin lipoprotein (PulS_OutS)
+PF09692	Arb1	Argonaute siRNA chaperone (ARC) complex subunit Arb1
+PF09693	Phage_XkdX	Phage uncharacterised protein (Phage_XkdX)
+PF09694	Gcw_chp	Bacterial protein of unknown function (Gcw_chp)
+PF09695	YtfJ_HI0045	Bacterial protein of unknown function (YtfJ_HI0045)
+PF09696	Ctf8	Ctf8
+PF09697	Porph_ging	Protein of unknown function (Porph_ging)
+PF09698	GSu_C4xC__C2xCH	Geobacter CxxxxCH...CXXCH motif (GSu_C4xC__C2xCH)
+PF09699	Paired_CXXCH_1	Doubled CXXCH motif (Paired_CXXCH_1)
+PF09700	Cas_Cmr3	CRISPR-associated protein (Cas_Cmr3)
+PF09701	Cas_Cmr5	CRISPR-associated protein (Cas_Cmr5)
+PF09702	Cas_Csa5	CRISPR-associated protein (Cas_Csa5)
+PF09703	Cas_Csa4	CRISPR-associated protein (Cas_Csa4)
+PF09704	Cas_Cas5d	CRISPR-associated protein (Cas_Cas5)
+PF09706	Cas_CXXC_CXXC	CRISPR-associated protein (Cas_CXXC_CXXC)
+PF09707	Cas_Cas2CT1978	CRISPR-associated protein (Cas_Cas2CT1978)
+PF09709	Cas_Csd1	CRISPR-associated protein (Cas_Csd1)
+PF09710	Trep_dent_lipo	Treponema clustered lipoprotein (Trep_dent_lipo)
+PF09711	Cas_Csn2	CRISPR-associated protein (Cas_Csn2)
+PF09712	PHA_synth_III_E	Poly(R)-hydroxyalkanoic acid synthase subunit (PHA_synth_III_E)
+PF09713	A_thal_3526	Plant protein 1589 of unknown function (A_thal_3526)
+PF09715	Plasmod_dom_1	Plasmodium protein of unknown function (Plasmod_dom_1)
+PF09716	ETRAMP	Malarial early transcribed membrane protein (ETRAMP)
+PF09717	CPW_WPC	Plasmodium falciparum domain of unknown function (CPW_WPC)
+PF09718	Tape_meas_lam_C	Lambda phage tail tape-measure protein (Tape_meas_lam_C)
+PF09719	C_GCAxxG_C_C	Putative redox-active protein (C_GCAxxG_C_C)
+PF09720	Unstab_antitox	Putative addiction module component
+PF09721	Exosortase_EpsH	Transmembrane exosortase (Exosortase_EpsH)
+PF09722	DUF2384	Protein of unknown function (DUF2384)
+PF09723	Zn-ribbon_8	Zinc ribbon domain
+PF09724	Dcc1	Sister chromatid cohesion protein Dcc1
+PF09725	Fra10Ac1	Folate-sensitive fragile site protein Fra10Ac1
+PF09726	Macoilin	Macoilin family
+PF09727	CortBP2	Cortactin-binding protein-2
+PF09728	Taxilin	Myosin-like coiled-coil protein
+PF09729	Gti1_Pac2	Gti1/Pac2 family
+PF09730	BicD	Microtubule-associated protein Bicaudal-D
+PF09731	Mitofilin	Mitochondrial inner membrane protein
+PF09732	CactinC_cactus	Cactus-binding C-terminus of cactin protein
+PF09733	VEFS-Box	VEFS-Box of polycomb protein
+PF09734	Tau95	RNA polymerase III transcription factor (TF)IIIC subunit
+PF09735	Nckap1	Membrane-associated apoptosis protein
+PF09736	Bud13	Pre-mRNA-splicing factor of RES complex
+PF09737	Det1	De-etiolated protein 1 Det1
+PF09738	LRRFIP	LRRFIP family
+PF09739	MCM_bind	Mini-chromosome maintenance replisome factor
+PF09740	DUF2043	Uncharacterized conserved protein (DUF2043)
+PF09741	DUF2045	Uncharacterized conserved protein (DUF2045)
+PF09742	Dymeclin	Dyggve-Melchior-Clausen syndrome protein
+PF09743	E3_UFM1_ligase	E3 UFM1-protein ligase 1
+PF09744	Jnk-SapK_ap_N	JNK_SAPK-associated protein-1
+PF09745	DUF2040	Coiled-coil domain-containing protein 55 (DUF2040)
+PF09746	Membralin	Tumour-associated protein
+PF09747	DUF2052	Coiled-coil domain containing protein (DUF2052)
+PF09748	Med10	Transcription factor subunit Med10 of Mediator complex
+PF09749	HVSL	Uncharacterised conserved protein
+PF09750	DRY_EERY	Alternative splicing regulator  
+PF09751	Es2	Nuclear protein Es2
+PF09752	DUF2048	Abhydrolase domain containing 18 
+PF09753	Use1	Membrane fusion protein Use1
+PF09754	PAC2	PAC2 family
+PF09755	DUF2046	Uncharacterized conserved protein H4 (DUF2046)
+PF09756	DDRGK	DDRGK domain
+PF09757	Arb2	Arb2 domain
+PF09758	FPL	Uncharacterised conserved protein
+PF09759	Atx10homo_assoc	Spinocerebellar ataxia type 10 protein domain
+PF09762	KOG2701	Coiled-coil domain-containing protein (DUF2037)
+PF09763	Sec3_C	Exocyst complex component Sec3
+PF09764	Nt_Gln_amidase	N-terminal glutamine amidase
+PF09765	WD-3	WD-repeat region
+PF09766	FimP	Fms-interacting protein
+PF09767	DUF2053	Predicted membrane protein (DUF2053)
+PF09768	Peptidase_M76	Peptidase M76 family
+PF09769	ApoO	Apolipoprotein O
+PF09770	PAT1	Topoisomerase II-associated protein PAT1
+PF09771	Tmemb_18A	Transmembrane protein 188
+PF09772	Tmem26	Transmembrane protein 26
+PF09773	Meckelin	Meckelin (Transmembrane protein 67)
+PF09774	Cid2	Caffeine-induced death protein 2
+PF09775	Keratin_assoc	Keratinocyte-associated protein 2
+PF09776	Mitoc_L55	Mitochondrial ribosomal protein L55
+PF09777	OSTMP1	Osteopetrosis-associated transmembrane protein 1 precursor
+PF09778	Guanylate_cyc_2	Guanylylate cyclase
+PF09779	Ima1_N	Ima1 N-terminal domain
+PF09781	NDUF_B5	NADH:ubiquinone oxidoreductase, NDUFB5/SGDH subunit
+PF09782	NDUF_B6	NADH:ubiquinone oxidoreductase, NDUFB6/B17 subunit
+PF09783	Vac_ImportDeg	Vacuolar import and degradation protein
+PF09784	L31	Mitochondrial ribosomal protein L31
+PF09785	Prp31_C	Prp31 C terminal domain
+PF09786	CytochromB561_N	Cytochrome B561, N terminal
+PF09787	Golgin_A5	Golgin subfamily A member 5
+PF09788	Tmemb_55A	Transmembrane protein 55A
+PF09789	DUF2353	Uncharacterized coiled-coil protein (DUF2353)
+PF09790	Hyccin	Hyccin
+PF09791	Oxidored-like	Oxidoreductase-like protein, N-terminal
+PF09792	But2	Ubiquitin 3 binding protein But2 C-terminal domain
+PF09793	AD	Anticodon-binding domain
+PF09794	Avl9	Transport protein Avl9
+PF09795	Atg31	Autophagy-related protein 31
+PF09796	QCR10	Ubiquinol-cytochrome-c reductase complex subunit (QCR10)
+PF09797	NatB_MDM20	N-acetyltransferase B complex (NatB) non catalytic subunit
+PF09798	LCD1	DNA damage checkpoint protein
+PF09799	Transmemb_17	Predicted membrane protein
+PF09801	SYS1	Integral membrane protein S linking to the trans Golgi network
+PF09802	Sec66	Preprotein translocase subunit Sec66
+PF09803	Pet100	Pet100
+PF09804	DUF2347	Uncharacterized conserved protein (DUF2347)
+PF09805	Nop25	Nucleolar protein 12 (25kDa)
+PF09806	CDK2AP	Cyclin-dependent kinase 2-associated protein
+PF09807	ELP6	Elongation complex protein 6
+PF09808	SNAPc_SNAP43	Small nuclear RNA activating complex (SNAPc), subunit SNAP43
+PF09809	MRP-L27	Mitochondrial ribosomal protein L27
+PF09810	Exo5	Exonuclease V - a 5' deoxyribonuclease
+PF09811	Yae1_N	Essential protein Yae1, N terminal
+PF09812	MRP-L28	Mitochondrial ribosomal protein L28
+PF09813	Coiled-coil_56	Coiled-coil domain-containing protein 56
+PF09814	HECT_2	HECT-like Ubiquitin-conjugating enzyme (E2)-binding
+PF09815	XK-related	XK-related protein
+PF09816	EAF	RNA polymerase II transcription elongation factor
+PF09817	Zwilch	RZZ complex, subunit zwilch
+PF09818	ABC_ATPase	Predicted ATPase of the ABC class
+PF09819	ABC_cobalt	ABC-type cobalt transport system, permease component
+PF09820	AAA-ATPase_like	Predicted AAA-ATPase
+PF09821	AAA_assoc_C	C-terminal AAA-associated domain
+PF09822	ABC_transp_aux	ABC-type uncharacterized transport system
+PF09823	DUF2357	Domain of unknown function (DUF2357)
+PF09824	ArsR	ArsR transcriptional regulator
+PF09825	BPL_N	Biotin-protein ligase, N terminal
+PF09826	Beta_propel	Beta propeller domain
+PF09827	CRISPR_Cas2	CRISPR associated protein Cas2
+PF09828	Chrome_Resist	Chromate resistance exported protein
+PF09829	DUF2057	Uncharacterized protein conserved in bacteria (DUF2057)
+PF09830	ATP_transf	ATP adenylyltransferase
+PF09831	DUF2058	Uncharacterized protein conserved in bacteria (DUF2058)
+PF09832	DUF2059	Uncharacterized protein conserved in bacteria (DUF2059)
+PF09834	DUF2061	Predicted membrane protein (DUF2061)
+PF09835	DUF2062	Uncharacterized protein conserved in bacteria (DUF2062)
+PF09836	DUF2063	Putative DNA-binding domain
+PF09837	DUF2064	Uncharacterized protein conserved in bacteria (DUF2064)
+PF09838	DUF2065	Uncharacterized protein conserved in bacteria (DUF2065)
+PF09839	DUF2066	Uncharacterized protein conserved in bacteria (DUF2066)
+PF09840	DUF2067	Uncharacterized protein conserved in archaea (DUF2067)
+PF09842	DUF2069	Predicted membrane protein (DUF2069)
+PF09843	DUF2070	Predicted membrane protein (DUF2070)
+PF09844	DUF2071	Uncharacterized conserved protein (COG2071)
+PF09845	DUF2072	Zn-ribbon containing protein
+PF09846	DUF2073	Uncharacterized protein conserved in archaea (DUF2073)
+PF09847	12TM_1	Membrane protein of 12 TMs
+PF09848	DUF2075	Uncharacterized conserved protein (DUF2075)
+PF09849	DUF2076	Uncharacterized protein conserved in bacteria (DUF2076)
+PF09850	DotU	Type VI secretion system protein DotU
+PF09851	SHOCT	Short C-terminal domain
+PF09852	DUF2079	Predicted membrane protein (DUF2079)
+PF09853	DUF2080	Putative transposon-encoded protein (DUF2080)
+PF09855	zinc_ribbon_13	Nucleic-acid-binding protein containing Zn-ribbon domain (DUF2082)
+PF09856	DUF2083	Predicted transcriptional regulator (DUF2083)
+PF09857	YjhX_toxin	Putative toxin of bacterial toxin-antitoxin pair
+PF09858	DUF2085	Predicted membrane protein (DUF2085)
+PF09859	Oxygenase-NA	Oxygenase, catalysing oxidative methylation of damaged DNA
+PF09860	DUF2087	Uncharacterized protein conserved in bacteria (DUF2087)
+PF09861	DUF2088	Domain of unknown function (DUF2088)
+PF09862	DUF2089	Protein of unknown function (DUF2089)
+PF09863	DUF2090	Uncharacterized protein conserved in bacteria (DUF2090)
+PF09864	MliC	Membrane-bound lysozyme-inhibitor of c-type lysozyme
+PF09865	DUF2092	Predicted periplasmic protein (DUF2092)
+PF09866	DUF2093	Uncharacterized protein conserved in bacteria (DUF2093)
+PF09867	DUF2094	Uncharacterized protein conserved in bacteria (DUF2094)
+PF09868	DUF2095	Uncharacterized protein conserved in archaea (DUF2095)
+PF09869	DUF2096	Uncharacterized protein conserved in archaea (DUF2096)
+PF09870	DUF2097	Uncharacterized protein conserved in archaea (DUF2097)
+PF09871	DUF2098	Uncharacterized protein conserved in archaea (DUF2098)
+PF09872	DUF2099	Uncharacterized protein conserved in archaea (DUF2099)
+PF09873	DUF2100	Uncharacterized protein conserved in archaea (DUF2100)
+PF09874	DUF2101	Predicted membrane protein (DUF2101)
+PF09875	DUF2102	Uncharacterized protein conserved in archaea (DUF2102)
+PF09876	DUF2103	Predicted metal-binding protein (DUF2103)
+PF09877	DUF2104	Predicted membrane protein (DUF2104)
+PF09878	DUF2105	Predicted membrane protein (DUF2105)
+PF09879	DUF2106	Predicted membrane protein (DUF2106)
+PF09880	DUF2107	Predicted membrane protein (DUF2107)
+PF09881	DUF2108	Predicted membrane protein (DUF2108)
+PF09882	DUF2109	Predicted membrane protein (DUF2109)
+PF09883	DUF2110	Uncharacterized protein conserved in archaea (DUF2110)
+PF09884	DUF2111	Uncharacterized protein conserved in archaea (DUF2111)
+PF09885	DUF2112	Uncharacterized protein conserved in archaea (DUF2112)
+PF09886	DUF2113	Uncharacterized protein conserved in archaea (DUF2113)
+PF09887	DUF2114	Uncharacterized protein conserved in archaea (DUF2114)
+PF09888	DUF2115	Uncharacterized protein conserved in archaea (DUF2115)
+PF09889	DUF2116	Uncharacterized protein containing a Zn-ribbon (DUF2116)
+PF09890	DUF2117	Uncharacterized protein conserved in archaea (DUF2117)
+PF09891	DUF2118	Uncharacterized protein conserved in archaea (DUF2118)
+PF09892	DUF2119	Uncharacterized protein conserved in archaea (DUF2119)
+PF09893	DUF2120	Uncharacterized protein conserved in archaea (DUF2120)
+PF09894	DUF2121	Uncharacterized protein conserved in archaea (DUF2121)
+PF09895	DUF2122	RecB-family nuclease (DUF2122)
+PF09897	DUF2124	Uncharacterized protein conserved in archaea (DUF2124)
+PF09898	DUF2125	Uncharacterized protein conserved in bacteria (DUF2125)
+PF09899	DUF2126	Putative amidoligase enzyme (DUF2126)
+PF09900	DUF2127	Predicted membrane protein (DUF2127)
+PF09902	DUF2129	Uncharacterized protein conserved in bacteria (DUF2129)
+PF09903	DUF2130	Uncharacterized protein conserved in bacteria (DUF2130)
+PF09904	HTH_43	Winged helix-turn helix
+PF09905	VF530	DNA-binding protein VF530
+PF09906	DUF2135	Uncharacterized protein conserved in bacteria (DUF2135)
+PF09907	HigB_toxin	HigB_toxin, RelE-like toxic component of a toxin-antitoxin system
+PF09909	DUF2138	Uncharacterized protein conserved in bacteria (DUF2138)
+PF09910	DUF2139	Uncharacterized protein conserved in archaea (DUF2139)
+PF09911	DUF2140	Uncharacterized protein conserved in bacteria (DUF2140)
+PF09912	DUF2141	Uncharacterized protein conserved in bacteria (DUF2141)
+PF09913	DUF2142	Predicted membrane protein (DUF2142)
+PF09916	DUF2145	Uncharacterized protein conserved in bacteria (DUF2145)
+PF09917	DUF2147	Uncharacterized protein conserved in bacteria (DUF2147)
+PF09918	DUF2148	Uncharacterized protein containing a ferredoxin domain (DUF2148)
+PF09919	DUF2149	Uncharacterized conserved protein (DUF2149)
+PF09920	DUF2150	Uncharacterized protein conserved in archaea (DUF2150)
+PF09921	DUF2153	Uncharacterized protein conserved in archaea (DUF2153)
+PF09922	DUF2154	Cell wall-active antibiotics response 4TMS YvqF
+PF09923	DUF2155	Uncharacterized protein conserved in bacteria (DUF2155)
+PF09924	DUF2156	Uncharacterised conserved protein (DUF2156)
+PF09925	DUF2157	Predicted membrane protein (DUF2157)
+PF09926	DUF2158	Uncharacterized small protein (DUF2158)
+PF09928	DUF2160	Predicted small integral membrane protein (DUF2160)
+PF09929	DUF2161	Putative PD-(D/E)XK phosphodiesterase (DUF2161)
+PF09930	DUF2162	Predicted transporter (DUF2162)
+PF09931	DUF2163	Uncharacterized conserved protein (DUF2163)
+PF09932	DUF2164	Uncharacterized conserved protein (DUF2164)
+PF09933	DUF2165	Predicted small integral membrane protein (DUF2165)
+PF09935	DUF2167	Protein of unknown function (DUF2167)
+PF09936	Methyltrn_RNA_4	SAM-dependent RNA methyltransferase
+PF09937	DUF2169	Uncharacterized protein conserved in bacteria (DUF2169)
+PF09938	DUF2170	Uncharacterized protein conserved in bacteria (DUF2170)
+PF09939	DUF2171	Uncharacterized protein conserved in bacteria (DUF2171)
+PF09940	DUF2172	Domain of unknown function (DUF2172)
+PF09941	DUF2173	Uncharacterized conserved protein (DUF2173)
+PF09943	DUF2175	Uncharacterized protein conserved in archaea (DUF2175)
+PF09945	DUF2177	Predicted membrane protein (DUF2177)
+PF09946	DUF2178	Predicted membrane protein (DUF2178)
+PF09947	DUF2180	Uncharacterized protein conserved in archaea (DUF2180)
+PF09948	DUF2182	Predicted metal-binding integral membrane protein (DUF2182)
+PF09949	DUF2183	Uncharacterized conserved protein (DUF2183)
+PF09950	DUF2184	Uncharacterized protein conserved in bacteria (DUF2184)
+PF09951	DUF2185	Protein of unknown function (DUF2185)
+PF09952	AbiEi_2	Transcriptional regulator, AbiEi antitoxin, Type IV TA system
+PF09953	DUF2187	Uncharacterized protein conserved in bacteria (DUF2187)
+PF09954	DUF2188	Uncharacterized protein conserved in bacteria (DUF2188)
+PF09955	DUF2189	Predicted integral membrane protein (DUF2189)
+PF09956	DUF2190	Uncharacterized conserved protein (DUF2190)
+PF09957	VapB_antitoxin	Bacterial antitoxin of type II TA system, VapB
+PF09958	DUF2192	Uncharacterized protein conserved in archaea (DUF2192)
+PF09959	DUF2193	Uncharacterized protein conserved in archaea (DUF2193)
+PF09960	DUF2194	Uncharacterised protein conserved in bacteria (DUF2194)
+PF09961	DUF2195	Uncharacterized protein conserved in bacteria (DUF2195)
+PF09962	DUF2196	Uncharacterized conserved protein (DUF2196)
+PF09963	DUF2197	Uncharacterized protein conserved in bacteria (DUF2197)
+PF09964	DUF2198	Uncharacterized protein conserved in bacteria (DUF2198)
+PF09965	DUF2199	Uncharacterized protein conserved in bacteria (DUF2199)
+PF09966	DUF2200	Uncharacterized protein conserved in bacteria (DUF2200)
+PF09967	DUF2201	VWA-like domain (DUF2201)
+PF09968	DUF2202	Uncharacterized protein domain (DUF2202)
+PF09969	DUF2203	Uncharacterized conserved protein (DUF2203)
+PF09970	DUF2204	Nucleotidyl transferase of unknown function (DUF2204)
+PF09971	DUF2206	Predicted membrane protein (DUF2206)
+PF09972	DUF2207	Predicted membrane protein (DUF2207)
+PF09973	DUF2208	Predicted membrane protein (DUF2208)
+PF09974	DUF2209	Uncharacterized protein conserved in archaea (DUF2209)
+PF09976	TPR_21	Tetratricopeptide repeat-like domain
+PF09977	Tad_C	Putative Tad-like Flp pilus-assembly
+PF09979	DUF2213	Uncharacterized protein conserved in bacteria (DUF2213)
+PF09980	DUF2214	Predicted membrane protein (DUF2214)
+PF09981	DUF2218	Uncharacterized protein conserved in bacteria (DUF2218)
+PF09982	DUF2219	Uncharacterized protein conserved in bacteria (DUF2219)
+PF09983	DUF2220	Uncharacterized protein conserved in bacteria C-term(DUF2220)
+PF09984	DUF2222	Uncharacterised signal transduction histidine kinase domain (DUF2222)
+PF09985	Glucodextran_C	C-terminal binding-module, SLH-like, of glucodextranase
+PF09986	DUF2225	Uncharacterized protein conserved in bacteria (DUF2225)
+PF09987	DUF2226	Uncharacterized protein conserved in archaea (DUF2226)
+PF09988	DUF2227	Uncharacterized metal-binding protein (DUF2227)
+PF09989	DUF2229	CoA enzyme activase uncharacterised domain (DUF2229)
+PF09990	DUF2231	Predicted membrane protein (DUF2231)
+PF09991	DUF2232	Predicted membrane protein (DUF2232)
+PF09992	NAGPA	Phosphodiester glycosidase
+PF09994	DUF2235	Uncharacterized alpha/beta hydrolase domain (DUF2235)
+PF09995	DUF2236	Uncharacterized protein conserved in bacteria (DUF2236)
+PF09996	DUF2237	Uncharacterized protein conserved in bacteria (DUF2237)
+PF09997	DUF2238	Predicted membrane protein (DUF2238)
+PF09998	DUF2239	Uncharacterized protein conserved in bacteria (DUF2239)
+PF09999	DUF2240	Uncharacterized protein conserved in archaea (DUF2240)
+PF10000	ACT_3	ACT domain
+PF10001	DUF2242	Uncharacterized protein conserved in bacteria (DUF2242)
+PF10002	DUF2243	Predicted membrane protein (DUF2243)
+PF10003	DUF2244	Integral membrane protein (DUF2244)
+PF10004	DUF2247	Uncharacterized protein conserved in bacteria (DUF2247)
+PF10005	zinc-ribbon_6	zinc-ribbon domain
+PF10006	DUF2249	Uncharacterized conserved protein (DUF2249)
+PF10007	DUF2250	Uncharacterized protein conserved in archaea (DUF2250)
+PF10008	DUF2251	Uncharacterized protein conserved in bacteria (DUF2251)
+PF10009	DUF2252	Uncharacterized protein conserved in bacteria (DUF2252)
+PF10011	DUF2254	Predicted membrane protein (DUF2254)
+PF10012	DUF2255	Uncharacterized protein conserved in bacteria (DUF2255)
+PF10013	DUF2256	Uncharacterized protein conserved in bacteria (DUF2256)
+PF10014	2OG-Fe_Oxy_2	2OG-Fe dioxygenase
+PF10015	DUF2258	Uncharacterized protein conserved in archaea (DUF2258)
+PF10016	DUF2259	Predicted secreted protein (DUF2259)
+PF10017	Methyltransf_33	Histidine-specific methyltransferase, SAM-dependent
+PF10018	Med4	Vitamin-D-receptor interacting Mediator subunit 4
+PF10020	DUF2262	Uncharacterized protein conserved in bacteria (DUF2262)
+PF10021	DUF2263	Uncharacterized protein conserved in bacteria (DUF2263)
+PF10022	DUF2264	Uncharacterized protein conserved in bacteria (DUF2264)
+PF10023	Aminopep	Putative aminopeptidase
+PF10025	DUF2267	Uncharacterized conserved protein (DUF2267)
+PF10026	DUF2268	Predicted Zn-dependent protease (DUF2268)
+PF10027	DUF2269	Predicted integral membrane protein (DUF2269)
+PF10028	DUF2270	Predicted integral membrane protein (DUF2270)
+PF10029	DUF2271	Predicted periplasmic protein (DUF2271)
+PF10030	DUF2272	Uncharacterized protein conserved in bacteria (DUF2272)
+PF10031	DUF2273	Small integral membrane protein (DUF2273)
+PF10032	Pho88	Phosphate transport (Pho88)
+PF10033	ATG13	Autophagy-related protein 13
+PF10034	Dpy19	Q-cell neuroblast polarisation
+PF10035	DUF2179	Uncharacterized protein conserved in bacteria (DUF2179)
+PF10036	RLL	Putative carnitine deficiency-associated protein
+PF10037	MRP-S27	Mitochondrial 28S ribosomal protein S27
+PF10038	DUF2274	Protein of unknown function (DUF2274)
+PF10039	DUF2275	Predicted integral membrane protein (DUF2275)
+PF10040	CRISPR_Cas6	CRISPR-associated endoribonuclease Cas6
+PF10041	DUF2277	Uncharacterized conserved protein (DUF2277)
+PF10042	DUF2278	Uncharacterized conserved protein (DUF2278)
+PF10043	DUF2279	Predicted periplasmic lipoprotein (DUF2279)
+PF10044	LIN52	Retinal tissue protein
+PF10045	DUF2280	Uncharacterized conserved protein (DUF2280)
+PF10046	BLOC1_2	Biogenesis of lysosome-related organelles complex-1 subunit 2 
+PF10047	DUF2281	Protein of unknown function (DUF2281)
+PF10048	DUF2282	Predicted integral membrane protein (DUF2282)
+PF10049	DUF2283	Protein of unknown function (DUF2283)
+PF10050	DUF2284	Predicted metal-binding protein (DUF2284)
+PF10051	DUF2286	Uncharacterized protein conserved in archaea (DUF2286)
+PF10052	DUF2288	Protein of unknown function (DUF2288)
+PF10053	DUF2290	Uncharacterized conserved protein (DUF2290)
+PF10054	DUF2291	Predicted periplasmic lipoprotein (DUF2291)
+PF10055	DUF2292	Uncharacterized small protein (DUF2292)
+PF10056	DUF2293	Uncharacterized conserved protein (DUF2293)
+PF10057	DUF2294	Uncharacterized conserved protein (DUF2294)
+PF10058	zinc_ribbon_10	Predicted integral membrane zinc-ribbon metal-binding protein
+PF10060	DUF2298	Uncharacterized membrane protein (DUF2298)
+PF10061	DUF2299	Uncharacterized conserved protein (DUF2299)
+PF10062	DUF2300	Predicted secreted protein (DUF2300)
+PF10063	DUF2301	Uncharacterized integral membrane protein (DUF2301)
+PF10065	DUF2303	Uncharacterized conserved protein (DUF2303)
+PF10066	DUF2304	Uncharacterized conserved protein (DUF2304)
+PF10067	DUF2306	Predicted membrane protein (DUF2306)
+PF10069	DICT	Sensory domain in DIguanylate Cyclases and Two-component system
+PF10070	DUF2309	Uncharacterized protein conserved in bacteria (DUF2309)
+PF10071	DUF2310	Zn-ribbon-containing, possibly nucleic-acid-binding protein (DUF2310)
+PF10073	DUF2312	Uncharacterized protein conserved in bacteria (DUF2312)
+PF10074	DUF2285	Uncharacterized conserved protein (DUF2285)
+PF10075	CSN8_PSD8_EIF3K	CSN8/PSMD8/EIF3K family
+PF10076	DUF2313	Uncharacterised protein conserved in bacteria (DUF2313)
+PF10077	DUF2314	Uncharacterized protein conserved in bacteria (DUF2314)
+PF10078	DUF2316	Uncharacterized protein conserved in bacteria (DUF2316)
+PF10079	BshC	Bacillithiol biosynthesis BshC 
+PF10080	DUF2318	Predicted membrane protein (DUF2318)
+PF10081	Abhydrolase_9	Alpha/beta-hydrolase family
+PF10082	BBP2_2	Putative beta-barrel porin 2
+PF10083	DUF2321	Uncharacterized protein conserved in bacteria (DUF2321)
+PF10084	DUF2322	Uncharacterized protein conserved in bacteria (DUF2322)
+PF10086	DUF2324	Putative membrane peptidase family (DUF2324)
+PF10087	DUF2325	Uncharacterized protein conserved in bacteria (DUF2325)
+PF10088	DUF2326	Uncharacterised protein conserved in bacteria (DUF2326)
+PF10090	HPTransfase	Histidine phosphotransferase C-terminal domain
+PF10091	Glycoamylase	Putative glucoamylase
+PF10092	DUF2330	Uncharacterized protein conserved in bacteria (DUF2330)
+PF10093	DUF2331	Uncharacterized protein conserved in bacteria (DUF2331)
+PF10094	DUF2332	Uncharacterized protein conserved in bacteria (DUF2332)
+PF10095	DUF2333	Uncharacterized protein conserved in bacteria (DUF2333)
+PF10096	DUF2334	Uncharacterized protein conserved in bacteria (DUF2334)
+PF10097	DUF2335	Predicted membrane protein (DUF2335)
+PF10098	DUF2336	Uncharacterised protein conserved in bacteria (DUF2336)
+PF10099	RskA	Anti-sigma-K factor rskA
+PF10100	Staph_opine_DH	Staphylopine dehydrogenase
+PF10101	DUF2339	Predicted membrane protein (DUF2339)
+PF10102	DUF2341	Domain of unknown function (DUF2341)
+PF10103	Zincin_2	Zincin-like metallopeptidase
+PF10104	Brr6_like_C_C	Di-sulfide bridge nucleocytoplasmic transport domain
+PF10105	DUF2344	Uncharacterized protein conserved in bacteria (DUF2344)
+PF10106	DUF2345	Uncharacterized protein conserved in bacteria (DUF2345)
+PF10107	Endonuc_Holl	Endonuclease related to archaeal Holliday junction resolvase
+PF10108	DNA_pol_B_exo2	Predicted 3'-5' exonuclease related to the exonuclease domain of PolB
+PF10109	Phage_TAC_7	Phage tail assembly chaperone proteins, E, or 41 or 14
+PF10110	GPDPase_memb	Membrane domain of glycerophosphoryl diester phosphodiesterase
+PF10111	Glyco_tranf_2_2	Glycosyltransferase like family 2
+PF10112	Halogen_Hydrol	5-bromo-4-chloroindolyl phosphate hydrolysis protein
+PF10113	Fibrillarin_2	Fibrillarin-like archaeal protein
+PF10114	PocR	Sensory domain found in PocR
+PF10115	HlyU	Transcriptional activator HlyU
+PF10116	Host_attach	Protein required for attachment to host cells
+PF10117	McrBC	McrBC 5-methylcytosine restriction system component
+PF10118	Metal_hydrol	Predicted metal-dependent hydrolase
+PF10119	MethyTransf_Reg	Predicted methyltransferase regulatory domain
+PF10120	ThiP_synth	Thiamine-phosphate synthase
+PF10122	Mu-like_Com	Mu-like prophage protein Com
+PF10123	Mu-like_Pro	Mu-like prophage I protein
+PF10124	Mu-like_gpT	Mu-like prophage major head subunit gpT
+PF10125	NADHdeh_related	NADH dehydrogenase I, subunit N related protein
+PF10126	Nit_Regul_Hom	Uncharacterized protein, homolog of nitrogen regulatory protein PII
+PF10127	Nuc-transf	Predicted nucleotidyltransferase
+PF10128	OpcA_G6PD_assem	Glucose-6-phosphate dehydrogenase subunit
+PF10129	OpgC_C	OpgC protein
+PF10130	PIN_2	PIN domain
+PF10131	PTPS_related	6-pyruvoyl-tetrahydropterin synthase related domain; membrane protein
+PF10133	RNA_bind_2	Predicted RNA-binding protein
+PF10134	RPA	Replication initiator protein A
+PF10135	Rod-binding	Rod binding protein
+PF10136	SpecificRecomb	Site-specific recombinase
+PF10137	TIR-like	Predicted nucleotide-binding protein containing TIR-like domain
+PF10138	vWA-TerF-like	vWA found in TerF C terminus 
+PF10139	Virul_Fac	Putative bacterial virulence factor
+PF10140	YukC	WXG100 protein secretion system (Wss), protein YukC
+PF10141	ssDNA-exonuc_C	Single-strand DNA-specific exonuclease, C terminal domain
+PF10142	PhoPQ_related	PhoPQ-activated pathogenicity-related protein
+PF10143	PhosphMutase	2,3-bisphosphoglycerate-independent phosphoglycerate mutase
+PF10144	SMP_2	Bacterial virulence factor haemolysin
+PF10145	PhageMin_Tail	Phage-related minor tail protein
+PF10146	zf-C4H2	Zinc finger-containing protein 
+PF10147	CR6_interact	Growth arrest and DNA-damage-inducible proteins-interacting protein 1
+PF10148	SCHIP-1	Schwannomin-interacting protein 1
+PF10149	TM231	Transmembrane protein 231
+PF10150	RNase_E_G	Ribonuclease E/G family
+PF10151	TMEM214	TMEM214, C-terminal, caspase 4 activator
+PF10152	CCDC53	Subunit CCDC53 of WASH complex
+PF10153	Efg1	rRNA-processing protein Efg1
+PF10154	DUF2362	Uncharacterized conserved protein (DUF2362)
+PF10155	DUF2363	Uncharacterized conserved protein (DUF2363)
+PF10156	Med17	Subunit 17 of Mediator complex
+PF10157	BORCS6	BLOC-1-related complex sub-unit 6
+PF10158	LOH1CR12	Tumour suppressor protein
+PF10159	MMtag	Kinase phosphorylation protein
+PF10160	Tmemb_40	Predicted membrane protein
+PF10161	DDDD	Putative mitochondrial precursor protein
+PF10162	G8	G8 domain
+PF10163	EnY2	Transcription factor e(y)2
+PF10164	DUF2367	Uncharacterized conserved protein (DUF2367)
+PF10165	Ric8	Guanine nucleotide exchange factor synembryn
+PF10166	DUF2368	Uncharacterised conserved protein (DUF2368)
+PF10167	BORCS8	BLOC-1-related complex sub-unit 8
+PF10168	Nup88	Nuclear pore component
+PF10169	Laps	Learning-associated protein
+PF10170	C6_DPF	Cysteine-rich domain
+PF10171	Tim29	Translocase of the Inner Mitochondrial membrane 29
+PF10172	DDA1	Det1 complexing ubiquitin ligase
+PF10173	Mit_KHE1	Mitochondrial K+-H+ exchange-related
+PF10174	Cast	RIM-binding protein of the cytomatrix active zone
+PF10175	MPP6	M-phase phosphoprotein 6
+PF10176	DUF2370	Protein of unknown function (DUF2370)
+PF10177	DUF2371	Uncharacterised conserved protein (DUF2371)
+PF10178	PAC3	Proteasome assembly chaperone 3
+PF10179	DUF2369	Uncharacterised conserved protein (DUF2369)
+PF10180	DUF2373	Uncharacterised conserved protein (DUF2373)
+PF10181	PIG-H	GPI-GlcNAc transferase complex, PIG-H component
+PF10182	Flo11	Flo11 domain
+PF10183	ESSS	ESSS subunit of NADH:ubiquinone oxidoreductase (complex I) 
+PF10184	DUF2358	Uncharacterized conserved protein (DUF2358)
+PF10185	Mesd	Chaperone for wingless signalling and trafficking of LDL receptor
+PF10186	Atg14	Vacuolar sorting 38 and autophagy-related subunit 14
+PF10187	Nefa_Nip30_N	N-terminal domain of NEFA-interacting nuclear protein NIP30
+PF10188	Oscp1	Organic solute transport protein 1
+PF10189	Ints3	Integrator complex subunit 3 
+PF10190	Tmemb_170	Putative transmembrane protein 170
+PF10191	COG7	Golgi complex component 7 (COG7)
+PF10192	GpcrRhopsn4	Rhodopsin-like GPCR transmembrane domain
+PF10193	Telomere_reg-2	Telomere length regulation protein
+PF10195	Phospho_p8	DNA-binding nuclear phosphoprotein p8
+PF10197	Cir_N	N-terminal domain of CBF1 interacting co-repressor CIR
+PF10198	Ada3	Histone acetyltransferases subunit 3
+PF10199	Adaptin_binding	Alpha and gamma adaptin binding protein p34
+PF10200	Ndufs5	NADH:ubiquinone oxidoreductase, NDUFS5-15kDa
+PF10203	Pet191_N	Cytochrome c oxidase assembly protein PET191
+PF10204	DuoxA	Dual oxidase maturation factor
+PF10205	KLRAQ	Predicted coiled-coil domain-containing protein
+PF10206	WRW	Mitochondrial F1F0-ATP synthase, subunit f
+PF10208	Armet	Degradation arginine-rich protein for mis-folding
+PF10209	DUF2340	Uncharacterized conserved protein (DUF2340)
+PF10210	MRP-S32	Mitochondrial 28S ribosomal protein S32
+PF10211	Ax_dynein_light	Axonemal dynein light chain
+PF10212	TTKRSYEDQ	Predicted coiled-coil domain-containing protein
+PF10213	MRP-S28	Mitochondrial ribosomal subunit protein 
+PF10214	Rrn6	RNA polymerase I-specific transcription-initiation factor
+PF10215	Ost4	Oligosaccaryltransferase  
+PF10216	ChpXY	CO2 hydration protein (ChpXY)
+PF10217	DUF2039	Uncharacterized conserved protein (DUF2039)
+PF10218	DUF2054	Uncharacterized conserved protein (DUF2054)
+PF10220	Smg8_Smg9	Smg8_Smg9 
+PF10221	DUF2151	Cell cycle and development regulator
+PF10222	DUF2152	Uncharacterized conserved protein (DUF2152)
+PF10223	DUF2181	Uncharacterized conserved protein (DUF2181)
+PF10224	DUF2205	Predicted coiled-coil protein (DUF2205)
+PF10225	NEMP	NEMP family 
+PF10226	CCDC85	CCDC85 family
+PF10228	DUF2228	Uncharacterised conserved protein (DUF2228)
+PF10229	MMADHC	Methylmalonic aciduria and homocystinuria type D protein
+PF10230	LIDHydrolase	Lipid-droplet associated hydrolase
+PF10231	DUF2315	Uncharacterised conserved protein (DUF2315)
+PF10232	Med8	Mediator of RNA polymerase II transcription complex subunit 8
+PF10233	Cg6151-P	Uncharacterized conserved protein CG6151-P
+PF10234	Cluap1	Clusterin-associated protein-1
+PF10235	Cript	Microtubule-associated protein CRIPT
+PF10236	DAP3	Mitochondrial ribosomal death-associated protein 3
+PF10237	N6-adenineMlase	Probable N6-adenine methyltransferase
+PF10238	Eapp_C	E2F-associated phosphoprotein
+PF10239	DUF2465	Protein of unknown function (DUF2465)
+PF10240	DUF2464	Multivesicular body subunit 12
+PF10241	KxDL	Uncharacterized conserved protein
+PF10242	L_HMGIC_fpl	Lipoma HMGIC fusion partner-like protein
+PF10243	MIP-T3	Microtubule-binding protein MIP-T3
+PF10244	MRP-L51	Mitochondrial ribosomal subunit
+PF10245	MRP-S22	Mitochondrial 28S ribosomal protein S22
+PF10246	MRP-S35	Mitochondrial ribosomal protein MRP-S35
+PF10247	Romo1	Reactive mitochondrial oxygen species modulator 1
+PF10248	Mlf1IP	Myelodysplasia-myeloid leukemia factor 1-interacting protein
+PF10249	NDUFB10	NADH-ubiquinone oxidoreductase subunit 10
+PF10250	O-FucT	GDP-fucose protein O-fucosyltransferase
+PF10251	PEN-2	Presenilin enhancer-2 subunit of gamma secretase
+PF10252	PP28	Casein kinase substrate phosphoprotein PP28
+PF10253	PRCC	Mitotic checkpoint regulator, MAD2B-interacting
+PF10254	Pacs-1	PACS-1 cytosolic sorting protein
+PF10255	Paf67	RNA polymerase I-associated factor PAF67
+PF10256	Erf4	Golgin subfamily A member 7/ERF4 family
+PF10257	RAI16-like	Retinoic acid induced 16-like protein
+PF10258	RNA_GG_bind	PHAX RNA-binding domain
+PF10259	Rogdi_lz	Rogdi leucine zipper containing protein
+PF10260	SAYSvFN	Uncharacterized conserved domain (SAYSvFN)
+PF10261	Scs3p	Inositol phospholipid synthesis and fat-storage-inducing TM
+PF10262	Rdx	Rdx family
+PF10263	SprT-like	SprT-like family
+PF10264	Stork_head	Winged helix Storkhead-box1 domain
+PF10265	Miga	Mitoguardin
+PF10266	Strumpellin	Hereditary spastic paraplegia protein strumpellin
+PF10267	Tmemb_cc2	Predicted transmembrane and coiled-coil 2 protein
+PF10268	Tmemb_161AB	Predicted transmembrane protein 161AB
+PF10269	Tmemb_185A	Transmembrane Fragile-X-F protein 
+PF10270	MMgT	Membrane magnesium transporter
+PF10271	Tmp39	Putative transmembrane protein
+PF10272	Tmpp129	Putative transmembrane protein precursor
+PF10273	WGG	Pre-rRNA-processing protein TSR2
+PF10274	ParcG	Parkin co-regulated protein
+PF10275	Peptidase_C65	Peptidase C65 Otubain
+PF10276	zf-CHCC	Zinc-finger domain
+PF10277	Frag1	Frag1/DRAM/Sfk1 family
+PF10278	Med19	Mediator of RNA pol II transcription subunit 19 
+PF10279	Latarcin	Latarcin precursor
+PF10280	Med11	Mediator complex protein 
+PF10281	Ish1	Putative stress-responsive nuclear envelope protein
+PF10282	Lactonase	Lactonase, 7-bladed beta-propeller
+PF10283	zf-CCHH	Zinc-finger (CX5CX6HX5H) motif
+PF10284	Luciferase_3H	Luciferase helical bundle domain
+PF10285	Luciferase_cat	Luciferase catalytic domain
+PF10287	DUF2401	Putative TOS1-like glycosyl hydrolase (DUF2401)
+PF10288	CTU2	Cytoplasmic tRNA 2-thiolation protein 2
+PF10290	DUF2403	Glycine-rich protein domain (DUF2403)
+PF10291	muHD	Muniscin C-terminal mu homology domain
+PF10292	7TM_GPCR_Srab	Serpentine type 7TM GPCR receptor class ab chemoreceptor
+PF10293	DUF2405	Domain of unknown function (DUF2405)
+PF10294	Methyltransf_16	Lysine methyltransferase
+PF10295	DUF2406	Uncharacterised protein (DUF2406)
+PF10296	MMM1	Maintenance of mitochondrial morphology protein 1
+PF10297	Hap4_Hap_bind	Minimal binding motif of Hap4 for binding to Hap2/3/5   
+PF10298	WhiA_N	WhiA N-terminal LAGLIDADG-like domain
+PF10300	DUF3808	Protein of unknown function (DUF3808)
+PF10302	DUF2407	DUF2407 ubiquitin-like domain
+PF10303	DUF2408	Protein of unknown function (DUF2408)
+PF10304	RTP1_C2	Required for nuclear transport of RNA pol II C-terminus 2
+PF10305	Fmp27_SW	RNA pol II promoter Fmp27 protein domain
+PF10306	FLILHELTA	Hypothetical protein FLILHELTA
+PF10307	DUF2410	Hypothetical protein (DUF2410)
+PF10309	NCBP3	Nuclear cap-binding protein subunit 3 
+PF10310	DUF5427	Family of unknown function (DUF5427)
+PF10311	Ilm1	Increased loss of mitochondrial DNA protein 1
+PF10312	Cactin_mid	Conserved mid region of cactin
+PF10313	DUF2415	Uncharacterised protein domain (DUF2415)
+PF10315	Aim19	Altered inheritance of mitochondria protein 19 
+PF10316	7TM_GPCR_Srbc	Serpentine type 7TM GPCR chemoreceptor Srbc 
+PF10317	7TM_GPCR_Srd	Serpentine type 7TM GPCR chemoreceptor Srd
+PF10318	7TM_GPCR_Srh	Serpentine type 7TM GPCR chemoreceptor Srh
+PF10319	7TM_GPCR_Srj	Serpentine type 7TM GPCR chemoreceptor Srj
+PF10320	7TM_GPCR_Srsx	Serpentine type 7TM GPCR chemoreceptor Srsx
+PF10321	7TM_GPCR_Srt	Serpentine type 7TM GPCR chemoreceptor Srt
+PF10322	7TM_GPCR_Sru	Serpentine type 7TM GPCR chemoreceptor Sru
+PF10323	7TM_GPCR_Srv	Serpentine type 7TM GPCR chemoreceptor Srv
+PF10324	7TM_GPCR_Srw	Serpentine type 7TM GPCR chemoreceptor Srw
+PF10325	7TM_GPCR_Srz	Serpentine type 7TM GPCR chemoreceptor Srz
+PF10326	7TM_GPCR_Str	Serpentine type 7TM GPCR chemoreceptor Str
+PF10327	7TM_GPCR_Sri	Serpentine type 7TM GPCR chemoreceptor Sri
+PF10328	7TM_GPCR_Srx	Serpentine type 7TM GPCR chemoreceptor Srx
+PF10329	DUF2417	Region of unknown function (DUF2417)
+PF10330	Stb3	Putative Sin3 binding protein
+PF10332	DUF2418	Protein of unknown function (DUF2418)
+PF10333	Pga1	GPI-Mannosyltransferase II co-activator
+PF10334	ArAE_2	Aromatic acid exporter family member 2
+PF10335	DUF294_C	Putative nucleotidyltransferase substrate binding domain
+PF10336	DUF2420	Protein of unknown function (DUF2420)
+PF10337	ArAE_2_N	Putative ER transporter, 6TM, N-terminal
+PF10338	DUF2423	Protein of unknown function (DUF2423)
+PF10339	Vel1p	Yeast-specific zinc responsive
+PF10340	Say1_Mug180	Steryl acetyl hydrolase
+PF10341	TPP1	Shelterin complex subunit, TPP1/ACD
+PF10342	GPI-anchored	Ser-Thr-rich glycosyl-phosphatidyl-inositol-anchored membrane family
+PF10343	Q_salvage	Potential Queuosine, Q, salvage protein family
+PF10344	Fmp27	Mitochondrial protein from FMP27
+PF10345	Cohesin_load	Cohesin loading factor
+PF10346	Con-6	Conidiation protein 6
+PF10347	Fmp27_GFWDK	RNA pol II promoter Fmp27 protein domain
+PF10348	DUF2427	Domain of unknown function (DUF2427)
+PF10350	DUF2428	Putative death-receptor fusion protein (DUF2428)
+PF10351	Apt1	Golgi-body localisation protein domain
+PF10353	DUF2430	Protein of unknown function (DUF2430)
+PF10354	DUF2431	Domain of unknown function (DUF2431)
+PF10355	Ytp1	Protein of unknown function (Ytp1)
+PF10356	DUF2034	Protein of unknown function (DUF2034)
+PF10357	Kin17_mid	Domain of Kin17 curved DNA-binding protein
+PF10358	NT-C2	N-terminal C2 in EEIG1 and EHBP1 proteins
+PF10359	Fmp27_WPPW	RNA pol II promoter Fmp27 protein domain
+PF10360	DUF2433	Protein of unknown function (DUF2433)
+PF10361	DUF2434	Protein of unknown function (DUF2434)
+PF10363	RTP1_C1	Required for nuclear transport of RNA pol II C-terminus 1
+PF10364	NKWYS	Putative capsular polysaccharide synthesis protein
+PF10365	DUF2436	Domain of unknown function (DUF2436)
+PF10366	Vps39_1	Vacuolar sorting protein 39 domain 1
+PF10367	Vps39_2	Vacuolar sorting protein 39 domain 2
+PF10368	YkyA	Putative cell-wall binding lipoprotein
+PF10369	ALS_ss_C	Small subunit of acetolactate synthase
+PF10370	DUF2437	Domain of unknown function (DUF2437)
+PF10371	EKR	Domain of unknown function
+PF10372	YojJ	Bacterial membrane-spanning protein N-terminus
+PF10373	EST1_DNA_bind	Est1 DNA/RNA binding domain
+PF10374	EST1	Telomerase activating protein Est1
+PF10375	GRAB	GRIP-related Arf-binding domain 
+PF10376	Mei5	Double-strand recombination repair protein  
+PF10377	ATG11	Autophagy-related protein 11
+PF10378	RRM	Putative RRM domain  
+PF10379	nec1	Virulence protein nec1
+PF10380	CRF1	Transcription factor CRF1
+PF10381	Autophagy_C	Autophagocytosis associated protein C-terminal
+PF10382	DUF2439	Protein of unknown function (DUF2439)
+PF10383	Clr2	Transcription-silencing protein Clr2   
+PF10384	Scm3	Centromere protein Scm3
+PF10385	RNA_pol_Rpb2_45	RNA polymerase beta subunit external 1 domain
+PF10386	DUF2441	Protein of unknown function (DUF2441)
+PF10387	DUF2442	Protein of unknown function (DUF2442)
+PF10388	YkuI_C	EAL-domain associated signalling protein domain
+PF10389	CoatB	Bacteriophage coat protein B 
+PF10390	ELL	RNA polymerase II elongation factor ELL  
+PF10391	DNA_pol_lambd_f	Fingers domain of DNA polymerase lambda
+PF10392	COG5	Golgi transport complex subunit 5
+PF10393	Matrilin_ccoil	Trimeric coiled-coil oligomerisation domain of matrilin
+PF10394	Hat1_N	Histone acetyl transferase HAT1 N-terminus
+PF10395	Utp8	Utp8 family
+PF10396	TrmE_N	GTP-binding protein TrmE N-terminus
+PF10397	ADSL_C	Adenylosuccinate lyase C-terminus
+PF10398	DUF2443	Protein of unknown function (DUF2443)
+PF10399	UCR_Fe-S_N	Ubiquitinol-cytochrome C reductase Fe-S subunit TAT signal
+PF10400	Vir_act_alpha_C	Virulence activator alpha C-term
+PF10401	IRF-3	Interferon-regulatory factor 3
+PF10403	BHD_1	Rad4 beta-hairpin domain 1
+PF10404	BHD_2	Rad4 beta-hairpin domain 2
+PF10405	BHD_3	Rad4 beta-hairpin domain 3
+PF10406	TAF8_C	Transcription factor TFIID complex subunit 8 C-term 
+PF10407	Cytokin_check_N	Cdc14 phosphatase binding protein N-terminus   
+PF10408	Ufd2P_core	Ubiquitin elongating factor core
+PF10409	PTEN_C2	C2 domain of PTEN tumour-suppressor protein
+PF10410	DnaB_bind	DnaB-helicase binding domain of primase
+PF10411	DsbC_N	Disulfide bond isomerase protein N-terminus
+PF10412	TrwB_AAD_bind	Type IV secretion-system coupling protein DNA-binding domain
+PF10413	Rhodopsin_N	Amino terminal of the G-protein receptor rhodopsin
+PF10414	CysG_dimeriser	Sirohaem synthase dimerisation region
+PF10415	FumaraseC_C	Fumarase C C-terminus
+PF10416	IBD	Transcription-initiator DNA-binding domain IBD
+PF10417	1-cysPrx_C	C-terminal domain of 1-Cys peroxiredoxin
+PF10418	DHODB_Fe-S_bind	Iron-sulfur cluster binding domain of dihydroorotate dehydrogenase B
+PF10419	TFIIIC_sub6	TFIIIC subunit
+PF10420	IL12p40_C	Cytokine interleukin-12p40 C-terminus
+PF10421	OAS1_C	2'-5'-oligoadenylate synthetase 1, domain 2, C-terminus 
+PF10422	LRS4	Monopolin complex subunit LRS4
+PF10423	AMNp_N	Bacterial AMP nucleoside phosphorylase N-terminus 
+PF10425	SdrG_C_C	C-terminus of bacterial fibrinogen-binding adhesin
+PF10426	zf-RAG1	Recombination-activating protein 1 zinc-finger domain
+PF10427	Ago_hook	Argonaute hook
+PF10428	SOG2	RAM signalling pathway protein
+PF10429	Mtr2	Nuclear pore RNA shuttling protein Mtr2
+PF10430	Ig_Tie2_1	Tie-2 Ig-like domain 1
+PF10431	ClpB_D2-small	C-terminal, D2-small domain, of ClpB protein 
+PF10432	bact-PGI_C	Bacterial phospho-glucose isomerase C-terminal SIS domain
+PF10433	MMS1_N	Mono-functional DNA-alkylating methyl methanesulfonate N-term
+PF10434	MAM1	Monopolin complex protein MAM1
+PF10435	BetaGal_dom2	Beta-galactosidase, domain 2
+PF10436	BCDHK_Adom3	Mitochondrial branched-chain alpha-ketoacid dehydrogenase kinase
+PF10437	Lip_prot_lig_C	Bacterial lipoate protein ligase C-terminus
+PF10438	Cyc-maltodext_C	Cyclo-malto-dextrinase C-terminal domain
+PF10439	Bacteriocin_IIc	Bacteriocin class II with double-glycine leader peptide
+PF10440	WIYLD	Ubiquitin-binding WIYLD domain
+PF10441	Urb2	Urb2/Npa2 family
+PF10442	FIST_C	FIST C domain
+PF10443	RNA12	RNA12 protein
+PF10444	Nbl1_Borealin_N	Nbl1 / Borealin N terminal
+PF10445	DUF2456	Protein of unknown function (DUF2456)
+PF10446	DUF2457	Protein of unknown function (DUF2457)
+PF10447	EXOSC1	Exosome component EXOSC1/CSL4
+PF10448	POC3_POC4	20S proteasome chaperone assembly proteins 3 and 4
+PF10450	POC1	POC1 chaperone
+PF10451	Stn1	Telomere regulation protein Stn1
+PF10452	TCO89	TORC1 subunit TCO89
+PF10453	NUFIP1	Nuclear fragile X mental retardation-interacting protein 1 (NUFIP1)
+PF10454	DUF2458	Protein of unknown function (DUF2458)
+PF10455	BAR_2	Bin/amphiphysin/Rvs domain for vesicular trafficking
+PF10456	BAR_3_WASP_bdg	WASP-binding domain of Sorting nexin protein
+PF10457	MENTAL	Cholesterol-capturing domain
+PF10458	Val_tRNA-synt_C	Valyl tRNA synthetase tRNA binding arm
+PF10459	Peptidase_S46	Peptidase S46
+PF10460	Peptidase_M30	Peptidase M30
+PF10461	Peptidase_S68	Peptidase S68
+PF10462	Peptidase_M66	Peptidase M66
+PF10463	Peptidase_U49	Peptidase U49
+PF10464	Peptidase_U40	Peptidase U40
+PF10465	Inhibitor_I24	PinA peptidase inhibitor 
+PF10466	Inhibitor_I34	Saccharopepsin inhibitor I34
+PF10467	Inhibitor_I48	Peptidase inhibitor clitocypin
+PF10468	Inhibitor_I68	Carboxypeptidase inhibitor I68
+PF10469	AKAP7_NLS	AKAP7 2'5' RNA ligase-like domain
+PF10470	AKAP7_RIRII_bdg	PKA-RI-RII subunit binding domain of A-kinase anchor protein
+PF10471	ANAPC_CDC26	Anaphase-promoting complex APC subunit CDC26
+PF10472	CReP_N	eIF2-alpha phosphatase phosphorylation constitutive repressor
+PF10473	CENP-F_leu_zip	Leucine-rich repeats of kinetochore protein Cenp-F/LEK1
+PF10474	DUF2451	Protein of unknown function C-terminus (DUF2451)
+PF10475	Vps54_N	Vacuolar-sorting protein 54, of GARP complex 
+PF10476	DUF2448	Protein of unknown function C-terminus (DUF2448) 
+PF10477	EIF4E-T	Nucleocytoplasmic shuttling protein for mRNA cap-binding EIF4E
+PF10479	FSA_C	Fragile site-associated protein C-terminus
+PF10480	ICAP-1_inte_bdg	Beta-1 integrin binding protein
+PF10481	CENP-F_N	Cenp-F N-terminal domain
+PF10482	CtIP_N	Tumour-suppressor protein CtIP N-terminal domain
+PF10483	Elong_Iki1	Elongator subunit Iki1
+PF10484	MRP-S23	Mitochondrial ribosomal protein S23
+PF10486	PI3K_1B_p101	Phosphoinositide 3-kinase gamma adapter protein p101 subunit
+PF10487	Nup188	Nucleoporin subcomplex protein binding to Pom34
+PF10488	PP1c_bdg	Phosphatase-1 catalytic subunit binding region
+PF10490	CENP-F_C_Rb_bdg	Rb-binding domain of kinetochore protein Cenp-F/LEK1
+PF10491	Nrf1_DNA-bind	NLS-binding and DNA-binding and dimerisation domains of Nrf1
+PF10492	Nrf1_activ_bdg	Nrf1 activator activation site binding domain
+PF10493	Rod_C	Rough deal protein C-terminal region
+PF10494	Stk19	Serine-threonine protein kinase 19
+PF10495	PACT_coil_coil	Pericentrin-AKAP-450 domain of centrosomal targeting protein
+PF10496	Syntaxin-18_N	SNARE-complex protein Syntaxin-18 N-terminus 
+PF10497	zf-4CXXC_R1	Zinc-finger domain of monoamine-oxidase A repressor R1
+PF10498	IFT57	Intra-flagellar transport protein 57  
+PF10500	SR-25	Nuclear RNA-splicing-associated protein
+PF10501	Ribosomal_L50	Ribosomal subunit 39S
+PF10502	Peptidase_S26	Signal peptidase, peptidase S26 
+PF10503	Esterase_phd	Esterase PHB depolymerase
+PF10504	DUF2452	Protein of unknown function (DUF2452)
+PF10505	NARG2_C	NMDA receptor-regulated gene protein 2 C-terminus
+PF10506	MCC-bdg_PDZ	PDZ domain of MCC-2 bdg protein for Usher syndrome
+PF10507	TMEM65	Transmembrane protein 65 
+PF10508	Proteasom_PSMB	Proteasome non-ATPase 26S subunit
+PF10509	GalKase_gal_bdg	Galactokinase galactose-binding signature
+PF10510	PIG-S	Phosphatidylinositol-glycan biosynthesis class S protein
+PF10511	Cementoin	Trappin protein transglutaminase binding domain
+PF10512	Borealin	Cell division cycle-associated protein 8 
+PF10513	EPL1	Enhancer of polycomb-like
+PF10514	Bcl-2_BAD	Pro-apoptotic Bcl-2 protein, BAD
+PF10515	APP_amyloid	beta-amyloid precursor protein C-terminus
+PF10516	SHNi-TPR	SHNi-TPR
+PF10517	DM13	Electron transfer DM13
+PF10518	TAT_signal	TAT (twin-arginine translocation) pathway signal sequence
+PF10520	TMEM189_B_dmain	B domain of TMEM189, localisation domain
+PF10521	Tti2	Tti2 family 
+PF10522	RII_binding_1	RII binding domain
+PF10523	BEN	BEN domain
+PF10524	NfI_DNAbd_pre-N	Nuclear factor I protein pre-N-terminus
+PF10525	Engrail_1_C_sig	Engrailed homeobox C-terminal signature domain
+PF10528	GLEYA	GLEYA domain
+PF10529	Hist_rich_Ca-bd	Histidine-rich Calcium-binding repeat region
+PF10530	Toxin_35	Toxin with inhibitor cystine knot ICK or Knottin scaffold
+PF10531	SLBB	SLBB domain
+PF10532	Plant_all_beta	Plant specific N-all beta domain
+PF10533	Plant_zn_clust	Plant zinc cluster domain
+PF10534	CRIC_ras_sig	Connector enhancer of kinase suppressor of ras
+PF10536	PMD	Plant mobile domain
+PF10537	WAC_Acf1_DNA_bd	ATP-utilising chromatin assembly and remodelling N-terminal
+PF10538	ITAM_Cys-rich	Immunoreceptor tyrosine-based activation motif
+PF10539	Dev_Cell_Death	Development and cell death domain
+PF10540	Membr_traf_MHD	Munc13 (mammalian uncoordinated) homology domain
+PF10541	KASH	Nuclear envelope localisation domain
+PF10542	Vitelline_membr	Vitelline membrane cysteine-rich region
+PF10543	ORF6N	ORF6N domain
+PF10544	T5orf172	T5orf172 domain
+PF10545	MADF_DNA_bdg	Alcohol dehydrogenase transcription factor Myb/SANT-like
+PF10546	P63C	P63C domain
+PF10547	P22_AR_N	P22_AR N-terminal domain
+PF10548	P22_AR_C	P22AR C-terminal domain
+PF10549	ORF11CD3	ORF11CD3 domain
+PF10550	Toxin_36	Conantokin-G mollusc-toxin
+PF10551	MULE	MULE transposase domain
+PF10552	ORF6C	ORF6C domain
+PF10553	MSV199	MSV199 domain
+PF10554	Phage_ASH	Ash protein family
+PF10555	MraY_sig1	Phospho-N-acetylmuramoyl-pentapeptide-transferase signature 1 
+PF10557	Cullin_Nedd8	Cullin protein neddylation domain
+PF10558	MTP18	Mitochondrial 18 KDa protein (MTP18)  
+PF10559	Plug_translocon	Plug domain of Sec61p
+PF10561	UPF0565	Uncharacterised protein family UPF0565
+PF10562	CaM_bdg_C0	Calmodulin-binding domain C0 of NMDA receptor NR1 subunit
+PF10563	CdCA1	Cadmium carbonic anhydrase repeat
+PF10564	MAR_sialic_bdg	Sialic-acid binding micronemal adhesive repeat
+PF10565	NMDAR2_C	N-methyl D-aspartate receptor 2B3 C-terminus
+PF10566	Glyco_hydro_97	Glycoside hydrolase 97  
+PF10567	Nab6_mRNP_bdg	RNA-recognition motif
+PF10568	Tom37	Outer mitochondrial membrane transport complex protein
+PF10569	Thiol-ester_cl	Alpha-macro-globulin thiol-ester bond-forming region
+PF10570	Myelin-PO_C	Myelin-PO cytoplasmic C-term p65 binding region
+PF10571	UPF0547	Uncharacterised protein family UPF0547
+PF10572	UPF0556	Uncharacterised protein family UPF0556
+PF10573	UPF0561	Uncharacterised protein family UPF0561
+PF10574	UPF0552	Uncharacterised protein family UPF0552
+PF10576	EndIII_4Fe-2S	Iron-sulfur binding domain of endonuclease III
+PF10577	UPF0560	Uncharacterised protein family UPF0560
+PF10578	SVS_QK	Seminal vesicle protein repeat
+PF10579	Rapsyn_N	Rapsyn N-terminal myristoylation and linker region
+PF10580	Neuromodulin_N	Gap junction protein N-terminal region
+PF10581	Synapsin_N	Synapsin N-terminal
+PF10583	Involucrin_N	Involucrin of squamous epithelia N-terminus
+PF10584	Proteasome_A_N	Proteasome subunit A N-terminal signature
+PF10585	UBA_e1_thiolCys	Ubiquitin-activating enzyme active site 
+PF10587	EF-1_beta_acid	Eukaryotic elongation factor 1 beta central acidic region
+PF10588	NADH-G_4Fe-4S_3	NADH-ubiquinone oxidoreductase-G iron-sulfur binding region
+PF10589	NADH_4Fe-4S	NADH-ubiquinone oxidoreductase-F iron-sulfur binding region
+PF10590	PNP_phzG_C	Pyridoxine 5'-phosphate oxidase C-terminal dimerisation region
+PF10591	SPARC_Ca_bdg	Secreted protein acidic and rich in cysteine Ca binding region
+PF10592	AIPR	AIPR protein
+PF10593	Z1	Z1 domain
+PF10595	UPF0564	Uncharacterised protein family UPF0564
+PF10596	U6-snRNA_bdg	U6-snRNA interacting domain of PrP8
+PF10597	U5_2-snRNA_bdg	U5-snRNA binding site 2 of PrP8
+PF10598	RRM_4	RNA recognition motif of the spliceosomal PrP8
+PF10599	Nup_retrotrp_bd	Retro-transposon transporting motif  
+PF10600	PDZ_assoc	PDZ-associated domain of NMDA receptors
+PF10601	zf-LITAF-like	LITAF-like zinc ribbon domain
+PF10602	RPN7	26S proteasome subunit RPN7
+PF10604	Polyketide_cyc2	Polyketide cyclase / dehydrase and lipid transport
+PF10605	3HBOH	3HB-oligomer hydrolase (3HBOH) 
+PF10606	GluR_Homer-bdg	Homer-binding domain of metabotropic glutamate receptor 
+PF10607	CLTH	CTLH/CRA C-terminal to LisH motif domain
+PF10608	MAGUK_N_PEST	Polyubiquitination (PEST) N-terminal domain of MAGUK
+PF10609	ParA	NUBPL iron-transfer P-loop NTPase
+PF10610	Tafi-CsgC	Thin aggregative fimbriae synthesis protein
+PF10611	DUF2469	Protein of unknown function (DUF2469)
+PF10612	Spore-coat_CotZ	Spore coat protein Z
+PF10613	Lig_chan-Glu_bd	Ligated ion channel L-glutamate- and glycine-binding site
+PF10614	CsgF	Type VIII secretion system (T8SS), CsgF protein
+PF10615	DUF2470	Protein of unknown function (DUF2470)
+PF10616	DUF2471	Protein of unknown function (DUF2471) 
+PF10617	DUF2474	Protein of unknown function (DUF2474)
+PF10618	Tail_tube	Phage tail tube protein
+PF10620	MdcG	Phosphoribosyl-dephospho-CoA transferase MdcG
+PF10621	FpoO	F420H2 dehydrogenase subunit FpoO 
+PF10622	Ehbp	Energy-converting hydrogenase B subunit P (EhbP)
+PF10623	PilI	Plasmid conjugative transfer protein PilI
+PF10624	TraS	Plasmid conjugative transfer entry exclusion protein TraS
+PF10625	UspB	Universal stress protein B (UspB)
+PF10626	TraO	Conjugative transposon protein TraO
+PF10627	CsgE	Curli assembly protein CsgE
+PF10628	CotE	Outer spore coat protein E (CotE)
+PF10629	DUF2475	Protein of unknown function (DUF2475)
+PF10630	DUF2476	Protein of unknown function (DUF2476)
+PF10631	DUF2477	Protein of unknown function (DUF2477)
+PF10632	He_PIG_assoc	He_PIG associated, NEW1 domain of bacterial glycohydrolase
+PF10633	NPCBM_assoc	NPCBM-associated, NEW3 domain of alpha-galactosidase
+PF10634	Iron_transport	Fe2+ transport protein
+PF10635	DisA-linker	DisA bacterial checkpoint controller linker region 
+PF10636	hemP	Hemin uptake protein hemP
+PF10637	Ofd1_CTDD	Oxoglutarate and iron-dependent oxygenase degradation C-term
+PF10638	Sfi1_C	Spindle body associated protein C-terminus  
+PF10639	TMEM234	Putative transmembrane family 234
+PF10640	Pox_ATPase-GT	mRNA capping enzyme N-terminal, ATPase and guanylyltransferase
+PF10642	Tom5	Mitochondrial import receptor subunit or translocase
+PF10643	Cytochrome-c551	Photosystem P840 reaction-centre cytochrome c-551
+PF10644	Misat_Tub_SegII	Misato Segment II tubulin-like domain
+PF10645	Carb_bind	Carbohydrate binding
+PF10646	Germane	Sporulation and spore germination
+PF10647	Gmad1	Lipoprotein LpqB beta-propeller domain
+PF10648	Gmad2	Immunoglobulin-like domain of bacterial spore germination
+PF10649	DUF2478	Protein of unknown function (DUF2478)
+PF10650	zf-C3H1	Putative zinc-finger domain
+PF10651	DUF2479	Domain of unknown function (DUF2479)
+PF10652	DUF2480	Protein of unknown function (DUF2480)
+PF10653	Phage-A118_gp45	Protein gp45 of Bacteriophage A118
+PF10654	DUF2481	Protein of unknown function (DUF2481) 
+PF10655	DUF2482	Hypothetical protein of unknown function (DUF2482)
+PF10656	DUF2483	Hypothetical protein of unknown function (DUF2483)
+PF10657	RC-P840_PscD	Photosystem P840 reaction centre protein PscD
+PF10658	DUF2484	Protein of unknown function (DUF2484)
+PF10659	Trypan_glycop_C	Trypanosome variant surface glycoprotein C-terminal domain
+PF10660	MitoNEET_N	Iron-containing outer mitochondrial membrane protein N-terminus  
+PF10661	EssA	WXG100 protein secretion system (Wss), protein EssA
+PF10662	PduV-EutP	Ethanolamine utilisation - propanediol utilisation
+PF10664	NdhM	Cyanobacterial and plastid NDH-1 subunit M
+PF10665	Minor_capsid_1	Minor capsid protein
+PF10666	Phage_TAC_8	Phage tail assembly chaperone protein Gp14 ()A118
+PF10667	DUF2486	Protein of unknown function (DUF2486)
+PF10668	Phage_terminase	Phage terminase small subunit
+PF10669	Phage_Gp23	Protein gp23 (Bacteriophage A118)
+PF10670	DUF4198	Domain of unknown function (DUF4198)
+PF10671	TcpQ	Toxin co-regulated pilus biosynthesis protein Q
+PF10672	Methyltrans_SAM	S-adenosylmethionine-dependent methyltransferase
+PF10673	DUF2487	Protein of unknown function (DUF2487)
+PF10674	Ycf54	Protein of unknown function (DUF2488)
+PF10675	DUF2489	Protein of unknown function (DUF2489)
+PF10676	gerPA	Spore germination protein gerPA/gerPF
+PF10677	DUF2490	Protein of unknown function (DUF2490)
+PF10678	DUF2492	Protein of unknown function (DUF2492)
+PF10679	DUF2491	Protein of unknown function (DUF2491)
+PF10680	RRN9	RNA polymerase I specific transcription initiation factor
+PF10681	Rot1	Chaperone for protein-folding within the ER, fungal
+PF10682	UL40	Glycoprotein of human cytomegalovirus HHV-5
+PF10683	DBD_Tnp_Hermes	Hermes transposase DNA-binding domain  
+PF10684	BDM	Putative biofilm-dependent modulation protein
+PF10685	KGG	Stress-induced bacterial acidophilic repeat motif
+PF10686	DUF2493	Protein of unknown function (DUF2493)
+PF10688	Imp-YgjV	Bacterial inner membrane protein
+PF10689	DUF2496	Protein of unknown function (DUF2496)
+PF10690	Myticin-prepro	Myticin pre-proprotein from the mussel
+PF10691	DUF2497	Protein of unknown function (DUF2497) 
+PF10692	DUF2498	Protein of unknown function (DUF2498)
+PF10693	DUF2499	Protein of unknown function (DUF2499)
+PF10694	DUF2500	Protein of unknown function (DUF2500)
+PF10696	DUF2501	Protein of unknown function (DUF2501)
+PF10697	DUF2502	Protein of unknown function (DUF2502)
+PF10698	DUF2505	Protein of unknown function (DUF2505)
+PF10699	HAP2-GCS1	Male gamete fusion factor
+PF10702	DUF2507	Protein of unknown function (DUF2507)
+PF10703	MoaF	MoaF N-terminal domain
+PF10704	DUF2508	Protein of unknown function (DUF2508)
+PF10705	Ycf15	Chloroplast protein precursor Ycf15 putative
+PF10706	Aminoglyc_resit	Aminoglycoside-2''-adenylyltransferase
+PF10707	YrbL-PhoP_reg	PhoP regulatory network protein YrbL
+PF10708	DUF2510	Protein of unknown function (DUF2510)
+PF10709	DUF2511	Protein of unknown function (DUF2511)
+PF10710	DUF2512	Protein of unknown function (DUF2512)
+PF10711	DUF2513	Hypothetical protein (DUF2513)
+PF10712	NAD-GH	NAD-specific glutamate dehydrogenase
+PF10713	DUF2509	Protein of unknown function (DUF2509) 
+PF10714	LEA_6	Late embryogenesis abundant protein 18
+PF10715	REGB_T4	T4-page Endoribonuclease RegB
+PF10716	NdhL	NADH dehydrogenase transmembrane subunit
+PF10717	ODV-E18	Occlusion-derived virus envelope protein ODV-E18
+PF10718	Ycf34	Hypothetical chloroplast protein Ycf34
+PF10719	ComFB	Late competence development protein ComFB
+PF10720	DUF2515	Protein of unknown function (DUF2515)
+PF10721	DUF2514	Protein of unknown function (DUF2514)
+PF10722	YbjN	Putative bacterial sensory transduction regulator
+PF10723	RepB-RCR_reg	Replication regulatory protein RepB
+PF10724	DUF2516	Protein of unknown function (DUF2516)
+PF10725	DUF2517	Protein of unknown function (DUF2517)
+PF10726	DUF2518	Protein of function (DUF2518)
+PF10727	Rossmann-like	Rossmann-like domain
+PF10728	DUF2520	Domain of unknown function (DUF2520)
+PF10729	CedA	Cell division activator CedA
+PF10730	DUF2521	Protein of unknown function (DUF2521)
+PF10731	Anophelin	Thrombin inhibitor from mosquito
+PF10732	DUF2524	Protein of unknown function (DUF2524)
+PF10733	DUF2525	Protein of unknown function (DUF2525)
+PF10734	DUF2523	Protein of unknown function (DUF2523)
+PF10735	DUF2526	Protein of unknown function (DUF2526)   
+PF10736	DUF2527	Protein of unknown function (DUF2627) 
+PF10737	GerPC	Spore germination protein GerPC
+PF10738	Lpp-LpqN	Probable lipoprotein LpqN
+PF10739	DUF2550	Protein of unknown function (DUF2550)
+PF10740	DUF2529	Domain of unknown function (DUF2529)
+PF10741	T2SSM_b	Type II secretion system (T2SS), protein M subtype b
+PF10742	DUF2555	Protein of unknown function (DUF2555)
+PF10743	Phage_Cox	Regulatory phage protein cox
+PF10744	Med1	Mediator of RNA polymerase II transcription subunit 1
+PF10745	DUF2530	Protein of unknown function (DUF2530)
+PF10746	Phage_holin_2_2	Phage holin T7 family, holin superfamily II
+PF10747	SirA	Sporulation inhibitor of replication protein SirA 
+PF10748	DUF2531	Protein of unknown function (DUF2531)
+PF10749	DUF2534	Protein of unknown function (DUF2534)
+PF10750	DUF2536	Protein of unknown function (DUF2536)
+PF10751	DUF2535	Protein of unknown function (DUF2535)
+PF10752	DUF2533	Protein of unknown function (DUF2533) 
+PF10753	Toxin_GhoT_OrtT	Toxin GhoT_OrtT
+PF10754	DUF2569	Protein of unknown function (DUF2569)
+PF10755	DUF2585	Protein of unknown function (DUF2585)
+PF10756	bPH_6	Bacterial PH domain
+PF10757	YbaJ	Biofilm formation regulator YbaJ
+PF10758	DUF2586	Protein of unknown function (DUF2586)
+PF10759	DUF2587	Protein of unknown function (DUF2587)
+PF10761	DUF2590	Protein of unknown function (DUF2590)
+PF10762	DUF2583	Protein of unknown function (DUF2583)   
+PF10763	DUF2584	Protein of unknown function (DUF2584)
+PF10764	Gin	Inhibitor of sigma-G Gin
+PF10765	DUF2591	Protein of unknown function (DUF2591)
+PF10766	AcrZ	Multidrug efflux pump-associated protein AcrZ
+PF10767	DUF2593	Protein of unknown function (DUF2593)
+PF10768	FliX	Class II flagellar assembly regulator
+PF10769	DUF2594	Protein of unknown function (DUF2594)
+PF10771	DUF2582	Winged helix-turn-helix domain (DUF2582)
+PF10772	DUF2597	Protein of unknown function (DUF2597)
+PF10774	DUF4226	Domain of unknown function (DUF4226)
+PF10775	ATP_sub_h	ATP synthase complex subunit h
+PF10776	DUF2600	Protein of unknown function (DUF2600)
+PF10777	YlaC	Inner membrane protein YlaC
+PF10778	DehI	Halocarboxylic acid dehydrogenase DehI
+PF10779	XhlA	Haemolysin XhlA
+PF10780	MRP_L53	39S ribosomal protein L53/MRP-L53
+PF10781	DSRB	Dextransucrase DSRB
+PF10782	zf-C2HCIx2C	Zinc-finger
+PF10783	DUF2599	Protein of unknown function (DUF2599)
+PF10784	Plasmid_stab_B	Plasmid stability protein
+PF10785	NADH-u_ox-rdase	NADH-ubiquinone oxidoreductase complex I, 21 kDa subunit
+PF10786	G6PD_bact	Glucose-6-phosphate 1-dehydrogenase (EC 1.1.1.49)
+PF10787	YfmQ	Uncharacterised protein from bacillus cereus group
+PF10788	DUF2603	Protein of unknown function (DUF2603)
+PF10789	Phage_RpbA	Phage RNA polymerase binding, RpbA
+PF10790	DUF2604	Protein of Unknown function (DUF2604)
+PF10791	F1F0-ATPsyn_F	Mitochondrial F1-F0 ATP synthase subunit F of fungi
+PF10792	DUF2605	Protein of unknown function (DUF2605)
+PF10793	Gloverin	Gloverin-like protein 
+PF10794	DUF2606	Protein of unknown function (DUF2606)
+PF10795	DUF2607	Protein of unknown function (DUF2607)
+PF10796	Anti-adapt_IraP	Sigma-S stabilisation anti-adaptor protein 
+PF10797	YhfT	Protein of unknown function
+PF10798	YmgB	Biofilm development protein YmgB/AriR
+PF10799	YliH	Biofilm formation protein (YliH/bssR)
+PF10800	DUF2528	Protein of unknown function (DUF2528) 
+PF10801	DUF2537	Protein of unknown function (DUF2537)
+PF10802	DUF2540	Protein of unknown function (DUF2540)
+PF10803	GerPB	Spore germination GerPB
+PF10804	DUF2538	Protein of unknown function (DUF2538) 
+PF10805	DUF2730	Protein of unknown function (DUF2730)
+PF10806	SAM35	SAM35, subunit of SAM coomplex
+PF10807	DUF2541	Protein of unknown function (DUF2541)
+PF10808	DUF2542	Protein of unknown function (DUF2542) 
+PF10809	DUF2732	Protein of unknown function (DUF2732)
+PF10810	DUF2545	Protein of unknown function (DUF2545)   
+PF10811	DUF2532	Protein of unknown function (DUF2532)
+PF10812	DUF2561	Protein of unknown function (DUF2561)
+PF10813	DUF2733	Protein of unknown function (DUF2733)
+PF10814	CwsA	Cell wall synthesis protein CwsA
+PF10815	ComZ	ComZ
+PF10816	DUF2760	Domain of unknown function (DUF2760)
+PF10817	DUF2563	Protein of unknown function (DUF2563)
+PF10818	DUF2547	Protein of unknown function (DUF2547)
+PF10819	DUF2564	Protein of unknown function (DUF2564)     
+PF10820	DUF2543	Protein of unknown function (DUF2543)
+PF10821	DUF2567	Protein of unknown function (DUF2567)
+PF10823	DUF2568	Protein of unknown function (DUF2568)
+PF10824	T7SS_ESX_EspC	Excreted virulence factor EspC, type VII ESX diderm
+PF10825	DUF2752	Protein of unknown function (DUF2752)
+PF10826	DUF2551	Protein of unknown function (DUF2551) 
+PF10827	DUF2552	Protein of unknown function (DUF2552) 
+PF10828	DUF2570	Protein of unknown function (DUF2570)
+PF10829	DUF2554	Protein of unknown function (DUF2554)
+PF10830	DUF2553	Protein of unknown function (DUF2553)
+PF10831	DUF2556	Protein of unknown function (DUF2556)
+PF10832	DUF2559	Protein of unknown function (DUF2559)
+PF10833	DUF2572	Protein of unknown function (DUF2572)
+PF10834	DUF2560	Protein of unknown function (DUF2560)
+PF10835	DUF2573	Protein of unknown function (DUF2573)
+PF10836	DUF2574	Protein of unknown function (DUF2574)  
+PF10837	DUF2575	Protein of unknown function (DUF2575)
+PF10838	DUF2677	Protein of unknown function (DUF2677)
+PF10839	DUF2647	Protein of unknown function (DUF2647)   
+PF10840	DUF2645	Protein of unknown function (DUF2645)
+PF10841	DUF2644	Protein of unknown function (DUF2644)
+PF10842	DUF2642	Protein of unknown function (DUF2642)
+PF10843	RGI1	Respiratory growth induced protein 1 
+PF10844	DUF2577	Protein of unknown function (DUF2577)
+PF10845	DUF2576	Protein of unknown function (DUF2576)
+PF10846	DUF2722	Protein of unknown function (DUF2722)
+PF10847	DUF2656	Protein of unknown function (DUF2656)
+PF10848	DUF2655	Protein of unknown function (DUF2655)
+PF10849	DUF2654	Protein of unknown function (DUF2654)
+PF10850	DUF2653	Protein of unknown function (DUF2653)
+PF10851	DUF2652	Protein of unknown function (DUF2652)   
+PF10852	DUF2651	Protein of unknown function (DUF2651)   
+PF10853	DUF2650	Protein of unknown function (DUF2650)
+PF10854	DUF2649	Protein of unknown function (DUF2649)
+PF10855	DUF2648	Protein of unknown function (DUF2648)
+PF10856	DUF2678	Protein of unknown function (DUF2678)
+PF10857	DUF2701	Protein of unknown function (DUF2701)
+PF10858	DUF2659	Protein of unknown function (DUF2659)
+PF10859	DUF2660	Protein of unknown function (DUF2660)
+PF10860	DUF2661	Protein of unknown function (DUF2661)
+PF10861	DUF2784	Protein of Unknown function (DUF2784)
+PF10862	FcoT	FcoT-like thioesterase domain
+PF10863	NOP19	Nucleolar protein 19
+PF10864	DUF2663	Protein of unknown function (DUF2663)
+PF10865	DUF2703	Domain of unknown function (DUF2703)
+PF10866	DUF2704	Protein of unknown function (DUF2704)
+PF10867	DUF2664	Protein of unknown function (DUF2664)
+PF10868	Defensin_like	Cysteine-rich antifungal protein 2, defensin-like
+PF10869	DUF2666	Protein of unknown function (DUF2666) 
+PF10870	DUF2729	Protein of unknown function (DUF2729)
+PF10871	DUF2748	Protein of unknown function (DUF2748)
+PF10872	DUF2740	Protein of unknown function (DUF2740)
+PF10873	CYYR1	Cysteine and tyrosine-rich protein 1 
+PF10874	DUF2746	Protein of unknown function (DUF2746)
+PF10875	DUF2670	Protein of unknown function (DUF2670)
+PF10876	Phage_TAC_9	Phage tail assemb.y chaperone protein, TAC
+PF10877	DUF2671	Protein of unknown function (DUF2671)
+PF10878	DUF2672	Protein of unknown function (DUF2672)
+PF10879	DUF2674	Protein of unknown function (DUF2674)
+PF10880	DUF2673	Protein of unknown function (DUF2673)
+PF10881	DUF2726	Protein of unknown function (DUF2726)
+PF10882	bPH_5	Bacterial PH domain
+PF10883	DUF2681	Protein of unknown function (DUF2681)
+PF10884	DUF2683	Protein of unknown function (DUF2683)
+PF10885	DUF2684	Protein of unknown function (DUF2684)
+PF10886	DUF2685	Protein of unknown function (DUF2685)
+PF10887	DUF2686	Protein of unknown function (DUF2686)
+PF10888	DUF2742	Protein of unknown function (DUF2742)
+PF10890	Cyt_b-c1_8	Cytochrome b-c1 complex subunit 8
+PF10891	DUF2719	Protein of unknown function (DUF2719)
+PF10892	DUF2688	Protein of unknown function (DUF2688)
+PF10893	DUF2724	Protein of unknown function (DUF2724)
+PF10894	DUF2689	Protein of unknown function (DUF2689)
+PF10895	DUF2715	Domain of unknown function (DUF2715)
+PF10896	DUF2714	Protein of unknown function (DUF2714)
+PF10897	DUF2713	Protein of unknown function (DUF2713)
+PF10898	DUF2716	Protein of unknown function (DUF2716)
+PF10899	AbiGi	Putative abortive phage resistance protein AbiGi, antitoxin
+PF10901	DUF2690	Protein of unknown function (DUF2690)
+PF10902	WYL_2	WYL_2, Sm-like SH3 beta-barrel fold
+PF10903	DUF2691	Protein of unknown function (DUF2691)
+PF10904	DUF2694	Protein of unknown function (DUF2694)
+PF10905	DUF2695	Protein of unknown function (DUF2695)
+PF10906	Mrx7	MIOREX complex component 7 
+PF10907	DUF2749	Protein of unknown function (DUF2749)
+PF10908	DUF2778	Protein of unknown function (DUF2778)
+PF10909	DUF2682	Protein of unknown function (DUF2682)
+PF10910	DUF2744	Protein of unknown function (DUF2744)
+PF10911	DUF2717	Protein of unknown function (DUF2717)
+PF10912	DUF2700	Protein of unknown function (DUF2700)
+PF10913	DUF2706	Protein of unknown function (DUF2706)
+PF10914	DUF2781	Protein of unknown function (DUF2781)
+PF10915	DUF2709	Protein of unknown function (DUF2709)
+PF10916	DUF2712	Protein of unknown function (DUF2712)
+PF10917	Fungus-induced	Fungus-induced protein 
+PF10918	DUF2718	Protein of unknown function (DUF2718)
+PF10920	DUF2705	Protein of unknown function (DUF2705)
+PF10921	DUF2710	Protein of unknown function (DUF2710)
+PF10922	DUF2745	Protein of unknown function (DUF2745)
+PF10923	DUF2791	P-loop Domain of unknown function (DUF2791)
+PF10924	DUF2711	Protein of unknown function (DUF2711)
+PF10925	DUF2680	Protein of unknown function (DUF2680)
+PF10926	DUF2800	Protein of unknown function (DUF2800)
+PF10927	DUF2738	Protein of unknown function (DUF2738)
+PF10928	DUF2810	Protein of unknown function (DUF2810)
+PF10929	DUF2811	Protein of unknown function (DUF2811)
+PF10930	DUF2737	Protein of unknown function (DUF2737)
+PF10931	DUF2735	Protein of unknown function (DUF2735)
+PF10932	DUF2783	Protein of unknown function (DUF2783)
+PF10933	DUF2827	Protein of unknown function (DUF2827)
+PF10934	DUF2634	Protein of unknown function (DUF2634)
+PF10935	DUF2637	Protein of unknown function (DUF2637)
+PF10936	DUF2617	Protein of unknown function DUF2617
+PF10937	S36_mt	Ribosomal protein S36, mitochondrial 
+PF10938	YfdX	YfdX protein
+PF10939	DUF2631	Protein of unknown function (DUF2631)   
+PF10940	DUF2618	Protein of unknown function (DUF2618)
+PF10941	DUF2620	Protein of unknown function DUF2620
+PF10942	DUF2619	Protein of unknown function (DUF2619)
+PF10943	DUF2632	Protein of unknown function (DUF2632)
+PF10944	DUF2630	Protein of unknown function (DUF2630)
+PF10945	CBP_BcsR	Cellulose biosynthesis protein BcsR
+PF10946	DUF2625	Protein of unknown function DUF2625
+PF10947	DUF2628	Protein of unknown function (DUF2628)    
+PF10948	DUF2635	Protein of unknown function (DUF2635)
+PF10949	DUF2777	Protein of unknown function (DUF2777)
+PF10950	Organ_specific	Organ specific protein 
+PF10951	DUF2776	Protein of unknown function (DUF2776)
+PF10952	DUF2753	Protein of unknown function (DUF2753)
+PF10953	DUF2754	Protein of unknown function (DUF2754)
+PF10954	DUF2755	Protein of unknown function (DUF2755)
+PF10955	DUF2757	Protein of unknown function (DUF2757)
+PF10956	DUF2756	Protein of unknown function (DUF2756)
+PF10957	Spore_Cse60	Sporulation protein Cse60 
+PF10958	DUF2759	Protein of unknown function (DUF2759)
+PF10959	DUF2761	Protein of unknown function (DUF2761)
+PF10960	Holin_BhlA	BhlA holin family
+PF10961	SelK_SelG	Selenoprotein SelK_SelG 
+PF10962	DUF2764	Protein of unknown function (DUF2764)
+PF10963	Phage_TAC_10	Phage tail assembly chaperone
+PF10964	DUF2766	Protein of unknown function (DUF2766)
+PF10965	DUF2767	Protein of unknown function (DUF2767)
+PF10966	DUF2768	Protein of unknown function (DUF2768)
+PF10967	DUF2769	Protein of unknown function (DUF2769)
+PF10968	DUF2770	Protein of unknown function (DUF2770)
+PF10969	DUF2771	Protein of unknown function (DUF2771)
+PF10970	GerPE	Spore germination protein GerPE 
+PF10971	DUF2773	Protein of unknown function (DUF2773)
+PF10972	CsiV	Peptidoglycan-binding protein, CsiV
+PF10973	DUF2799	Protein of unknown function (DUF2799)
+PF10974	DUF2804	Protein of unknown function (DUF2804)
+PF10975	DUF2802	Protein of unknown function (DUF2802)
+PF10976	DUF2790	Protein of unknown function (DUF2790)
+PF10977	DUF2797	Protein of unknown function (DUF2797)
+PF10978	DUF2785	Protein of unknown function (DUF2785)
+PF10979	DUF2786	Protein of unknown function (DUF2786)
+PF10980	DUF2787	Protein of unknown function (DUF2787)
+PF10981	DUF2788	Protein of unknown function (DUF2788)
+PF10982	DUF2789	Protein of unknown function (DUF2789)
+PF10983	DUF2793	Protein of unknown function (DUF2793)
+PF10984	DUF2794	Protein of unknown function (DUF2794)
+PF10985	DUF2805	Protein of unknown function (DUF2805)
+PF10986	DUF2796	Protein of unknown function (DUF2796)
+PF10987	DUF2806	Protein of unknown function (DUF2806)
+PF10988	DUF2807	Putative auto-transporter adhesin, head GIN domain
+PF10989	DUF2808	Protein of unknown function (DUF2808)
+PF10990	DUF2809	Protein of unknown function (DUF2809)
+PF10991	DUF2815	Protein of unknown function (DUF2815)
+PF10992	DUF2816	Protein of unknown function (DUF2816)
+PF10993	DUF2818	Protein of unknown function (DUF2818)
+PF10994	DUF2817	Protein of unknown function (DUF2817)
+PF10995	CBP_GIL	GGDEF I-site like or GIL domain
+PF10996	Beta-Casp	Beta-Casp domain
+PF10997	Amj	Alternate to MurJ
+PF10998	DUF2838	Protein of unknown function (DUF2838)
+PF10999	DUF2839	Protein of unknown function (DUF2839)
+PF11000	DUF2840	Protein of unknown function (DUF2840)
+PF11001	DUF2841	Protein of unknown function (DUF2841)
+PF11002	RDM	RFPL defining motif (RDM)
+PF11003	DUF2842	Protein of unknown function (DUF2842)
+PF11004	Kdo_hydroxy	3-deoxy-D-manno-oct-2-ulosonic acid (Kdo) hydroxylase
+PF11005	DUF2844	Protein of unknown function (DUF2844)
+PF11006	DUF2845	Protein of unknown function (DUF2845)
+PF11007	CotJA	Spore coat associated protein JA (CotJA)
+PF11008	DUF2846	Protein of unknown function (DUF2846)
+PF11009	DUF2847	Protein of unknown function (DUF2847)
+PF11010	DUF2848	Protein of unknown function (DUF2848)
+PF11011	DUF2849	Protein of unknown function (DUF2849)
+PF11012	DUF2850	Protein of unknown function (DUF2850)
+PF11013	DUF2851	Protein of unknown function (DUF2851)
+PF11014	DUF2852	Protein of unknown function (DUF2852)
+PF11015	DUF2853	Protein of unknown function (DUF2853)
+PF11016	DUF2854	Protein of unknown function (DUF2854)
+PF11017	DUF2855	Protein of unknown function (DUF2855)
+PF11018	Cuticle_3	Pupal cuticle protein C1
+PF11019	DUF2608	Protein of unknown function (DUF2608)
+PF11020	DUF2610	Domain of unknown function (DUF2610)
+PF11021	DUF2613	Protein of unknown function (DUF2613)
+PF11022	DUF2611	Protein of unknown function (DUF2611)
+PF11023	DUF2614	Zinc-ribbon containing domain
+PF11024	DGF-1_4	Dispersed gene family protein 1 of Trypanosoma cruzi region 4
+PF11025	GP40	Glycoprotein GP40 of Cryptosporidium
+PF11026	DUF2721	Protein of unknown function (DUF2721)
+PF11027	DUF2615	Protein of unknown function (DUF2615)
+PF11028	DUF2723	Protein of unknown function (DUF2723)
+PF11029	DAZAP2	DAZ associated protein 2 (DAZAP2)
+PF11030	Nucleocapsid-N	Nucleocapsid protein N   
+PF11031	Phage_holin_T	Bacteriophage T holin
+PF11032	ApoM	ApoM domain
+PF11033	ComJ	Competence protein J (ComJ)
+PF11034	Grg1	Glucose-repressible protein Grg1 
+PF11035	SnAPC_2_like	Small nuclear RNA activating complex subunit 2, SNAP190 Myb
+PF11036	YqgB	Virulence promoting factor
+PF11037	Musclin	Insulin-resistance promoting peptide in skeletal muscle
+PF11038	DGF-1_5	Dispersed gene family protein 1 of Trypanosoma cruzi region 5
+PF11039	DUF2824	Protein of unknown function (DUF2824)
+PF11040	DGF-1_C	Dispersed gene family protein 1 of Trypanosoma cruzi C-terminus 
+PF11041	DUF2612	Protein of unknown function (DUF2612)
+PF11042	DUF2750	Protein of unknown function (DUF2750)
+PF11043	DUF2856	Protein of unknown function (DUF2856)
+PF11044	TMEMspv1-c74-12	Plectrovirus spv1-c74 ORF 12 transmembrane protein
+PF11045	YbjM	Putative inner membrane protein of Enterobacteriaceae
+PF11046	HycA_repressor	Transcriptional repressor of hyc and hyp operons
+PF11047	SopD	Salmonella outer protein D
+PF11049	KSHV_K1	Glycoprotein K1 of Kaposi's sarcoma-associated herpes virus
+PF11050	Viral_env_E26	Virus envelope protein E26
+PF11051	Mannosyl_trans3	Mannosyltransferase putative
+PF11052	Tr-sialidase_C	Trans-sialidase of Trypanosoma hydrophobic C-terminal
+PF11053	DNA_Packaging	Terminase DNA packaging enzyme
+PF11054	Surface_antigen	Sporozoite TA4 surface antigen
+PF11055	Gsf2	Glucose signalling factor 2
+PF11056	UvsY	Recombination, repair and ssDNA binding protein UvsY
+PF11057	Cortexin	Cortexin of kidney
+PF11058	Ral	Antirestriction protein Ral 
+PF11059	DUF2860	Protein of unknown function (DUF2860)
+PF11060	DUF2861	Protein of unknown function (DUF2861)
+PF11061	DUF2862	Protein of unknown function (DUF2862)
+PF11062	DUF2863	Protein of unknown function (DUF2863)
+PF11064	DUF2865	Protein of unknown function (DUF2865)
+PF11065	DUF2866	Protein of unknown function (DUF2866)
+PF11066	DUF2867	Protein of unknown function (DUF2867)
+PF11067	DUF2868	Protein of unknown function (DUF2868)
+PF11068	YlqD	YlqD protein
+PF11069	DUF2870	Protein of unknown function (DUF2870)
+PF11070	DUF2871	Protein of unknown function (DUF2871)
+PF11071	Nuc_deoxyri_tr3	Nucleoside 2-deoxyribosyltransferase YtoQ
+PF11072	DUF2859	Protein of unknown function (DUF2859)
+PF11073	NSs	Rift valley fever virus non structural protein (NSs) like 
+PF11074	DUF2779	Domain of unknown function(DUF2779)
+PF11075	DUF2780	Protein of unknown function VcgC/VcgE (DUF2780)
+PF11076	YbhQ	Putative inner membrane protein YbhQ
+PF11077	DUF2616	Protein of unknown function (DUF2616)
+PF11078	Optomotor-blind	Optomotor-blind protein N-terminal region
+PF11079	YqhG	Bacterial protein YqhG of unknown function
+PF11080	GhoS	Endoribonuclease GhoS 
+PF11081	DUF2890	Protein of unknown function (DUF2890)
+PF11082	DUF2880	Protein of unknown function (DUF2880)
+PF11083	Streptin-Immun	Lantibiotic streptin immunity protein
+PF11084	DUF2621	Protein of unknown function (DUF2621)
+PF11085	YqhR	Conserved membrane protein YqhR
+PF11086	DUF2878	Protein of unknown function (DUF2878)
+PF11087	PRD1_DD	PRD1 phage membrane DNA delivery
+PF11088	RL11D	Glycoprotein encoding membrane proteins RL5A and RL6
+PF11089	SyrA	Exopolysaccharide production repressor
+PF11090	DUF2833	Protein of unknown function (DUF2833)
+PF11091	T4_tail_cap	Tail-tube assembly protein
+PF11092	Alveol-reg_P311	Neuronal protein 3.1 (p311)
+PF11093	Mitochondr_Som1	Mitochondrial export protein Som1
+PF11094	UL11	Membrane-associated tegument protein
+PF11095	Gemin7	Gem-associated protein 7 (Gemin7)
+PF11097	DUF2883	Protein of unknown function (DUF2883)
+PF11098	Chlorosome_CsmC	Chlorosome envelope protein C
+PF11099	M11L	Apoptosis regulator M11L like
+PF11100	TrbE	Conjugal transfer protein TrbE 
+PF11101	DUF2884	Protein of unknown function (DUF2884)
+PF11102	YjbF	Group 4 capsule polysaccharide lipoprotein gfcB, YjbF
+PF11103	DUF2887	Protein of unknown function (DUF2887)
+PF11104	PilM_2	Type IV pilus assembly protein PilM;
+PF11105	CCAP	Arthropod cardioacceleratory peptide 2a
+PF11106	YjbE	Exopolysaccharide production protein YjbE
+PF11107	FANCF	Fanconi anemia group F protein (FANCF)
+PF11108	Phage_glycop_gL	Viral glycoprotein L
+PF11109	RFamide_26RFa	Orexigenic neuropeptide Qrfp/P518 
+PF11110	Phage_hub_GP28	Baseplate hub distal subunit
+PF11111	CENP-M	Centromere protein M (CENP-M)
+PF11112	PyocinActivator	Pyocin activator protein PrtN
+PF11113	Phage_head_chap	Head assembly gene product
+PF11114	Minor_capsid_2	Minor capsid protein
+PF11115	DUF2623	Protein of unknown function (DUF2623)
+PF11116	DUF2624	Protein of unknown function (DUF2624)
+PF11117	DUF2626	Protein of unknown function (DUF2626)
+PF11118	DUF2627	Protein of unknown function (DUF2627)
+PF11119	DUF2633	Protein of unknown function (DUF2633)
+PF11120	CBP_BcsF	Cellulose biosynthesis protein BcsF
+PF11121	DUF2639	Protein of unknown function (DUF2639)
+PF11122	Spore-coat_CotD	Inner spore coat protein D
+PF11123	DNA_Packaging_2	DNA packaging protein 
+PF11124	Pho86	Inorganic phosphate transporter Pho86
+PF11125	DUF2830	Protein of unknown function (DUF2830)
+PF11126	Phage_DsbA	Transcriptional regulator DsbA
+PF11127	DUF2892	Protein of unknown function (DUF2892)
+PF11128	Nucleocap_ssRNA	Plant viral coat protein nucleocapsid
+PF11129	EIAV_Rev	Rev protein of equine infectious anaemia virus
+PF11130	TraC_F_IV	F pilus assembly Type-IV secretion system for plasmid transfer
+PF11131	PhrC_PhrF	Rap-phr extracellular signalling
+PF11132	SplA	Transcriptional regulator protein (SplA)
+PF11133	Phage_head_fibr	Head fiber protein
+PF11134	Phage_stabilise	Phage stabilisation protein
+PF11135	DUF2888	Protein of unknown function (DUF2888)
+PF11136	DUF2889	Protein of unknown function (DUF2889)
+PF11137	DUF2909	Protein of unknown function (DUF2909)
+PF11138	DUF2911	Protein of unknown function (DUF2911)
+PF11139	SfLAP	Sap, sulfolipid-1-addressing protein
+PF11140	DUF2913	Protein of unknown function (DUF2913)
+PF11141	DUF2914	Protein of unknown function (DUF2914)
+PF11142	DUF2917	Protein of unknown function (DUF2917)
+PF11143	DUF2919	Protein of unknown function (DUF2919)
+PF11144	DUF2920	Protein of unknown function (DUF2920)
+PF11145	DUF2921	Protein of unknown function (DUF2921)
+PF11146	DUF2905	Protein of unknown function (DUF2905)
+PF11148	DUF2922	Protein of unknown function (DUF2922)
+PF11149	DUF2924	Protein of unknown function (DUF2924)
+PF11150	DUF2927	Protein of unknown function (DUF2927)
+PF11151	DUF2929	Protein of unknown function (DUF2929)
+PF11152	CCB2_CCB4	Cofactor assembly of complex C subunit B, CCB2/CCB4 
+PF11153	DUF2931	Protein of unknown function (DUF2931)
+PF11154	DUF2934	Protein of unknown function (DUF2934)
+PF11155	DUF2935	Domain of unknown function (DUF2935)
+PF11157	DUF2937	Protein of unknown function (DUF2937)
+PF11158	DUF2938	Protein of unknown function (DUF2938)
+PF11159	DUF2939	Protein of unknown function (DUF2939)
+PF11160	DUF2945	Protein of unknown function (DUF2945)
+PF11161	DUF2944	Protein of unknown function (DUF2946)
+PF11162	DUF2946	Protein of unknown function (DUF2946)
+PF11163	DUF2947	Protein of unknown function (DUF2947)
+PF11164	DUF2948	Protein of unknown function (DUF2948)
+PF11165	DUF2949	Protein of unknown function (DUF2949)
+PF11166	DUF2951	Protein of unknown function (DUF2951)
+PF11167	DUF2953	Protein of unknown function (DUF2953)
+PF11168	DUF2955	Protein of unknown function (DUF2955)
+PF11169	DUF2956	Protein of unknown function (DUF2956)
+PF11170	DUF2957	Protein of unknown function (DUF2957)
+PF11171	DUF2958	Protein of unknown function (DUF2958)
+PF11172	DUF2959	Protein of unknown function (DUF2959)
+PF11173	DUF2960	Protein of unknown function (DUF2960)
+PF11174	DUF2970	Protein of unknown function (DUF2970)
+PF11175	DUF2961	Protein of unknown function (DUF2961)
+PF11176	Tma16	Translation machinery-associated protein 16 
+PF11177	DUF2964	Protein of unknown function (DUF2964)
+PF11178	DUF2963	Protein of unknown function (DUF2963)
+PF11179	DUF2967	Protein of unknown function (DUF2967)
+PF11180	DUF2968	Protein of unknown function (DUF2968)
+PF11181	YflT	Heat induced stress protein YflT
+PF11182	AlgF	Alginate O-acetyl transferase AlgF 
+PF11183	PmrD	Polymyxin resistance protein PmrD
+PF11184	DUF2969	Protein of unknown function (DUF2969)
+PF11185	DUF2971	Protein of unknown function (DUF2971)
+PF11186	DUF2972	Protein of unknown function (DUF2972)
+PF11187	DUF2974	Protein of unknown function (DUF2974)
+PF11188	DUF2975	Protein of unknown function (DUF2975)
+PF11189	DUF2973	Protein of unknown function (DUF2973)
+PF11190	DUF2976	Protein of unknown function (DUF2976)
+PF11191	DUF2782	Protein of unknown function (DUF2782)
+PF11192	DUF2977	Protein of unknown function (DUF2977)
+PF11193	DUF2812	Protein of unknown function (DUF2812)
+PF11195	DUF2829	Protein of unknown function (DUF2829) 
+PF11196	DUF2834	Protein of unknown function (DUF2834)
+PF11197	DUF2835	Protein of unknown function (DUF2835)
+PF11198	DUF2857	Protein of unknown function (DUF2857)
+PF11199	DUF2891	Protein of unknown function (DUF2891)
+PF11200	DUF2981	Protein of unknown function (DUF2981)
+PF11201	DUF2982	Protein of unknown function (DUF2982)
+PF11202	PRTase_1	Phosphoribosyl transferase (PRTase)
+PF11203	EccE	Putative type VII ESX secretion system translocon, EccE
+PF11204	DUF2985	Protein of unknown function (DUF2985)
+PF11205	DUF2987	Protein of unknown function (DUF2987)
+PF11207	DUF2989	Protein of unknown function (DUF2989)
+PF11208	DUF2992	Protein of unknown function (DUF2992)
+PF11209	DUF2993	Protein of unknown function (DUF2993)
+PF11210	DUF2996	Protein of unknown function (DUF2996)
+PF11211	DUF2997	Protein of unknown function (DUF2997)
+PF11212	DUF2999	Protein of unknown function (DUF2999)
+PF11213	DUF3006	Protein of unknown function (DUF3006)
+PF11214	Med2	Mediator complex subunit 2
+PF11215	DUF3010	Protein of unknown function (DUF3010)
+PF11216	DUF3012	Protein of unknown function (DUF3012)
+PF11217	DUF3013	Protein of unknown function (DUF3013)
+PF11218	DUF3011	Protein of unknown function (DUF3011)
+PF11219	DUF3014	Protein of unknown function (DUF3014)
+PF11220	DUF3015	Protein of unknown function (DUF3015)
+PF11221	Med21	Subunit 21 of Mediator complex
+PF11222	DUF3017	Protein of unknown function (DUF3017)
+PF11223	DUF3020	Protein of unknown function (DUF3020)
+PF11224	DUF3023	Protein of unknown function (DUF3023)
+PF11225	DUF3024	Protein of unknown function (DUF3024)
+PF11226	DUF3022	Protein of unknown function (DUF3022)
+PF11227	DUF3025	Protein of unknown function (DUF3025)
+PF11228	DUF3027	Protein of unknown function (DUF3027)
+PF11229	Focadhesin	Focadhesin
+PF11230	DUF3029	Protein of unknown function (DUF3029)
+PF11231	DUF3034	Protein of unknown function (DUF3034)
+PF11232	Med25	Mediator complex subunit 25 PTOV activation and synapsin 2
+PF11233	DUF3035	Protein of unknown function (DUF3035)
+PF11235	Med25_SD1	Mediator complex subunit 25 synapsin 1
+PF11236	DUF3037	Protein of unknown function (DUF3037)
+PF11237	DUF3038	Protein of unknown function (DUF3038)
+PF11238	DUF3039	Protein of unknown function (DUF3039)
+PF11239	DUF3040	Protein of unknown function (DUF3040)
+PF11240	DUF3042	Protein of unknown function (DUF3042)
+PF11241	DUF3043	Protein of unknown function (DUF3043)
+PF11242	DUF2774	Protein of unknown function (DUF2774)
+PF11243	DUF3045	Protein of unknown function (DUF3045)
+PF11244	Med25_NR-box	Mediator complex subunit 25 C-terminal NR box-containing
+PF11245	DUF2544	Protein of unknown function (DUF2544)
+PF11246	Phage_gp53	Base plate wedge protein 53
+PF11247	DUF2675	Protein of unknown function (DUF2675) 
+PF11248	DUF3046	Protein of unknown function (DUF3046)
+PF11249	DUF3047	Protein of unknown function (DUF3047)
+PF11250	FAF	Fantastic Four meristem regulator
+PF11251	DUF3050	Protein of unknown function (DUF3050)
+PF11252	DUF3051	Protein of unknown function (DUF3051)
+PF11253	DUF3052	Protein of unknown function (DUF3052)
+PF11254	DUF3053	Protein of unknown function (DUF3053)
+PF11255	DUF3054	Protein of unknown function (DUF3054)
+PF11256	DUF3055	Protein of unknown function (DUF3055)
+PF11258	DUF3048	Protein of unknown function (DUF3048) N-terminal domain
+PF11259	DUF3060	Protein of unknown function (DUF3060)
+PF11260	Spidroin_MaSp	Major ampullate spidroin 1 and 2
+PF11261	IRF-2BP1_2	Interferon regulatory factor 2-binding protein zinc finger
+PF11262	Tho2	Transcription factor/nuclear export subunit protein 2
+PF11263	Attachment_P66	Borrelia burgdorferi attachment protein P66 
+PF11264	ThylakoidFormat	Thylakoid formation protein
+PF11265	Med25_VWA	Mediator complex subunit 25 von Willebrand factor type A
+PF11266	Ald_deCOase	Long-chain fatty aldehyde decarbonylase 
+PF11267	DUF3067	Domain of unknown function (DUF3067)
+PF11268	DUF3071	Protein of unknown function (DUF3071)
+PF11269	DUF3069	Protein of unknown function (DUF3069)
+PF11270	DUF3070	Protein of unknown function (DUF3070)
+PF11271	DUF3068	Protein of unknown function (DUF3068)
+PF11272	DUF3072	Protein of unknown function (DUF3072)
+PF11273	DUF3073	Protein of unknown function (DUF3073)
+PF11274	DUF3074	Protein of unknown function (DUF3074)
+PF11275	DUF3077	Protein of unknown function (DUF3077)
+PF11276	DUF3078	Protein of unknown function (DUF3078)
+PF11277	Med24_N	Mediator complex subunit 24 N-terminal
+PF11278	DUF3079	Protein of unknown function (DUF3079)
+PF11279	DUF3080	Protein of unknown function (DUF3080)
+PF11280	DUF3081	Protein of unknown function (DUF3081)
+PF11281	DUF3083	Protein of unknown function (DUF3083)
+PF11282	DUF3082	Protein of unknown function (DUF3082)
+PF11283	DUF3084	Protein of unknown function (DUF3084)
+PF11284	DUF3085	Protein of unknown function (DUF3085)
+PF11285	DUF3086	Protein of unknown function (DUF3086)
+PF11286	DUF3087	Protein of unknown function (DUF3087)
+PF11287	DUF3088	Protein of unknown function (DUF3088)
+PF11288	DUF3089	Protein of unknown function (DUF3089)
+PF11289	APA3_viroporin	Coronavirus accessory protein 3a
+PF11290	DUF3090	Protein of unknown function (DUF3090)
+PF11291	DUF3091	Protein of unknown function (DUF3091)
+PF11292	DUF3093	Protein of unknown function (DUF3093)
+PF11293	DUF3094	Protein of unknown function (DUF3094)
+PF11294	DUF3095	Protein of unknown function (DUF3095)
+PF11295	DUF3096	Protein of unknown function (DUF3096)
+PF11296	DUF3097	Protein of unknown function (DUF3097)
+PF11297	DUF3098	Protein of unknown function (DUF3098)
+PF11298	DUF3099	Protein of unknown function (DUF3099)
+PF11299	DUF3100	Protein of unknown function (DUF3100)
+PF11300	DUF3102	Protein of unknown function (DUF3102)
+PF11301	DUF3103	Protein of unknown function (DUF3103)
+PF11302	DUF3104	Protein of unknown function (DUF3104)
+PF11303	DUF3105	Protein of unknown function (DUF3105)
+PF11304	DUF3106	Protein of unknown function (DUF3106)
+PF11305	DUF3107	Protein of unknown function (DUF3107)
+PF11306	DUF3108	Protein of unknown function (DUF3108)
+PF11307	DUF3109	Protein of unknown function (DUF3109)
+PF11308	Glyco_hydro_129	Glycosyl hydrolases related to GH101 family, GH129
+PF11309	DUF3112	Protein of unknown function (DUF3112)
+PF11310	DUF3113	Protein of unknown function (DUF3113)
+PF11311	DUF3114	Protein of unknown function (DUF3114)
+PF11312	Methyltransf_34	Putative SAM-dependent methyltransferase
+PF11313	DUF3116	Protein of unknown function (DUF3116)
+PF11314	DUF3117	Protein of unknown function (DUF3117)
+PF11315	Med30	Mediator complex subunit 30
+PF11316	Rhamno_transf	Putative rhamnosyl transferase 
+PF11317	DUF3119	Protein of unknown function (DUF3119)
+PF11318	DUF3120	Protein of unknown function (DUF3120)
+PF11319	VasI	Type VI secretion system VasI, EvfG, VC_A0118
+PF11320	DUF3122	Protein of unknown function (DUF3122)
+PF11321	DUF3123	Protein of unknown function (DUF3123)
+PF11322	DUF3124	Protein of unknown function (DUF3124)
+PF11323	DUF3125	Protein of unknown function (DUF3125)
+PF11324	DUF3126	Protein of unknown function (DUF3126)
+PF11325	DUF3127	Domain of unknown function (DUF3127)
+PF11326	DUF3128	Protein of unknown function (DUF3128)
+PF11327	DUF3129	Protein of unknown function (DUF3129)
+PF11328	DUF3130	Protein of unknown function (DUF3130
+PF11329	DUF3131	Protein of unknown function (DUF3131)
+PF11330	DUF3132	Protein of unknown function (DUF3132)
+PF11331	zinc_ribbon_12	Probable zinc-ribbon domain
+PF11332	DUF3134	Protein of unknown function (DUF3134)
+PF11333	DUF3135	Protein of unknown function (DUF3135)
+PF11334	DUF3136	Protein of unknown function (DUF3136)
+PF11335	DUF3137	Protein of unknown function (DUF3137) 
+PF11336	DUF3138	Protein of unknown function (DUF3138)
+PF11337	DUF3139	Protein of unknown function (DUF3139)
+PF11338	DUF3140	Protein of unknown function (DUF3140)
+PF11339	DUF3141	Protein of unknown function (DUF3141)
+PF11340	DUF3142	Protein of unknown function (DUF3142)
+PF11341	DUF3143	Protein of unknown function (DUF3143)
+PF11342	DUF3144	Protein of unknown function (DUF3144)
+PF11343	DUF3145	Protein of unknown function (DUF3145)
+PF11344	DUF3146	Protein of unknown function (DUF3146)
+PF11345	DUF3147	Protein of unknown function (DUF3147)
+PF11346	DUF3149	Protein of unknown function (DUF3149)
+PF11347	DUF3148	Protein of unknown function (DUF3148)
+PF11348	DUF3150	Protein of unknown function (DUF3150)
+PF11349	DUF3151	Protein of unknown function (DUF3151)
+PF11350	DUF3152	Protein of unknown function (DUF3152)
+PF11351	GTA_holin_3TM	Holin of 3TMs, for gene-transfer release
+PF11352	DUF3155	Protein of unknown function (DUF3155)
+PF11353	DUF3153	Protein of unknown function (DUF3153)
+PF11354	DUF3156	Protein of unknown function (DUF3156)
+PF11355	DUF3157	Protein of unknown function (DUF3157)
+PF11356	T2SSC	Type II secretion system protein C
+PF11357	Spy1	Cell cycle regulatory protein
+PF11358	DUF3158	Protein of unknown function (DUF3158)
+PF11359	gpUL132	Glycoprotein UL132
+PF11360	DUF3110	Protein of unknown function (DUF3110)
+PF11361	DUF3159	Protein of unknown function (DUF3159)
+PF11362	DUF3161	Protein of unknown function (DUF3161)
+PF11363	DUF3164	Protein of unknown function (DUF3164)
+PF11364	DUF3165	Protein of unknown function (DUF3165)
+PF11365	SOGA	Protein SOGA 
+PF11367	DUF3168	Protein of unknown function (DUF3168)
+PF11368	DUF3169	Protein of unknown function (DUF3169)
+PF11369	DUF3160	Protein of unknown function (DUF3160)
+PF11371	DUF3172	Protein of unknown function (DUF3172)
+PF11372	DUF3173	Domain of unknown function (DUF3173)
+PF11373	DUF3175	Protein of unknown function (DUF3175)
+PF11374	DUF3176	Protein of unknown function (DUF3176)
+PF11375	DUF3177	Protein of unknown function (DUF3177)
+PF11376	DUF3179	Protein of unknown function (DUF3179)
+PF11377	DUF3180	Protein of unknown function (DUF3180)
+PF11378	DUF3181	Protein of unknown function (DUF3181)
+PF11379	DUF3182	Protein of unknown function (DUF3182)
+PF11380	Stealth_CR2	Stealth protein CR2, conserved region 2
+PF11381	DUF3185	Protein of unknown function (DUF3185)
+PF11382	MctB	Copper transport outer membrane protein, MctB
+PF11383	DUF3187	Protein of unknown function (DUF3187)
+PF11384	DUF3188	Protein of unknown function (DUF3188)
+PF11385	DUF3189	Protein of unknown function (DUF3189)
+PF11386	VERL	Vitelline envelope receptor for lysin
+PF11387	DUF2795	Protein of unknown function (DUF2795)
+PF11388	DotA	Phagosome trafficking protein DotA
+PF11389	Porin_OmpL1	Leptospira porin protein OmpL1
+PF11390	FdsD	NADH-dependant formate dehydrogenase delta subunit FdsD
+PF11391	DUF2798	Protein of unknown function (DUF2798)
+PF11392	DUF2877	Protein of unknown function (DUF2877)
+PF11393	T4BSS_DotI_IcmL	Type-IV b secretion system, inner-membrane complex component
+PF11394	DUF2875	Protein of unknown function (DUF2875)
+PF11395	DUF2873	Protein of unknown function (DUF2873)
+PF11396	PepSY_like	Putative beta-lactamase-inhibitor-like, PepSY-like
+PF11397	GlcNAc	Glycosyltransferase (GlcNAc)
+PF11398	DUF2813	Protein of unknown function (DUF2813)
+PF11399	DUF3192	Protein of unknown function (DUF3192)
+PF11401	Tetrabrachion	Tetrabrachion
+PF11402	Antifungal_prot	Antifungal protein
+PF11403	Yeast_MT	Yeast metallothionein
+PF11404	Potassium_chann	Potassium voltage-gated channel
+PF11405	Inhibitor_I67	Bromelain inhibitor VI
+PF11406	Tachystatin_A	Antimicrobial peptide tachystatin A
+PF11407	RestrictionMunI	Type II restriction enzyme MunI
+PF11408	Helicase_Sgs1	Sgs1 RecQ helicase
+PF11409	SARA	Smad anchor for receptor activation (SARA)
+PF11410	Antifungal_pept	Antifungal peptide
+PF11411	DNA_ligase_IV	DNA ligase IV
+PF11412	DsbC	Disulphide bond corrector protein DsbC
+PF11413	HIF-1	Hypoxia-inducible factor-1
+PF11414	Suppressor_APC	Adenomatous polyposis coli tumour suppressor protein
+PF11415	Toxin_37	Antifungal peptide termicin
+PF11416	Syntaxin-5_N	Syntaxin-5 N-terminal, Sly1p-binding domain
+PF11417	Inhibitor_G39P	Loader and inhibitor of phage G40P
+PF11418	Scaffolding_pro	Phi29 scaffolding protein
+PF11419	DUF3194	Protein of unknown function (DUF3194)
+PF11420	Subtilosin_A	Bacteriocin subtilosin A
+PF11421	Synthase_beta	ATP synthase F1 beta subunit
+PF11422	IBP39	Initiator binding protein 39 kDa
+PF11423	Repressor_Mnt	Regulatory protein Mnt
+PF11424	DUF3195	Protein of unknown function (DUF3195)
+PF11426	Tn7_TnsC_Int	Tn7 transposition regulator TnsC
+PF11427	HTH_Tnp_Tc3_1	Tc3 transposase
+PF11428	DUF3196	Protein of unknown function (DUF3196)
+PF11429	Colicin_D	Colicin D
+PF11430	EGL-1	Programmed cell death activator EGL-1
+PF11431	Transport_MerF	Membrane transport protein MerF
+PF11432	DUF3197	Protein of unknown function (DUF3197)
+PF11433	DUF3198	Protein of unknown function (DUF3198)
+PF11434	CHIPS	Chemotaxis-inhibiting protein CHIPS
+PF11435	She2p	RNA binding protein She2p
+PF11436	DUF3199	Protein of unknown function (DUF3199)
+PF11437	Vanabin-2	Vanadium-binding protein 2
+PF11438	N36	36-mer N-terminal peptide of the N protein (N36)
+PF11439	T3SchapCesA	Type III secretion system filament chaperone CesA
+PF11440	AGT	DNA alpha-glucosyltransferase
+PF11441	MxiM	Pilot protein MxiM
+PF11442	DUF2826	Protein of unknown function (DUF2826)
+PF11443	DUF2828	Domain of unknown function (DUF2828)
+PF11444	DUF2895	Protein of unknown function (DUF2895)
+PF11445	DUF2894	Protein of unknown function (DUF2894)
+PF11446	DUF2897	Protein of unknown function (DUF2897)
+PF11447	DUF3201	Protein of unknown function (DUF3201)
+PF11448	DUF3005	Protein of unknown function (DUF3005)
+PF11449	ArsP_2	Putative, 10TM heavy-metal exporter
+PF11450	DUF3008	Protein of unknwon function (DUF3008)
+PF11452	DUF3000	Protein of unknown function (DUF3000)
+PF11453	DUF2950	Protein of unknown function (DUF2950)
+PF11454	DUF3016	Protein of unknown function (DUF3016)
+PF11455	DUF3018	Protein  of unknown function (DUF3018)
+PF11456	DUF3019	Protein of unknown function (DUF3019)
+PF11457	DUF3021	Protein of unknown function (DUF3021)
+PF11458	Mistic	Membrane-integrating protein Mistic
+PF11459	AbiEi_3	Transcriptional regulator, AbiEi antitoxin, Type IV TA system
+PF11460	DUF3007	Protein of unknown function (DUF3007)
+PF11461	RILP	Rab interacting lysosomal protein
+PF11462	DUF3203	Protein of unknown function (DUF3203)
+PF11463	R-HINP1I	R.HinP1I restriction endonuclease
+PF11464	Rbsn	Rabenosyn Rab binding domain
+PF11465	Receptor_2B4	Natural killer cell receptor 2B4
+PF11466	Doppel	Prion-like protein Doppel
+PF11467	LEDGF	Lens epithelium-derived growth factor (LEDGF) 
+PF11468	PTase_Orf2	Aromatic prenyltransferase Orf2
+PF11469	Ribonucleas_3_2	Ribonuclease III
+PF11470	TUG-UBL1	TUG ubiquitin-like domain
+PF11471	Sugarporin_N	Maltoporin periplasmic N-terminal extension
+PF11472	DUF3206	Protein of unknown function (DUF3206)
+PF11473	B2	RNA binding protein B2
+PF11474	N-Term_TEN	Telomerase reverse transcriptase TEN domain
+PF11475	VP_N-CPKC	Virion protein N terminal domain 
+PF11476	TgMIC1	Toxoplasma gondii micronemal protein 1 TgMIC1
+PF11477	PM0188	Sialyltransferase PMO188
+PF11478	Tachystatin_B	Antimicrobial chitin binding protein tachystatin B
+PF11479	Suppressor_P21	RNA silencing suppressor P21
+PF11480	ImmE5	Colicin-E5 Imm protein
+PF11482	DUF3208	Protein of unknown function (DUF3208)
+PF11483	DUF3209	Protein of unknown function (DUF3209)
+PF11485	DUF3211	Protein of unknown function (DUF3211)
+PF11486	DUF3212	Protein of unknown function (DUF3212)
+PF11487	RestrictionSfiI	Type II restriction enzyme SfiI
+PF11488	Lge1	Transcriptional regulatory protein LGE1
+PF11489	Aim21	Altered inheritance of mitochondria protein 21 
+PF11490	DNA_pol3_a_NII	DNA polymerase III polC-type N-terminus II
+PF11491	DUF3213	Protein of unknown function (DUF3213)   
+PF11492	Dicistro_VP4	Cricket paralysis virus, VP4
+PF11493	TSP9	Thylakoid soluble phosphoprotein TSP9
+PF11494	Ta0938	Ta0938
+PF11495	Regulator_TrmB	Archaeal transcriptional regulator TrmB
+PF11496	HDA2-3	Class II histone deacetylase complex subunits 2 and 3
+PF11497	NADH_Oxid_Nqo15	NADH-quinone oxidoreductase chain 15
+PF11498	Activator_LAG-3	Transcriptional activator LAG-3
+PF11500	Cut12	Spindle pole body formation-associated protein
+PF11501	Nsp1	Non structural protein Nsp1
+PF11502	BCL9	B-cell lymphoma 9 protein
+PF11503	DUF3215	Protein of unknown function (DUF3215)
+PF11504	Colicin_Ia	Colicin Ia
+PF11505	DUF3216	Protein of unknown function (DUF3216)
+PF11506	DUF3217	Protein of unknown function (DUF3217)
+PF11507	Transcript_VP30	Ebola virus-specific transcription factor VP30
+PF11508	DUF3218	Protein of unknown function (DUF3218)
+PF11510	FA_FANCE	Fanconi Anaemia group E protein FANCE
+PF11511	RhodobacterPufX	Intrinsic membrane protein PufX
+PF11512	Atu4866	Agrobacterium tumefaciens protein Atu4866
+PF11513	TA0956	Thermoplasma acidophilum protein TA0956
+PF11514	DUF3219	Protein of unknown function (DUF3219)
+PF11515	Cul7	Mouse development and cellular proliferation protein Cullin-7
+PF11516	DUF3220	Protein of unknown function (DUF3120)
+PF11517	Nab2	Nuclear abundant poly(A) RNA-bind protein 2 (Nab2)
+PF11518	DUF3221	Protein of unknown function (DUF3221)
+PF11519	DUF3222	Protein of unknown function (DUF3222)
+PF11520	Cren7	Chromatin protein Cren7
+PF11521	TFIIE-A_C	C-terminal general transcription factor TFIIE alpha
+PF11522	Pik1	Yeast phosphatidylinositol-4-OH kinase Pik1
+PF11523	DUF3223	Protein of unknown function (DUF3223)
+PF11524	SeleniumBinding	Selenium binding protein
+PF11525	CopK	Copper resistance protein K
+PF11526	CFIA_Pcf11	Subunit of cleavage factor IA Pcf11
+PF11527	ARL2_Bind_BART	The ARF-like 2 binding protein BART
+PF11528	DUF3224	Protein of unknown function (DUF3224)
+PF11529	AvrL567-A	Melampsora lini avirulence protein AvrL567-A
+PF11530	Pilin_PilX	Minor type IV pilin, PilX
+PF11531	CARM1	Coactivator-associated arginine methyltransferase 1 N terminal
+PF11532	HnRNP_M	Heterogeneous nuclear ribonucleoprotein M
+PF11533	DUF3225	Protein of unknown function (DUF3225)
+PF11534	HTHP	Hexameric tyrosine-coordinated heme protein (HTHP)
+PF11535	Calci_bind_CcbP	Calcium binding
+PF11536	DUF3226	Protein of unknown function (DUF3226)
+PF11537	DUF3227	Protein of unknown function (DUF3227)
+PF11538	Snurportin1	Snurportin1
+PF11539	DUF3228	Protein of unknown function (DUF3228)
+PF11540	Dynein_IC2	Cytoplasmic dynein 1 intermediate chain 2
+PF11542	Mdv1	Mitochondrial division protein 1
+PF11543	UN_NPL4	Nuclear pore localisation protein NPL4
+PF11544	Spc42p	Spindle pole body component Spc42p
+PF11545	HemeBinding_Shp	Cell surface heme-binding protein Shp
+PF11546	CompInhib_SCIN	Staphylococcal complement inhibitor SCIN 
+PF11547	E3_UbLigase_EDD	E3 ubiquitin ligase EDD
+PF11548	Receptor_IA-2	Protein-tyrosine phosphatase receptor IA-2
+PF11549	Sec31	Protein transport protein SEC31
+PF11550	IglC	Intracellular growth locus C protein
+PF11551	Omp28	Outer membrane protein Omp28
+PF11553	DUF3231	Protein of unknown function (DUF3231)
+PF11554	DUF3232	Protein of unknown function (DUF3232)
+PF11555	Inhibitor_Mig-6	EGFR receptor inhibitor Mig-6
+PF11556	EBA-175_VI	Erythrocyte binding antigen 175
+PF11557	Omp_AT	Solitary outer membrane autotransporter beta-barrel domain
+PF11558	HET-s_218-289	Het-s 218-289
+PF11559	ADIP	Afadin- and alpha -actinin-Binding
+PF11560	LAP2alpha	Lamina-associated polypeptide 2 alpha
+PF11561	Saw1	Single strand annealing-weakened 1
+PF11563	Protoglobin	Protoglobin
+PF11564	BpuJI_N	Restriction endonuclease BpuJI - N terminal
+PF11565	PorB	Alpha helical Porin B
+PF11566	PI31_Prot_N	PI31 proteasome regulator N-terminal
+PF11567	PfUIS3	Plasmodium falciparum UIS3 membrane protein
+PF11568	Med29	Mediator complex subunit 29
+PF11569	Homez	Homeodomain leucine-zipper encoding, Homez
+PF11570	E2R135	Coiled-coil receptor-binding R-domain of colicin E2
+PF11571	Med27	Mediator complex subunit 27
+PF11572	DUF3234	Protein of unknown function (DUF3234)
+PF11573	Med23	Mediator complex subunit 23
+PF11574	DUF3235	Protein of unknown function (DUF3235)
+PF11575	FhuF_C	FhuF 2Fe-2S C-terminal domain
+PF11576	DUF3236	Protein of unknown function (DUF3236)
+PF11577	NEMO	NF-kappa-B essential modulator NEMO
+PF11578	DUF3237	Protein of unknown function (DUF3237)
+PF11579	DUF3238	Protein of unknown function (DUF3238)
+PF11580	DUF3239	Protein of unknown function (DUF3239)
+PF11581	Argos	Antagonist of EGFR signalling, Argos
+PF11582	DUF3240	Protein of unknown function (DUF3240)
+PF11583	AurF	P-aminobenzoate N-oxygenase AurF
+PF11584	Toxin_ToxA	Proteinaceous host-selective toxin ToxA
+PF11585	Stomoxyn	Insect antimicrobial peptide, stomoxyn
+PF11586	DUF3242	Protein of unknown function (DUF3242)  
+PF11587	Prion_bPrPp	Major prion protein bPrPp - N terminal
+PF11588	DUF3243	Protein of unknown function (DUF3243)
+PF11589	DUF3244	Domain of unknown function (DUF3244)
+PF11590	DNAPolymera_Pol	DNA polymerase catalytic subunit Pol
+PF11591	2Fe-2S_Ferredox	Ferredoxin chloroplastic transit peptide
+PF11592	AvrPto	Central core of the bacterial effector protein AvrPto
+PF11593	Med3	Mediator complex subunit 3 fungal
+PF11594	Med28	Mediator complex subunit 28
+PF11595	DUF3245	Protein of unknown function (DUF3245)
+PF11596	DUF3246	Protein of unknown function (DUF3246)
+PF11597	Med13_N	Mediator complex subunit 13 N-terminal
+PF11598	COMP	Cartilage oligomeric matrix protein
+PF11599	AviRa	RRNA methyltransferase AviRa
+PF11600	CAF-1_p150	Chromatin assembly factor 1 complex p150 subunit, N-terminal
+PF11601	Shal-type	Shal-type voltage-gated potassium channels, N-terminal
+PF11602	NTPase_P4	ATPase P4 of dsRNA bacteriophage phi-12
+PF11603	Sir1	Regulatory protein Sir1
+PF11604	CusF_Ec	Copper binding periplasmic protein CusF
+PF11605	Vps36_ESCRT-II	Vacuolar protein sorting protein 36 Vps36
+PF11606	AlcCBM31	Family 31 carbohydrate binding protein
+PF11607	DUF3247	Protein of unknown function (DUF3247)
+PF11608	Limkain-b1	Limkain b1
+PF11609	DUF3248	Protein of unknown function (DUF3248)
+PF11610	Ste5	Scaffold protein Ste5, Fus3-binding region
+PF11611	DUF4352	Domain of unknown function (DUF4352)
+PF11612	T2SSJ	Type II secretion system (T2SS), protein J
+PF11614	FixG_C	IG-like fold at C-terminal of FixG, putative oxidoreductase
+PF11615	Caf4	CCR4-associated factor 4 
+PF11616	EZH2_WD-Binding	WD repeat binding protein EZH2
+PF11617	Cu-binding_MopE	Putative metal-binding motif
+PF11618	C2-C2_1	First C2 domain of RPGR-interacting protein 1
+PF11619	P53_C	Transcription factor P53 - C terminal domain
+PF11620	GABP-alpha	GA-binding protein alpha chain
+PF11621	Sbi-IV	C3 binding domain 4 of IgG-bind protein SBI
+PF11622	DUF3251	Protein of unknown function (DUF3251)
+PF11623	NdhS	NAD(P)H dehydrogenase subunit S
+PF11624	M157	MHC class I-like protein M157
+PF11625	DUF3253	Protein of unknown function (DUF3253)
+PF11626	Rap1_C	TRF2-interacting telomeric protein/Rap1 - C terminal domain
+PF11627	HnRNPA1	Nuclear factor hnRNPA1
+PF11628	TCR_zetazeta	T-cell surface glycoprotein CD3 zeta chain
+PF11629	Mst1_SARAH	C terminal SARAH domain of Mst1
+PF11630	DUF3254	Protein of unknown function (DUF3254)
+PF11631	DUF3255	Protein of unknown function (DUF3255)
+PF11632	LcnG-beta	Lactococcin G-beta
+PF11633	SUD-M	Single-stranded poly(A) binding domain
+PF11634	IPI_T4	Nuclease inhibitor from bacteriophage T4
+PF11635	Med16	Mediator complex subunit 16
+PF11636	Troponin-I_N	Troponin I residues 1-32
+PF11637	UvsW	ATP-dependant DNA helicase UvsW
+PF11638	DnaA_N	DnaA N-terminal domain
+PF11639	HapK	REDY-like protein HapK
+PF11640	TAN	Telomere-length maintenance and DNA damage repair
+PF11641	Antigen_Bd37	Glycosylphosphatidylinositol-anchored merozoite surface protein
+PF11642	Blo-t-5	Mite allergen Blo t 5
+PF11644	DUF3256	Protein of unknown function (DUF3256)
+PF11645	PDDEXK_5	PD-(D/E)XK endonuclease
+PF11646	DUF3258	Protein of unknown function DUF3258
+PF11647	MLD	Membrane Localization Domain
+PF11648	RIG-I_C-RD	C-terminal domain of RIG-I
+PF11649	T4_neck-protein	Virus neck protein
+PF11650	P22_Tail-4	P22 tail accessory factor
+PF11651	P22_CoatProtein	P22 coat protein - gene protein 5
+PF11652	FAM167	FAM167
+PF11653	VirionAssem_T7	Bacteriophage T7 virion assembly protein
+PF11654	NCE101	Non-classical export protein 1 
+PF11655	DUF2589	Protein of unknown function (DUF2589)   
+PF11656	DUF3811	YjbD family (DUF3811)
+PF11657	Activator-TraM	Transcriptional activator TraM 
+PF11658	CBP_BcsG	Cellulose biosynthesis protein BcsG
+PF11659	DUF3261	Protein of unknown function (DUF3261)
+PF11660	DUF3262	Protein of unknown function (DUF3262)
+PF11661	DUF2986	Protein of unknown function (DUF2986)
+PF11662	DUF3263	Protein of unknown function (DUF3263)
+PF11663	Toxin_YhaV	Toxin with endonuclease activity, of toxin-antitoxin system
+PF11665	DUF3265	Protein of unknown function (DUF3265)
+PF11666	DUF2933	Protein of unknown function (DUF2933)
+PF11667	DUF3267	Putative zincin peptidase
+PF11668	Gp_UL130	HCMV glycoprotein pUL130
+PF11669	WBP-1	WW domain-binding protein 1
+PF11670	MSP1a	Major surface protein 1a (MSP1a)
+PF11671	Apis_Csd	Complementary sex determiner protein
+PF11672	DUF3268	zinc-finger-containing domain
+PF11673	DUF3269	Protein of unknown function (DUF3269)
+PF11674	DUF3270	Protein of unknown function (DUF3270)
+PF11675	DUF3271	Protein of unknown function (DUF3271)
+PF11676	DUF3272	Protein of unknown function (DUF3272)
+PF11677	DUF3273	Protein of unknown function (DUF3273)
+PF11678	DUF3274	Protein of unknown function (DUF3274)
+PF11679	DUF3275	Protein of unknown function (DUF3275)
+PF11680	DUF3276	Protein of unknown function (DUF3276)
+PF11681	DUF3277	Protein of unknown function (DUF3277)
+PF11682	zinc_ribbon_11	Probable zinc-ribbon
+PF11683	DUF3278	Protein of unknown function (DUF3278)
+PF11684	DUF3280	Protein of unknown function (DUF2380)
+PF11685	DUF3281	Protein of unknown function (DUF3281)
+PF11686	DUF3283	Protein of unknown function (DUF3283)
+PF11687	DUF3284	Domain of unknown function (DUF3284)
+PF11688	DUF3285	Protein of unknown function (DUF3285)
+PF11690	DUF3287	Protein of unknown function (DUF3287)
+PF11691	DUF3288	Protein of unknown function (DUF3288)
+PF11692	DUF3289	Protein of unknown function (DUF3289)
+PF11693	DUF2990	Protein of unknown function (DUF2990)
+PF11694	DUF3290	Protein of unknown function (DUF3290)
+PF11695	DUF3291	Domain of unknown function (DUF3291)
+PF11696	DUF3292	Protein of unknown function (DUF3292)
+PF11697	DUF3293	Protein of unknown function (DUF3293)
+PF11698	V-ATPase_H_C	V-ATPase subunit H
+PF11699	CENP-C_C	Mif2/CENP-C like
+PF11700	ATG22	Vacuole effluxer Atg22 like
+PF11701	UNC45-central	Myosin-binding striated muscle assembly central
+PF11702	DUF3295	Protein of unknown function (DUF3295)
+PF11703	UPF0506	UPF0506
+PF11704	Folliculin	Vesicle coat protein involved in Golgi to plasma membrane transport
+PF11705	RNA_pol_3_Rpc31	DNA-directed RNA polymerase III subunit Rpc31
+PF11706	zf-CGNR	CGNR zinc finger
+PF11707	Npa1	Ribosome 60S biogenesis N-terminal
+PF11708	Slu7	Pre-mRNA splicing Prp18-interacting factor
+PF11709	Mit_ribos_Mrp51	Mitochondrial ribosomal protein subunit 
+PF11710	Git3	G protein-coupled glucose receptor regulating Gpa2
+PF11711	Tim54	Inner membrane protein import complex subunit Tim54
+PF11712	Vma12	Endoplasmic reticulum-based factor for assembly of V-ATPase
+PF11713	Peptidase_C80	Peptidase C80 family
+PF11714	Inhibitor_I53	Thrombin inhibitor Madanin  
+PF11715	Nup160	Nucleoporin Nup120/160
+PF11716	MDMPI_N	Mycothiol maleylpyruvate isomerase N-terminal domain
+PF11717	Tudor-knot	RNA binding activity-knot of a chromodomain 
+PF11718	CPSF73-100_C	Pre-mRNA 3'-end-processing endonuclease polyadenylation factor C-term
+PF11719	Drc1-Sld2	DNA replication and checkpoint protein
+PF11720	Inhibitor_I78	Peptidase inhibitor I78 family
+PF11721	Malectin	Di-glucose binding within endoplasmic reticulum
+PF11722	zf-TRM13_CCCH	CCCH zinc finger in TRM13 protein
+PF11723	Aromatic_hydrox	Homotrimeric ring hydroxylase
+PF11724	YvbH_ext	YvbH-like oligomerisation region
+PF11725	AvrE	Pathogenicity factor
+PF11726	Inovirus_Gp2	Inovirus Gp2
+PF11727	ISG65-75	Invariant surface glycoprotein
+PF11728	ArAE_1_C	Putative aromatic acid exporter C-terminal domain
+PF11729	Capsid-VNN	nodavirus capsid protein 
+PF11730	DUF3297	Protein of unknown function (DUF3297)
+PF11731	Cdd1	Pathogenicity locus
+PF11732	Thoc2	Transcription- and export-related complex subunit
+PF11733	NP1-WLL	Non-capsid protein NP1
+PF11734	TilS_C	TilS substrate C-terminal domain
+PF11735	CAP59_mtransfer	Cryptococcal mannosyltransferase 1 
+PF11736	DUF3299	Protein of unknown function (DUF3299)
+PF11737	DUF3300	Protein of unknown function (DUF3300)
+PF11738	DUF3298	Protein of unknown function (DUF3298)
+PF11739	DctA-YdbH	Dicarboxylate transport
+PF11740	KfrA_N	Plasmid replication region DNA-binding N-term
+PF11741	AMIN	AMIN domain
+PF11742	DUF3302	Protein of unknown function (DUF3302)
+PF11743	DUF3301	Protein of unknown function (DUF3301)
+PF11744	ALMT	Aluminium activated malate transporter
+PF11745	DUF3304	Protein of unknown function (DUF3304)
+PF11746	DUF3303	Protein of unknown function (DUF3303)
+PF11747	RebB	Killing trait
+PF11748	DUF3306	Protein of unknown function (DUF3306)
+PF11749	DUF3305	Protein of unknown function (DUF3305)
+PF11750	DUF3307	Protein of unknown function (DUF3307)
+PF11751	PorP_SprF	Type IX secretion system membrane protein PorP/SprF
+PF11752	DUF3309	Protein of unknown function (DUF3309)
+PF11753	DUF3310	Protein of unknwon function (DUF3310)
+PF11754	Velvet	Velvet factor
+PF11755	DUF3311	Protein of unknown function (DUF3311)
+PF11756	YgbA_NO	Nitrous oxide-stimulated promoter
+PF11757	RSS_P20	Suppressor of RNA silencing P21-like
+PF11758	Bacteriocin_IIi	Aureocin-like type II bacteriocin
+PF11759	KRTAP	Keratin-associated matrix
+PF11760	CbiG_N	Cobalamin synthesis G N-terminal
+PF11761	CbiG_mid	Cobalamin biosynthesis central region
+PF11762	Arabinose_Iso_C	L-arabinose isomerase C-terminal domain
+PF11763	DIPSY	Cell-wall adhesin ligand-binding C-terminal
+PF11764	N-SET	COMPASS (Complex proteins associated with Set1p) component N
+PF11765	Hyphal_reg_CWP	Hyphally regulated cell wall protein N-terminal
+PF11766	Candida_ALS_N	Cell-wall agglutinin N-terminal ligand-sugar binding 
+PF11767	SET_assoc	Histone lysine methyltransferase SET associated
+PF11768	Frtz	WD repeat-containing and planar cell polarity effector protein Fritz
+PF11769	DUF3313	Protein of unknown function (DUF3313)
+PF11770	GAPT	GRB2-binding adapter (GAPT)
+PF11771	DUF3314	Protein of unknown function (DUF3314) 
+PF11772	EpuA	DNA-directed RNA polymerase subunit beta
+PF11773	PulG	Type II secretory pathway pseudopilin 
+PF11774	Lsr2	Lsr2 
+PF11775	CobT_C	Cobalamin biosynthesis protein CobT VWA domain
+PF11776	RcnB	Nickel/cobalt transporter regulator
+PF11777	DUF3316	Protein of unknown function (DUF3316)
+PF11778	SID	Septation initiation
+PF11779	SPT_ssu-like	Small subunit of serine palmitoyltransferase-like
+PF11780	DUF3318	Protein of unknown function (DUF3318)
+PF11781	zf-RRN7	Zinc-finger of RNA-polymerase I-specific TFIIB, Rrn7
+PF11782	DUF3319	Protein of unknown function (DUF3319)
+PF11783	Cytochrome_cB	Cytochrome c bacterial
+PF11784	DUF3320	Protein of unknown function (DUF3320)
+PF11785	Aft1_OSA	Aft1 osmotic stress response (OSM) domain
+PF11786	Aft1_HRA	Aft1 HRA domain
+PF11787	Aft1_HRR	Aft1 HRR domain
+PF11788	MRP-L46	39S mitochondrial ribosomal protein L46 
+PF11789	zf-Nse	Zinc-finger of the MIZ type in Nse subunit
+PF11790	Glyco_hydro_cc	Glycosyl hydrolase catalytic core
+PF11791	Aconitase_B_N	Aconitate B N-terminal domain
+PF11792	Baculo_LEF5_C	Baculoviridae late expression factor 5 C-terminal domain
+PF11793	FANCL_C	FANCL C-terminal domain
+PF11794	HpaB_N	4-hydroxyphenylacetate 3-hydroxylase N terminal
+PF11795	DUF3322	Uncharacterized protein conserved in bacteria N-term (DUF3322)
+PF11796	DUF3323	Protein of unknown function N-terminus (DUF3323)
+PF11797	DUF3324	Protein of unknown function C-terminal (DUF3324)
+PF11798	IMS_HHH	IMS family HHH motif
+PF11799	IMS_C	impB/mucB/samB family C-terminal domain
+PF11800	RP-C_C	Replication protein C C-terminal region
+PF11801	Tom37_C	Tom37 C-terminal domain
+PF11802	CENP-K	Centromere-associated protein K
+PF11803	UXS1_N	UDP-glucuronate decarboxylase N-terminal
+PF11804	DUF3325	Protein of unknown function (DUF3325)
+PF11805	DUF3326	Protein of unknown function (DUF3326)
+PF11806	DUF3327	Domain of unknown function (DUF3327)
+PF11807	DUF3328	Domain of unknown function (DUF3328)
+PF11808	DUF3329	Domain of unknown function (DUF3329)
+PF11809	DUF3330	Domain of unknown function (DUF3330)
+PF11810	DUF3332	Domain of unknown function (DUF3332)
+PF11811	DUF3331	Domain of unknown function (DUF3331)
+PF11812	DUF3333	Domain of unknown function (DUF3333)
+PF11813	DUF3334	Protein of unknown function (DUF3334)
+PF11814	DUF3335	Peptidase_C39 like family
+PF11815	DUF3336	Domain of unknown function (DUF3336)
+PF11816	DUF3337	Domain of unknown function (DUF3337)
+PF11817	Foie-gras_1	Foie gras liver health family 1
+PF11818	DUF3340	C-terminal domain of tail specific protease (DUF3340)
+PF11819	DUF3338	Domain of unknown function (DUF3338)
+PF11820	DUF3339	Protein of unknown function (DUF3339)
+PF11821	DUF3341	Protein of unknown function (DUF3341)
+PF11822	DUF3342	Domain of unknown function (DUF3342)
+PF11823	DUF3343	Protein of unknown function (DUF3343)
+PF11824	DUF3344	Protein of unknown function (DUF3344)
+PF11825	Nuc_recep-AF1	Nuclear/hormone receptor activator site AF-1
+PF11826	DUF3346	Protein of unknown function (DUF3346)
+PF11827	DUF3347	Protein of unknown function (DUF3347)
+PF11828	DUF3348	Protein of unknown function (DUF3348)
+PF11829	DUF3349	Protein of unknown function (DUF3349)
+PF11830	DUF3350	Domain of unknown function (DUF3350)
+PF11831	Myb_Cef	pre-mRNA splicing factor component
+PF11832	DUF3352	Protein of unknown function (DUF3352)
+PF11833	CPP1-like	Protein CHAPERONE-LIKE PROTEIN OF POR1-like 
+PF11834	KHA	KHA, dimerisation domain of potassium ion channel
+PF11835	DUF3355	Domain of unknown function (DUF3355)
+PF11836	Phage_TAC_11	Phage tail tube protein, GTA-gp10
+PF11837	DUF3357	Domain of unknown function (DUF3357)
+PF11838	ERAP1_C	ERAP1-like C-terminal domain
+PF11839	Alanine_zipper	Alanine-zipper, major outer membrane lipoprotein
+PF11840	DUF3360	Protein of unknown function (DUF3360)
+PF11841	DUF3361	Domain of unknown function (DUF3361)
+PF11842	DUF3362	Domain of unknown function (DUF3362)
+PF11843	DUF3363	Protein of unknown function (DUF3363)
+PF11844	DUF3364	Domain of unknown function (DUF3364)
+PF11845	DUF3365	Protein of unknown function (DUF3365)
+PF11846	Wzy_C_2	Virulence factor membrane-bound polymerase, C-terminal
+PF11847	DUF3367	Domain of unknown function (DUF3367)
+PF11848	DUF3368	Domain of unknown function (DUF3368)
+PF11849	DUF3369	Domain of unknown function (DUF3369)
+PF11850	DUF3370	Protein of unknown function (DUF3370)
+PF11851	DUF3371	Domain of unknown function (DUF3371)
+PF11852	DUF3372	Domain of unknown function (DUF3372)
+PF11853	DUF3373	Protein of unknown function (DUF3373)
+PF11854	MtrB_PioB	Putative outer membrane beta-barrel porin, MtrB/PioB
+PF11855	DUF3375	Protein of unknown function (DUF3375)
+PF11856	DUF3376	Protein of unknown function (DUF3376)
+PF11857	DUF3377	Domain of unknown function (DUF3377)
+PF11858	DUF3378	Domain of unknown function (DUF3378)
+PF11859	DUF3379	Protein of unknown function (DUF3379)
+PF11860	Muraidase	N-acetylmuramidase
+PF11861	DUF3381	Domain of unknown function (DUF3381)
+PF11862	DUF3382	Domain of unknown function (DUF3382)
+PF11863	DUF3383	Protein of unknown function (DUF3383)
+PF11864	DUF3384	Domain of unknown function (DUF3384)
+PF11865	DUF3385	Domain of unknown function (DUF3385)
+PF11866	DUF3386	Protein of unknown function (DUF3386)
+PF11867	DUF3387	Domain of unknown function (DUF3387)
+PF11868	DUF3388	Protein of unknown function (DUF3388)
+PF11869	DUF3389	Protein of unknown function (DUF3389)
+PF11870	DUF3390	Domain of unknown function (DUF3390)
+PF11871	DUF3391	Domain of unknown function (DUF3391)
+PF11872	DUF3392	Protein of unknown function (DUF3392)
+PF11873	DUF3393	Domain of unknown function (DUF3393)
+PF11874	DUF3394	Domain of unknown function (DUF3394)
+PF11875	DUF3395	Domain of unknown function (DUF3395)
+PF11876	DUF3396	Protein of unknown function (DUF3396)
+PF11877	DUF3397	Protein of unknown function (DUF3397)
+PF11878	DUF3398	Domain of unknown function (DUF3398)
+PF11879	DUF3399	Domain of unknown function (DUF3399)
+PF11880	DUF3400	Domain of unknown function (DUF3400)
+PF11881	SPAR_C	C-terminal domain of SPAR protein
+PF11882	DUF3402	Domain of unknown function (DUF3402)
+PF11883	DUF3403	Domain of unknown function (DUF3403)
+PF11884	DUF3404	Domain of unknown function (DUF3404)
+PF11885	DUF3405	Protein of unknown function (DUF3405)
+PF11886	TOC159_MAD	Translocase of chloroplast 159/132, membrane anchor domain
+PF11887	Mce4_CUP1	Cholesterol uptake porter CUP1 of Mce4, putative
+PF11888	DUF3408	Protein of unknown function (DUF3408)
+PF11889	DUF3409	Domain of unknown function (DUF3409)
+PF11890	DUF3410	Domain of unknown function (DUF3410)
+PF11891	RETICULATA-like	Protein RETICULATA-related 
+PF11892	DUF3412	Domain of unknown function (DUF3412)
+PF11893	DUF3413	Domain of unknown function (DUF3413)
+PF11894	Nup192	Nuclear pore complex scaffold, nucleoporins 186/192/205
+PF11895	Peroxidase_ext	Fungal peroxidase extension region
+PF11896	DUF3416	Domain of unknown function (DUF3416)
+PF11897	DUF3417	Protein of unknown function (DUF3417)
+PF11898	DUF3418	Domain of unknown function (DUF3418)
+PF11899	DUF3419	Protein of unknown function (DUF3419)
+PF11900	DUF3420	Domain of unknown function (DUF3420)
+PF11901	DUF3421	Protein of unknown function (DUF3421)
+PF11902	DUF3422	Protein of unknown function (DUF3422)
+PF11903	ParD_like	ParD-like antitoxin of type II bacterial toxin-antitoxin system
+PF11904	GPCR_chapero_1	GPCR-chaperone
+PF11905	DUF3425	Domain of unknown function (DUF3425)
+PF11906	DUF3426	Protein of unknown function (DUF3426)
+PF11907	DUF3427	Domain of unknown function (DUF3427)
+PF11909	NdhN	NADH-quinone oxidoreductase cyanobacterial subunit N
+PF11910	NdhO	Cyanobacterial and plant NDH-1 subunit O
+PF11911	DUF3429	Protein of unknown function (DUF3429)
+PF11912	DUF3430	Protein of unknown function (DUF3430)
+PF11913	DUF3431	Protein of unknown function (DUF3431)
+PF11914	DUF3432	Domain of unknown function (DUF3432)
+PF11915	DUF3433	Protein of unknown function (DUF3433)
+PF11916	Vac14_Fig4_bd	Vacuolar protein 14 C-terminal Fig4p binding
+PF11917	DUF3435	Protein of unknown function (DUF3435)
+PF11918	Peptidase_S41_N	N-terminal domain of Peptidase_S41 in eukaryotic IRBP
+PF11919	DUF3437	Domain of unknown function (DUF3437)
+PF11920	DUF3438	Protein of unknown function (DUF3438)
+PF11921	DUF3439	Domain of unknown function (DUF3439)
+PF11922	DUF3440	Domain of unknown function (DUF3440)
+PF11923	DUF3441	Domain of unknown function (DUF3441)
+PF11924	IAT_beta	Inverse autotransporter, beta-domain
+PF11925	DUF3443	Protein of unknown function (DUF3443)
+PF11926	DUF3444	Domain of unknown function (DUF3444)
+PF11927	DUF3445	Protein of unknown function (DUF3445)
+PF11928	DUF3446	Domain of unknown function (DUF3446)
+PF11929	DUF3447	Domain of unknown function (DUF3447)
+PF11931	DUF3449	Domain of unknown function (DUF3449)
+PF11932	DUF3450	Protein of unknown function (DUF3450)
+PF11933	Na_trans_cytopl	Cytoplasmic domain of voltage-gated Na+ ion channel
+PF11934	DUF3452	Domain of unknown function (DUF3452)
+PF11935	DUF3453	Domain of unknown function (DUF3453)
+PF11936	DUF3454	Domain of unknown function (DUF3454)
+PF11937	DUF3455	Protein of unknown function (DUF3455)
+PF11938	DUF3456	TLR4 regulator and MIR-interacting MSAP
+PF11939	NiFe-hyd_HybE	[NiFe]-hydrogenase assembly, chaperone, HybE
+PF11940	DUF3458	Domain of unknown function (DUF3458) Ig-like fold
+PF11941	DUF3459	Domain of unknown function (DUF3459)
+PF11942	Spt5_N	Spt5 transcription elongation factor, acidic N-terminal
+PF11943	DUF3460	Protein of unknown function (DUF3460)
+PF11944	DUF3461	Protein of unknown function (DUF3461)
+PF11945	WASH_WAHD	WAHD domain of WASH complex
+PF11946	DUF3463	Domain of unknown function (DUF3463)
+PF11947	DUF3464	Protein of unknown function (DUF3464)
+PF11948	DUF3465	Protein of unknown function (DUF3465)
+PF11949	DUF3466	Protein of unknown function (DUF3466)
+PF11950	DUF3467	Protein of unknown function (DUF3467)
+PF11951	Fungal_trans_2	Fungal specific transcription factor domain
+PF11952	XTBD	XRN-Two Binding Domain, XTBD
+PF11953	DUF3470	Domain of unknown function (DUF3470)
+PF11954	DUF3471	Domain of unknown function (DUF3471)
+PF11955	PORR	Plant organelle RNA recognition domain
+PF11956	KCNQC3-Ank-G_bd	Ankyrin-G binding motif of KCNQ2-3
+PF11957	efThoc1	THO complex subunit 1 transcription elongation factor
+PF11958	DUF3472	Domain of unknown function (DUF3472)
+PF11959	DUF3473	Domain of unknown function (DUF3473)
+PF11960	DUF3474	Domain of unknown function (DUF3474)
+PF11961	DUF3475	Domain of unknown function (DUF3475)
+PF11962	Peptidase_G2	Peptidase_G2, IMC autoproteolytic cleavage domain
+PF11963	DUF3477	Protein of unknown function (DUF3477)
+PF11964	SpoIIAA-like	SpoIIAA-like
+PF11965	DUF3479	Domain of unknown function (DUF3479)
+PF11966	SSURE	Fibronectin-binding repeat
+PF11967	RecO_N	Recombination protein O N terminal
+PF11968	Bmt2	25S rRNA (adenine(2142)-N(1))-methyltransferase, Bmt2 
+PF11969	DcpS_C	Scavenger mRNA decapping enzyme C-term binding
+PF11970	GPR_Gpa2_C	G protein-coupled glucose receptor regulating Gpa2 C-term
+PF11971	CAMSAP_CH	CAMSAP CH domain
+PF11972	HTH_13	HTH DNA binding domain
+PF11973	NQRA_SLBB	NQRA C-terminal domain
+PF11974	MG1	Alpha-2-macroglobulin MG1 domain
+PF11975	Glyco_hydro_4C	Family 4 glycosyl hydrolase C-terminal domain
+PF11976	Rad60-SLD	Ubiquitin-2 like Rad60 SUMO-like
+PF11977	RNase_Zc3h12a	Zc3h12a-like Ribonuclease NYN domain
+PF11978	MVP_shoulder	Shoulder domain
+PF11979	DUF3480	Domain of unknown function (DUF3480)
+PF11980	DUF3481	C-terminal domain of neuropilin glycoprotein
+PF11981	DUF3482	Domain of unknown function (DUF3482)
+PF11982	DUF3483	Domain of unknown function (DUF3483)
+PF11983	DUF3484	Membrane-attachment and polymerisation-promoting switch
+PF11984	DUF3485	Protein of unknown function (DUF3485)
+PF11985	DUF3486	Protein of unknown function (DUF3486)
+PF11986	PB1-F2	Influenza A Proapoptotic protein
+PF11987	IF-2	Translation-initiation factor 2
+PF11988	Dsl1_N	Retrograde transport protein Dsl1 N terminal
+PF11989	Dsl1_C	Retrograde transport protein Dsl1 C terminal
+PF11990	DUF3487	Protein of unknown function (DUF3487)
+PF11991	Trp_DMAT	Tryptophan dimethylallyltransferase
+PF11992	DUF3488	Domain of unknown function (DUF3488)
+PF11993	Ribosomal_S4Pg	Ribosomal S4P (gammaproteobacterial)
+PF11994	DUF3489	Protein of unknown function (DUF3489)
+PF11995	DUF3490	Domain of unknown function (DUF3490)
+PF11996	DUF3491	Protein of unknown function (DUF3491)
+PF11997	DUF3492	Domain of unknown function (DUF3492)
+PF11998	DUF3493	Protein of unknown function (DUF3493)
+PF11999	DUF3494	Protein of unknown function (DUF3494)
+PF12000	Glyco_trans_4_3	Gkycosyl transferase family 4 group
+PF12001	DUF3496	Domain of unknown function (DUF3496)
+PF12002	MgsA_C	MgsA AAA+ ATPase C terminal
+PF12004	DUF3498	Domain of unknown function (DUF3498)
+PF12005	DUF3499	Protein of unknown function (DUF3499)
+PF12006	DUF3500	Protein of unknown function (DUF3500)
+PF12007	DUF3501	Protein of unknown function (DUF3501)
+PF12008	EcoR124_C	Type I restriction and modification enzyme - subunit R C terminal
+PF12009	Telomerase_RBD	Telomerase ribonucleoprotein complex - RNA binding domain
+PF12010	DUF3502	Domain of unknown function (DUF3502)
+PF12011	NPH-II	RNA helicase NPH-II 
+PF12012	DUF3504	Domain of unknown function (DUF3504)
+PF12013	OrsD	Orsellinic acid/F9775 biosynthesis cluster protein D
+PF12014	DUF3506	Domain of unknown function (DUF3506)
+PF12015	DUF3507	Domain of unknown function (DUF3507)
+PF12016	Stonin2_N	Stonin 2
+PF12017	Tnp_P_element	Transposase protein
+PF12018	FAP206	Domain of unknown function
+PF12019	GspH	Type II transport protein GspH
+PF12020	TAFA	TAFA family
+PF12021	DUF3509	Protein of unknown function (DUF3509)
+PF12022	DUF3510	Domain of unknown function (DUF3510)
+PF12023	DUF3511	Domain of unknown function (DUF3511)
+PF12024	DUF3512	Domain of unknown function (DUF3512)
+PF12025	Phage_C	Phage protein C
+PF12026	DUF3513	Domain of unknown function (DUF3513)
+PF12027	DUF3514	Protein of unknown function (DUF3514)
+PF12028	DUF3515	Protein of unknown function (DUF3515)
+PF12029	DUF3516	Domain of unknown function (DUF3516)
+PF12030	DUF3517	Domain of unknown function (DUF3517)
+PF12031	BAF250_C	SWI/SNF-like complex subunit BAF250/Osa 
+PF12032	CLIP	Regulatory CLIP domain of proteinases
+PF12033	DUF3519	Protein of unknown function (DUF3519)
+PF12034	DUF3520	Domain of unknown function (DUF3520)
+PF12036	DUF3522	Protein of unknown function (DUF3522)
+PF12037	DUF3523	Domain of unknown function (DUF3523)
+PF12038	DUF3524	Domain of unknown function (DUF3524)
+PF12039	DUF3525	Protein of unknown function (DUF3525)
+PF12040	DUF3526	Domain of unknown function (DUF3526)
+PF12041	DELLA	Transcriptional regulator DELLA protein N terminal
+PF12042	RP1-2	Tubuliform egg casing silk strands structural domain
+PF12043	DUF3527	Domain of unknown function (DUF3527)
+PF12044	Metallopep	Putative peptidase family
+PF12045	DUF3528	Protein of unknown function (DUF3528)
+PF12046	CCB1	Cofactor assembly of complex C subunit B
+PF12047	DNMT1-RFD	Cytosine specific DNA methyltransferase replication foci domain
+PF12048	DUF3530	Protein of unknown function (DUF3530)
+PF12049	DUF3531	Protein of unknown function (DUF3531)
+PF12051	DUF3533	Protein of unknown function (DUF3533)
+PF12052	VGCC_beta4Aa_N	Voltage gated calcium channel subunit beta domain 4Aa N terminal
+PF12053	DUF3534	N-terminal of Par3 and HAL proteins
+PF12054	DUF3535	Domain of unknown function (DUF3535)
+PF12055	DUF3536	Domain of unknown function (DUF3536)
+PF12056	DUF3537	Protein of unknown function (DUF3537)
+PF12057	DUF3538	Domain of unknown function (DUF3538)
+PF12058	DUF3539	Protein of unknown function (DUF3539)
+PF12059	DUF3540	Protein of unknown function (DUF3540)
+PF12060	DUF3541	Domain of unknown function (DUF3541)
+PF12061	NB-LRR	Late blight resistance protein R1 
+PF12062	HSNSD	heparan sulfate-N-deacetylase
+PF12063	DUF3543	Domain of unknown function (DUF3543)
+PF12064	DUF3544	Domain of unknown function (DUF3544)
+PF12065	DUF3545	Protein of unknown function (DUF3545)
+PF12066	DUF3546	Domain of unknown function (DUF3546)
+PF12067	Sox17_18_mid	Sox 17/18 central domain
+PF12068	DUF3548	Domain of unknown function (DUF3548)
+PF12069	DUF3549	Protein of unknown function (DUF3549)
+PF12070	SCAI	Protein SCAI 
+PF12071	DUF3551	Protein of unknown function (DUF3551)
+PF12072	DUF3552	Domain of unknown function (DUF3552)
+PF12073	DUF3553	Protein of unknown function (DUF3553)
+PF12074	Gcn1_N	Domain of unknown function (DUF3554)
+PF12075	KN_motif	KN motif
+PF12076	Wax2_C	WAX2 C-terminal domain
+PF12077	DUF3556	Transmembrane protein of unknown function (DUF3556)
+PF12078	DUF3557	Domain of unknown function (DUF3557)
+PF12079	DUF3558	Protein of unknown function (DUF3558)
+PF12080	GldM_C	GldM C-terminal domain
+PF12081	GldM_N	GldM N-terminal domain
+PF12083	DUF3560	Domain of unknown function (DUF3560)
+PF12084	DUF3561	Protein of unknown function (DUF3561)
+PF12085	DUF3562	Protein of unknown function (DUF3562)
+PF12086	DUF3563	Protein of unknown function (DUF3563)
+PF12087	DUF3564	Protein of unknown function (DUF3564)
+PF12088	DUF3565	Protein of unknown function (DUF3565)
+PF12089	DUF3566	Transmembrane domain of unknown function (DUF3566)
+PF12090	Spt20	Spt20 family
+PF12091	DUF3567	Protein of unknown function (DUF3567)
+PF12092	DUF3568	Protein of unknown function (DUF3568)
+PF12093	Corona_NS8	Coronavirus NS8 protein
+PF12094	DUF3570	Protein of unknown function (DUF3570)
+PF12095	CRR7	Protein CHLORORESPIRATORY REDUCTION 7 
+PF12096	DUF3572	Protein of unknown function (DUF3572)
+PF12097	DUF3573	Protein of unknown function (DUF3573)
+PF12098	DUF3574	Protein of unknown function (DUF3574)
+PF12099	DUF3575	Protein of unknown function (DUF3575)
+PF12100	DUF3576	Domain of unknown function (DUF3576)
+PF12101	DUF3577	Protein of unknown function (DUF3577)
+PF12102	DUF3578	Domain of unknown function (DUF3578)
+PF12103	Lipl32	Surface lipoprotein of Spirochaetales order
+PF12104	Tcell_CD4_C	T cell CD4 receptor C terminal region
+PF12105	SpoU_methylas_C	SpoU, rRNA methylase, C-terminal
+PF12106	Colicin_E5	Colicin E5 ribonuclease domain
+PF12107	VEK-30	Plasminogen (Pg) ligand in fibrinolytic pathway
+PF12108	SF3a60_bindingd	Splicing factor SF3a60 binding domain
+PF12109	CXCR4_N	CXCR4 Chemokine receptor N terminal
+PF12110	Nup96	Nuclear protein 96
+PF12111	PNPase_C	Polyribonucleotide phosphorylase C terminal
+PF12112	DUF3579	Protein of unknown function (DUF3579)
+PF12113	SVM_signal	SVM protein signal sequence
+PF12114	Period_C	Period protein 2/3C-terminal region
+PF12115	Salp15	Salivary protein of 15kDa inhibits CD4+ T cell activation
+PF12116	SpoIIID	Stage III sporulation protein D
+PF12117	DUF3580	Protein of unknown function (DUF3580)
+PF12118	SprA-related	SprA-related family
+PF12119	DUF3581	Protein of unknown function (DUF3581)
+PF12120	Arr-ms	Rifampin ADP-ribosyl transferase
+PF12121	DD_K	Dermaseptin
+PF12122	Rhomboid_N	Cytoplasmic N-terminal domain of rhomboid serine protease
+PF12123	Amidase02_C	N-acetylmuramoyl-l-alanine amidase
+PF12124	Nsp3_PL2pro	Coronavirus polyprotein cleavage domain
+PF12125	Beta-TrCP_D	D domain of beta-TrCP
+PF12126	DUF3583	Protein of unknown function (DUF3583)
+PF12127	YdfA_immunity	SigmaW regulon antibacterial
+PF12128	DUF3584	Protein of unknown function (DUF3584)
+PF12129	Phtf-FEM1B_bdg	Male germ-cell putative homeodomain transcription factor
+PF12130	DUF3585	Protein of unknown function (DUF3585)
+PF12131	DUF3586	Protein of unknown function (DUF3586)
+PF12132	DUF3587	Protein of unknown function (DUF3587)
+PF12133	Sars6	Open reading frame 6 from SARS coronavirus
+PF12134	PRP8_domainIV	PRP8 domain IV core
+PF12135	Sialidase_penC	Sialidase enzyme penultimate C terminal domain
+PF12136	RNA_pol_Rpo13	RNA polymerase Rpo13 subunit HTH domain
+PF12137	RapA_C	RNA polymerase recycling family C-terminal
+PF12138	Spherulin4	Spherulation-specific family 4
+PF12139	APS-reductase_C	Adenosine-5'-phosphosulfate reductase beta subunit
+PF12140	SLED	SLED domain
+PF12141	DUF3589	Protein of unknown function (DUF3589)
+PF12142	PPO1_DWL	Polyphenol oxidase middle domain
+PF12143	PPO1_KFDV	Protein of unknown function (DUF_B2219)
+PF12144	Med12-PQL	Eukaryotic Mediator 12 catenin-binding domain
+PF12145	Med12-LCEWAV	Eukaryotic Mediator 12 subunit domain
+PF12146	Hydrolase_4	Serine aminopeptidase, S33
+PF12147	Methyltransf_20	Putative methyltransferase
+PF12148	TTD	Tandem tudor domain within UHRF1
+PF12149	HSV_VP16_C	Herpes simplex virus virion protein 16 C terminal
+PF12150	MFP2b	Cytosolic motility protein
+PF12151	MVL	Mannan-binding protein
+PF12152	eIF_4G1	Eukaryotic translation initiation factor 4G1
+PF12153	CAP18_C	LPS binding domain of CAP18 (C terminal)
+PF12154	HCMVantigenic_N	Glycoprotein B N-terminal antigenic domain of HCMV
+PF12155	NADHdh-2_N	NADH dehydrogenase subunit 2 N-terminal
+PF12156	ATPase-cat_bd	Putative metal-binding domain of cation transport ATPase
+PF12157	DUF3591	Protein of unknown function (DUF3591)
+PF12158	DUF3592	Protein of unknown function (DUF3592)
+PF12159	DUF3593	Protein of unknown function (DUF3593)
+PF12160	Fibrinogen_aC	Fibrinogen alpha C domain
+PF12161	HsdM_N	HsdM N-terminal domain
+PF12162	STAT1_TAZ2bind	STAT1 TAZ2 binding domain
+PF12163	HobA	DNA replication regulator
+PF12164	SporV_AA	Stage V sporulation protein AA
+PF12165	Alfin	Alfin 
+PF12166	Piezo_RRas_bdg	Piezo non-specific cation channel, R-Ras-binding domain
+PF12167	Arm-DNA-bind_2	Arm DNA-binding domain
+PF12168	DNA_pol3_tau_4	DNA polymerase III subunits tau domain IV DnaB-binding
+PF12169	DNA_pol3_gamma3	DNA polymerase III subunits gamma and tau domain III
+PF12170	DNA_pol3_tau_5	DNA polymerase III tau subunit V interacting with alpha
+PF12171	zf-C2H2_jaz	Zinc-finger double-stranded RNA-binding
+PF12172	DUF35_N	Rubredoxin-like zinc ribbon domain (DUF35_N)
+PF12173	BacteriocIIc_cy	Bacteriocin class IIc cyclic gassericin A-like
+PF12174	RST	RCD1-SRO-TAF4 (RST) plant domain
+PF12175	WSS_VP	White spot syndrome virus structural envelope protein VP
+PF12176	MtaB	Methanol-cobalamin methyltransferase B subunit
+PF12177	Proho_convert	Prohormone convertase enzyme
+PF12178	INCENP_N	Chromosome passenger complex (CPC) protein INCENP N terminal
+PF12179	IKKbetaNEMObind	I-kappa-kinase-beta NEMO binding domain
+PF12180	EABR	TSG101 and ALIX binding domain of CEP55
+PF12181	MogR_DNAbind	DNA binding domain of the motility gene repressor (MogR)
+PF12182	DUF3642	Bacterial lipoprotein
+PF12183	NotI	Restriction endonuclease NotI
+PF12185	IR1-M	Nup358/RanBP2 E3 ligase domain
+PF12186	AcylCoA_dehyd_C	Acyl-CoA dehydrogenase C terminal
+PF12187	VirArc_Nuclease	Viral/Archaeal nuclease
+PF12188	STAT2_C	Signal transducer and activator of transcription 2 C terminal
+PF12189	VirE1	Single-strand DNA-binding protein
+PF12190	amfpi-1	Fungal protease inhibitor
+PF12191	stn_TNFRSF12A	Tumour necrosis factor receptor stn_TNFRSF12A_TNFR domain
+PF12192	CBP	Fungal calcium binding protein
+PF12193	Sulf_coat_C	Sulfolobus virus coat protein C terminal
+PF12194	Ste5_C	Protein kinase Fus3-binding
+PF12195	End_beta_barrel	Beta barrel domain of bacteriophage endosialidase
+PF12196	hNIFK_binding	FHA Ki67 binding domain of hNIFK
+PF12197	lci	Bacillus cereus group antimicrobial protein
+PF12198	Tuberculin	Theoretical tuberculin protein
+PF12199	efb-c	Extracellular fibrinogen binding protein C terminal
+PF12200	DUF3597	Domain of unknown function (DUF3597)
+PF12201	bcl-2I13	Bcl2-interacting killer, BH3-domain containing
+PF12202	OSR1_C	Oxidative-stress-responsive kinase 1 C-terminal domain
+PF12203	HDAC4_Gln	Glutamine rich N terminal domain of histone deacetylase 4
+PF12204	DUF3598	Domain of unknown function (DUF3598)
+PF12205	GIT1_C	G protein-coupled receptor kinase-interacting protein 1 C term
+PF12206	DUF3599	Domain of unknown function (DUF3599)
+PF12207	DUF3600	Domain of unknown function (DUF3600)
+PF12208	DUF3601	Domain of unknown function (DUF3601)
+PF12209	SAC3	Leucine permease transcriptional regulator helical domain
+PF12210	Hrs_helical	Hepatocyte growth factor-regulated tyrosine kinase substrate
+PF12211	LMWSLP_N	Low molecular weight S layer protein N terminal
+PF12212	PAZ_siRNAbind	PAZ domain
+PF12213	Dpoe2NT	DNA polymerases epsilon N terminal
+PF12214	TPX2_importin	Cell cycle regulated microtubule associated protein
+PF12215	Glyco_hydr_116N	beta-glucosidase 2, glycosyl-hydrolase family 116 N-term
+PF12216	m04gp34like	Immune evasion protein
+PF12217	End_beta_propel	Catalytic beta propeller domain of bacteriophage endosialidase
+PF12218	End_N_terminal	N terminal extension of bacteriophage endosialidase
+PF12219	End_tail_spike	Catalytic domain of bacteriophage endosialidase
+PF12220	U1snRNP70_N	U1 small nuclear ribonucleoprotein of 70kDa MW N terminal
+PF12221	HflK_N	Bacterial membrane protein N terminal
+PF12222	PNGaseA	Peptide N-acetyl-beta-D-glucosaminyl asparaginase amidase A
+PF12223	DUF3602	Protein of unknown function (DUF3602)
+PF12224	Amidoligase_2	Putative amidoligase enzyme
+PF12225	MTHFR_C	Methylene-tetrahydrofolate reductase C terminal
+PF12226	Astro_capsid_p	Turkey astrovirus capsid protein
+PF12227	DUF3603	Protein of unknown function (DUF3603)
+PF12228	DUF3604	Protein of unknown function (DUF3604)
+PF12229	PG_binding_4	Putative peptidoglycan binding domain
+PF12230	PRP21_like_P	Pre-mRNA splicing factor PRP21 like protein
+PF12231	Rif1_N	Rap1-interacting factor 1 N terminal
+PF12232	Myf5	Myogenic determination factor 5
+PF12233	p12I	Human adult T cell leukemia/lymphoma virus protein
+PF12234	Rav1p_C	RAVE protein 1 C terminal
+PF12235	FXMRP1_C_core	Fragile X-related 1 protein core C terminal
+PF12236	Head-tail_con	Bacteriophage head to tail connecting protein
+PF12237	PCIF1_WW	Phosphorylated CTD interacting factor 1 WW domain
+PF12238	MSA-2c	Merozoite surface antigen 2c
+PF12239	DUF3605	Protein of unknown function (DUF3605)
+PF12240	Angiomotin_C	Angiomotin C terminal
+PF12241	Enoyl_reductase	Trans-2-enoyl-CoA reductase catalytic region
+PF12242	Eno-Rase_NADH_b	NAD(P)H binding domain of trans-2-enoyl-CoA reductase
+PF12243	CTK3	CTD kinase subunit gamma CTK3
+PF12244	DUF3606	Protein of unknown function (DUF3606)
+PF12245	Big_3_2	Bacterial Ig-like domain (group 3)
+PF12246	MKT1_C	Temperature dependent protein affecting M2 dsRNA replication
+PF12247	MKT1_N	Temperature dependent protein affecting M2 dsRNA replication
+PF12248	Methyltransf_FA	Farnesoic acid 0-methyl transferase
+PF12249	AftA_C	Arabinofuranosyltransferase A C terminal
+PF12250	AftA_N	Arabinofuranosyltransferase N terminal
+PF12251	zf-SNAP50_C	snRNA-activating protein of 50kDa MW C terminal
+PF12252	SidE	Dot/Icm substrate protein
+PF12253	CAF1A	Chromatin assembly factor 1 subunit A
+PF12254	DNA_pol_alpha_N	DNA polymerase alpha subunit p180 N terminal
+PF12255	TcdB_toxin_midC	Insecticide toxin TcdB middle/C-terminal region
+PF12256	TcdB_toxin_midN	Insecticide toxin TcdB middle/N-terminal region
+PF12257	IML1	Vacuolar membrane-associated protein Iml1 
+PF12258	Microcephalin	Microcephalin protein
+PF12259	Baculo_F	Baculovirus F protein
+PF12260	PIP49_C	Protein-kinase domain of FAM69
+PF12261	T_hemolysin	Thermostable hemolysin
+PF12262	Lipase_bact_N	Bacterial virulence factor lipase N-terminal
+PF12263	DUF3611	Protein of unknown function (DUF3611)
+PF12264	Waikav_capsid_1	Waikavirus capsid protein 1
+PF12265	CAF1C_H4-bd	Histone-binding protein RBBP4 or subunit C of CAF1 complex
+PF12266	DUF3613	Protein of unknown function (DUF3613)
+PF12267	DUF3614	Protein of unknown function (DUF3614)
+PF12268	DUF3612	Protein of unknown function (DUF3612)
+PF12269	zf-CpG_bind_C	CpG binding protein zinc finger C terminal domain
+PF12270	Cyt_c_ox_IV	Cytochrome c oxidase subunit IV
+PF12271	Chs3p	Chitin synthase III catalytic subunit
+PF12273	RCR	Chitin synthesis regulation, resistance to Congo red
+PF12274	DUF3615	Protein of unknown function (DUF3615)
+PF12275	DUF3616	Protein of unknown function (DUF3616)
+PF12276	DUF3617	Protein of unknown function (DUF3617)
+PF12277	DUF3618	Protein of unknown function (DUF3618)
+PF12278	SDP_N	Sex determination protein N terminal
+PF12279	DUF3619	Protein of unknown function (DUF3619)
+PF12280	BSMAP	Brain specific membrane anchored protein
+PF12281	NTP_transf_8	Nucleotidyltransferase
+PF12282	H_kinase_N	Signal transduction histidine kinase
+PF12283	Protein_K	Bacteriophage protein K
+PF12284	HoxA13_N	Hox protein A13 N terminal
+PF12285	DUF3621	Protein of unknown function (DUF3621)
+PF12286	DUF3622	Protein of unknown function (DUF3622)
+PF12287	Caprin-1_C	Cytoplasmic activation/proliferation-associated protein-1 C term
+PF12288	CsoS2_M	Carboxysome shell peptide mid-region
+PF12289	Rotavirus_VP1	Rotavirus VP1 C-terminal domain
+PF12290	DUF3802	Protein of unknown function (DUF3802)
+PF12291	DUF3623	Protein of unknown function (DUF3623)
+PF12292	DUF3624	Protein of unknown function (DUF3624)
+PF12293	T4BSS_DotH_IcmK	Putative outer membrane core complex of type IVb secretion
+PF12294	DUF3626	Protein of unknown function (DUF3626)
+PF12295	Symplekin_C	Symplekin tight junction protein C terminal
+PF12296	HsbA	Hydrophobic surface binding protein A
+PF12297	EVC2_like	Ellis van Creveld protein 2 like protein
+PF12298	Bot1p	Eukaryotic mitochondrial regulator protein 
+PF12299	DUF3627	Protein of unknown function (DUF3627)
+PF12300	RhlB	ATP-dependent RNA helicase RhlB 
+PF12301	CD99L2	CD99 antigen like protein 2
+PF12302	DUF3629	Protein of unknown function (DUF3629)
+PF12304	BCLP	Beta-casein like protein
+PF12305	DUF3630	Protein of unknown function (DUF3630)
+PF12306	PixA	Inclusion body protein
+PF12307	DUF3631	Protein of unknown function (DUF3631)
+PF12308	Noelin-1	Neurogenesis glycoprotein
+PF12309	KBP_C	KIF-1 binding protein C terminal
+PF12310	Elf-1_N	Transcription factor protein N terminal
+PF12311	DUF3632	Protein of unknown function (DUF3632)
+PF12312	NeA_P2	Nepovirus subgroup A polyprotein 
+PF12313	NPR1_like_C	NPR1/NIM1 like defence protein C terminal
+PF12314	IMCp	Inner membrane complex protein
+PF12315	DA1-like	Protein DA1
+PF12316	Dsh_C	Segment polarity protein dishevelled (Dsh) C terminal
+PF12317	IFT46_B_C	Intraflagellar transport complex B protein 46 C terminal
+PF12318	FAD-SLDH	Membrane bound FAD containing D-sorbitol dehydrogenase 
+PF12319	TryThrA_C	Tryptophan-Threonine-rich plasmodium antigen C terminal
+PF12320	SbcD_C	Type 5 capsule protein repressor C-terminal domain
+PF12321	DUF3634	Protein of unknown function (DUF3634)
+PF12322	T4_baseplate	T4 bacteriophage base plate protein
+PF12323	HTH_OrfB_IS605	Helix-turn-helix domain
+PF12324	HTH_15	Helix-turn-helix domain of alkylmercury lyase
+PF12325	TMF_TATA_bd	TATA element modulatory factor 1 TATA binding
+PF12326	EOS1	N-glycosylation protein
+PF12327	FtsZ_C	FtsZ family, C-terminal domain
+PF12328	Rpp20	Rpp20 subunit of nuclear RNase MRP and P
+PF12329	TMF_DNA_bd	TATA element modulatory factor 1 DNA binding
+PF12330	Haspin_kinase	Haspin like kinase domain
+PF12331	DUF3636	Protein of unknown function (DUF3636) 
+PF12333	Ipi1_N	Rix1 complex component involved in 60S ribosome maturation
+PF12334	rOmpB	Rickettsia outer membrane protein B 
+PF12335	SBF2	Myotubularin protein 
+PF12336	SOXp	SOX transcription factor
+PF12337	DUF3637	Protein of unknown function (DUF3637) 
+PF12338	RbcS	Ribulose-1,5-bisphosphate carboxylase small subunit
+PF12339	DNAJ_related	DNA-J related protein 
+PF12340	DUF3638	Protein of unknown function (DUF3638)
+PF12341	Mcl1_mid	Minichromosome loss protein, Mcl1, middle region
+PF12342	DUF3640	Protein of unknown function (DUF3640) 
+PF12343	DEADboxA	Cold shock protein DEAD box A
+PF12344	UvrB	Ultra-violet resistance protein B
+PF12345	DUF3641	Protein of unknown function (DUF3641) 
+PF12346	HJURP_mid	Holliday junction recognition protein-associated repeat
+PF12347	HJURP_C	Holliday junction regulator protein family C-terminal repeat
+PF12348	CLASP_N	CLASP N terminal
+PF12349	Sterol-sensing	Sterol-sensing domain of SREBP cleavage-activation
+PF12350	CTK3_C	CTD kinase subunit gamma CTK3 C-terminus
+PF12351	Fig1	Ca2+ regulator and membrane fusion protein Fig1
+PF12352	V-SNARE_C	Snare region anchored in the vesicle membrane C-terminus
+PF12353	eIF3g	Eukaryotic translation initiation factor 3 subunit G 
+PF12354	Internalin_N	Bacterial adhesion/invasion protein N terminal
+PF12355	Dscam_C	Down syndrome cell adhesion molecule C terminal 
+PF12356	BIRC6	Baculoviral IAP repeat-containing protein 6  
+PF12357	PLD_C	Phospholipase D C terminal 
+PF12358	DUF3644	Protein of unknown function (DUF3644) 
+PF12359	DUF3645	Protein of unknown function (DUF3645) 
+PF12360	Pax7	Paired box protein 7 
+PF12361	DBP	Duffy-antigen binding protein 
+PF12362	DUF3646	DNA polymerase III gamma and tau subunits C terminal
+PF12363	Phage_TAC_12	Phage tail assembly chaperone protein, TAC
+PF12364	DUF3648	Protein of unknown function (DUF3648) 
+PF12365	DUF3649	Protein of unknown function (DUF3649) 
+PF12366	Casc1	Cancer susceptibility candidate 1 
+PF12367	PFO_beta_C	Pyruvate ferredoxin oxidoreductase beta subunit C terminal
+PF12368	Rhodanese_C	Rhodanase C-terminal
+PF12369	GnHR_trans	Gonadotropin hormone receptor transmembrane region 
+PF12371	TMEM131_like	Transmembrane protein 131-like
+PF12372	DUF3652	Huntingtin protein region 
+PF12373	Msg2_C	Major surface glycoprotein 2 C terminal
+PF12374	Dmrt1	Double-sex mab3 related transcription factor 1
+PF12375	DUF3653	Phage protein
+PF12376	DUF3654	Protein of unknown function (DUF3654) 
+PF12377	DuffyBP_N	Duffy binding protein N terminal 
+PF12378	CytadhesinP1	Trypsin-sensitive surface-exposed protein
+PF12379	DUF3655	Protein of unknown function (DUF3655) 
+PF12380	Peptidase_C62	Gill-associated viral 3C-like peptidase
+PF12381	Peptidase_C3G	Tungro spherical virus-type peptidase
+PF12382	Peptidase_A2E	Retrotransposon peptidase
+PF12383	SARS_3b	Severe acute respiratory syndrome coronavirus 3b protein
+PF12384	Peptidase_A2B	Ty3 transposon peptidase
+PF12385	Peptidase_C70	Papain-like cysteine protease AvrRpt2
+PF12386	Peptidase_C71	Pseudomurein endo-isopeptidase Pei
+PF12387	Peptidase_C74	Pestivirus NS2 peptidase
+PF12388	Peptidase_M57	Dual-action HEIGH metallo-peptidase
+PF12389	Peptidase_M73	Camelysin metallo-endopeptidase
+PF12390	Se-cys_synth_N	Selenocysteine synthase N terminal
+PF12391	PCDO_beta_N	Protocatechuate 3,4-dioxygenase beta subunit N terminal
+PF12392	DUF3656	Collagenase 
+PF12393	Dr_adhesin	Dr family adhesin 
+PF12394	DUF3657	Protein FAM135 
+PF12395	DUF3658	Protein of unknown function 
+PF12396	DUF3659	Protein of unknown function (DUF3659) 
+PF12397	U3snoRNP10	U3 small nucleolar RNA-associated protein 10 
+PF12398	DUF3660	Receptor serine/threonine kinase 
+PF12399	BCA_ABC_TP_C	Branched-chain amino acid ATP-binding cassette transporter
+PF12400	STIMATE	STIMATE family
+PF12401	DUF3662	Protein of unknown function (DUF2662) 
+PF12402	nlz1	NocA-like zinc-finger protein 1
+PF12403	Pax2_C	Paired-box protein 2 C terminal
+PF12404	DUF3663	Peptidase 
+PF12406	DUF3664	Surface protein 
+PF12407	Abdominal-A	Homeobox protein 
+PF12408	DUF3666	Ribose-5-phosphate isomerase 
+PF12409	P5-ATPase	P5-type ATPase cation transporter
+PF12410	rpo30_N	Poxvirus DNA dependent RNA polymerase 30kDa subunit 
+PF12411	Choline_sulf_C	Choline sulfatase enzyme C terminal 
+PF12412	DUF3667	Protein of unknown function (DUF3667)
+PF12413	DLL_N	Homeobox protein distal-less-like N terminal 
+PF12414	Fox-1_C	Calcitonin gene-related peptide regulator C terminal
+PF12415	rpo132	Poxvirus DNA dependent RNA polymerase
+PF12416	DUF3668	Cep120 protein
+PF12417	DUF3669	Zinc finger protein 
+PF12418	AcylCoA_DH_N	Acyl-CoA dehydrogenase N terminal 
+PF12419	DUF3670	SNF2 Helicase protein 
+PF12420	DUF3671	Protein of unknown function 
+PF12421	DUF3672	Fibronectin type III protein 
+PF12422	Condensin2nSMC	Condensin II non structural maintenance of chromosomes subunit
+PF12423	KIF1B	Kinesin protein 1B
+PF12424	ATP_Ca_trans_C	Plasma membrane calcium transporter ATPase C terminal
+PF12425	DUF3673	Protein of unknown function (DUF3673) 
+PF12426	DUF3674	RNA dependent RNA polymerase
+PF12427	DUF3665	Branched-chain amino acid aminotransferase 
+PF12428	DUF3675	Protein of unknown function (DUF3675) 
+PF12429	DUF3676	Protein of unknown function (DUF3676) 
+PF12430	ABA_GPCR	Abscisic acid G-protein coupled receptor 
+PF12431	CitT	Transcriptional regulator 
+PF12432	DUF3677	Protein of unknown function (DUF3677) 
+PF12433	PV_NSP1	Parvovirus non-structural protein 1 
+PF12434	Malate_DH	Malate dehydrogenase enzyme 
+PF12435	DUF3678	Protein of unknown function (DUF3678) 
+PF12436	USP7_ICP0_bdg	ICP0-binding domain of Ubiquitin-specific protease 7
+PF12437	GSIII_N	Glutamine synthetase type III N terminal 
+PF12438	DUF3679	Protein of unknown function (DUF3679) 
+PF12439	GDE_N	Glycogen debranching enzyme N terminal
+PF12440	MAGE_N	Melanoma associated antigen family N terminal 
+PF12441	CopG_antitoxin	CopG antitoxin of type II toxin-antitoxin system 
+PF12442	DUF3681	Protein of unknown function (DUF3681) 
+PF12443	AKNA	AT-hook-containing transcription factor
+PF12444	Sox_N	Sox developmental protein N terminal 
+PF12445	FliC	Flagellin protein 
+PF12446	DUF3682	Protein of unknown function (DUF3682)
+PF12447	DUF3683	Protein of unknown function (DUF3683)
+PF12448	Milton	Kinesin associated protein
+PF12449	DUF3684	Protein of unknown function (DUF3684) 
+PF12450	vWF_A	von Willebrand factor 
+PF12451	VPS11_C	Vacuolar protein sorting protein 11 C terminal
+PF12452	DUF3685	Protein of unknown function (DUF3685) 
+PF12453	PTP_N	Protein tyrosine phosphatase N terminal 
+PF12454	Ecm33	GPI-anchored cell wall organization protein
+PF12455	Dynactin	Dynein associated protein 
+PF12456	hSac2	Inositol phosphatase 
+PF12457	TIP_N	Tuftelin interacting protein N terminal 
+PF12458	DUF3686	ATPase involved in DNA repair 
+PF12459	DUF3687	D-Ala-teichoic acid biosynthesis protein
+PF12460	MMS19_C	RNAPII transcription regulator C-terminal
+PF12461	DUF3688	Protein of unknown function (DUF3688) 
+PF12462	Helicase_IV_N	DNA helicase IV / RNA helicase N terminal
+PF12463	DUF3689	Protein of unknown function (DUF3689) 
+PF12464	Mac	Maltose acetyltransferase 
+PF12465	Pr_beta_C	Proteasome beta subunits C terminal 
+PF12466	GDH_N	Glutamate dehydrogenase N terminal
+PF12467	CMV_1a	Cucumber mosaic virus 1a protein family
+PF12468	TTSSLRR	Type III secretion system leucine rich repeat protein  
+PF12469	DUF3692	CRISPR-associated protein 
+PF12470	SUFU_C	Suppressor of Fused Gli/Ci N terminal binding domain
+PF12471	GTP_CH_N	GTP cyclohydrolase N terminal 
+PF12472	DUF3693	Phage related protein
+PF12473	DUF3694	Kinesin protein 
+PF12474	PKK	Polo kinase kinase 
+PF12475	Amdo_NSP	Amdovirus non-structural protein 
+PF12476	DUF3696	Protein of unknown function (DUF3696)
+PF12477	TraW_N	Sex factor F TraW protein N terminal
+PF12478	DUF3697	Ubiquitin-associated protein 2 
+PF12479	DUF3698	Protein of unknown function (DUF3698) 
+PF12480	DUF3699	Protein of unknown function (DUF3699) 
+PF12481	DUF3700	Aluminium induced protein 
+PF12482	DUF3701	Phage integrase protein
+PF12483	GIDE	E3 Ubiquitin ligase
+PF12484	PE_PPE_C	Polymorphic PE/PPE proteins C terminal
+PF12485	SLY	Lymphocyte signaling adaptor protein
+PF12486	VasL	Type VI secretion system, EvfB, or VasL
+PF12487	DUF3703	Protein of unknown function (DUF3703) 
+PF12488	DUF3704	Protein of unknown function (DUF3704) 
+PF12489	ARA70	Nuclear coactivator
+PF12490	BCAS3	Breast carcinoma amplified sequence 3 
+PF12491	ApoB100_C	Apolipoprotein B100 C terminal
+PF12493	DUF3709	Protein of unknown function (DUF3709)
+PF12494	DUF3695	Protein of unknown function (DUF3695) 
+PF12495	Vip3A_N	Vegetative insecticide protein 3A N terminal 
+PF12496	BNIP2	Bcl2-/adenovirus E1B nineteen kDa-interacting protein 2
+PF12497	ERbeta_N	Estrogen receptor beta
+PF12498	bZIP_C	Basic leucine-zipper C terminal
+PF12499	DUF3707	Pherophorin 
+PF12500	TRSP	TRSP domain C terminus to PRTase_2 
+PF12501	DUF3708	Phosphate ATP-binding cassette transporter
+PF12502	DUF3710	Protein of unknown function (DUF3710) 
+PF12503	CMV_1a_C	Cucumber mosaic virus 1a protein C terminal 
+PF12505	DUF3712	Protein of unknown function (DUF3712)
+PF12506	DUF3713	Protein of unknown function (DUF3713)
+PF12507	HCMV_UL139	Human Cytomegalovirus UL139 protein
+PF12508	Transposon_TraM	Conjugative transposon, TraM  
+PF12509	DUF3715	Protein of unknown function (DUF3715)
+PF12510	Smoothelin	Smoothelin cytoskeleton protein
+PF12511	DUF3716	Protein of unknown function (DUF3716) 
+PF12512	DUF3717	Protein of unknown function (DUF3717) 
+PF12513	SUV3_C	Mitochondrial degradasome RNA helicase subunit C terminal
+PF12514	DUF3718	Protein of unknown function (DUF3718)
+PF12515	CaATP_NAI	Ca2+-ATPase N terminal autoinhibitory domain
+PF12516	DUF3719	Protein of unknown function (DUF3719)
+PF12517	DUF3720	Protein of unknown function (DUF3720) 
+PF12518	DUF3721	Protein of unknown function
+PF12519	MDM10	Mitochondrial distribution and morphology protein 10
+PF12520	DUF3723	Protein of unknown function (DUF3723) 
+PF12521	DUF3724	Protein of unknown function (DUF3724) 
+PF12522	UL73_N	Cytomegalovirus glycoprotein N terminal
+PF12523	DUF3725	Protein of unknown function (DUF3725)
+PF12524	GlyL_C	dsDNA virus glycoprotein L C terminal 
+PF12525	DUF3726	Protein of unknown function (DUF3726) 
+PF12526	DUF3729	Protein of unknown function (DUF3729) 
+PF12527	DUF3727	Protein of unknown function (DUF3727) 
+PF12528	T2SSppdC	Type II secretion prepilin peptidase dependent protein C
+PF12529	Xylo_C	Xylosyltransferase C terminal 
+PF12530	DUF3730	Protein of unknown function (DUF3730) 
+PF12531	DUF3731	DNA-K related protein 
+PF12532	DUF3732	Protein of unknown function (DUF3732)
+PF12533	Neuro_bHLH	Neuronal helix-loop-helix transcription factor 
+PF12534	Pannexin_like	Pannexin-like TM region of LRRC8
+PF12535	Nudix_N	Hydrolase of X-linked nucleoside diphosphate N terminal 
+PF12536	DUF3734	Patatin phospholipase 
+PF12537	GPHR_N	The Golgi pH Regulator (GPHR) Family N-terminal
+PF12538	FtsK_SpoIIIE_N	DNA transporter 
+PF12539	Csm1	Chromosome segregation protein Csm1/Pcs1
+PF12540	DUF3736	Protein of unknown function (DUF3736)
+PF12541	DUF3737	Protein of unknown function (DUF3737) 
+PF12542	CWC25	Pre-mRNA splicing factor
+PF12543	DUF3738	Protein of unknown function (DUF3738)
+PF12544	LAM_C	Lysine-2,3-aminomutase 
+PF12545	DUF3739	Filamentous haemagglutinin family outer membrane protein
+PF12546	Cryptochrome_C	Blue/Ultraviolet sensing protein C terminal
+PF12547	ATXN-1_C	Capicua transcriptional repressor modulator 
+PF12548	DUF3740	Sulfatase protein
+PF12549	TOH_N	Tyrosine hydroxylase N terminal 
+PF12550	GCR1_C	Transcriptional activator of glycolytic enzymes
+PF12551	PHBC_N	Poly-beta-hydroxybutyrate polymerase N terminal
+PF12552	DUF3741	Protein of unknown function (DUF3741)
+PF12553	DUF3742	Protein of unknown function (DUF3742)
+PF12554	MOZART1	Mitotic-spindle organizing gamma-tubulin ring associated
+PF12555	TPPK_C	Thiamine pyrophosphokinase C terminal
+PF12556	CobS_N	Cobaltochelatase CobS subunit N terminal 
+PF12557	Co_AT_N	Cob(I)alamin adenosyltransferase N terminal 
+PF12558	DUF3744	ATP-binding cassette cobalt transporter
+PF12559	Inhibitor_I10	Serine endopeptidase inhibitors
+PF12560	RAG1_imp_bd	RAG1 importin binding
+PF12561	TagA	ToxR activated gene A lipoprotein
+PF12562	DUF3746	Protein of unknown function (DUF3746)
+PF12563	Hemolysin_N	Hemolytic toxin N terminal
+PF12564	TypeIII_RM_meth	Type III restriction/modification enzyme methylation subunit
+PF12565	DUF3747	Protein of unknown function (DUF3747)
+PF12566	DUF3748	Protein of unknown function (DUF3748)
+PF12567	CD45	Leukocyte receptor CD45
+PF12568	DUF3749	Acetyltransferase (GNAT) domain
+PF12569	NARP1	NMDA receptor-regulated protein 1 
+PF12570	DUF3750	Protein of unknown function (DUF3750)
+PF12571	DUF3751	Phage tail-collar fibre protein
+PF12572	DUF3752	Protein of unknown function (DUF3752)
+PF12573	OxoDH_E1alpha_N	2-oxoisovalerate dehydrogenase E1 alpha subunit N terminal
+PF12574	120_Rick_ant	120 KDa Rickettsia surface antigen
+PF12575	Pox_EPC_I2-L1	Poxvirus entry protein complex L1 and I2
+PF12576	DUF3754	Protein of unknown function (DUF3754)
+PF12577	PPARgamma_N	PPAR gamma N-terminal region
+PF12578	3-PAP	Myotubularin-associated protein
+PF12579	DUF3755	Protein of unknown function (DUF3755)
+PF12580	TPPII	Tripeptidyl peptidase II 
+PF12581	DUF3756	Protein of unknown function (DUF3756)
+PF12582	DUF3757	Protein of unknown function (DUF3757)
+PF12583	TPPII_N	Tripeptidyl peptidase II N terminal
+PF12584	TRAPPC10	Trafficking protein particle complex subunit 10, TRAPPC10
+PF12585	DUF3759	Protein of unknown function (DUF3759)
+PF12586	DUF3760	Protein of unknown function (DUF3760)
+PF12587	DUF3761	Protein of unknown function (DUF3761)
+PF12588	PSDC	Phophatidylserine decarboxylase 
+PF12589	WBS_methylT	Methyltransferase involved in Williams-Beuren syndrome
+PF12590	Acyl-thio_N	Acyl-ATP thioesterase
+PF12591	DUF3762	Protein of unknown function (DUF3762)
+PF12592	DUF3763	Protein of unknown function (DUF3763)
+PF12593	McyA_C	Microcystin synthetase C terminal
+PF12594	DUF3764	Protein of unknown function (DUF3764)
+PF12595	Rhomboid_SP	Rhomboid serine protease
+PF12596	Tnp_P_element_C	87kDa Transposase
+PF12597	DUF3767	Protein of unknown function (DUF3767)
+PF12598	TBX	T-box transcription factor
+PF12599	DUF3768	Protein of unknown function (DUF3768)
+PF12600	DUF3769	Protein of unknown function (DUF3769)
+PF12601	Rubi_NSP_C	Rubivirus non-structural protein
+PF12602	FinO_N	Fertility inhibition protein N terminal
+PF12603	DUF3770	Protein of unknown function (DUF3770)
+PF12604	gp37_C	Tail fibre protein gp37 C terminal
+PF12605	CK1gamma_C	Casein kinase 1 gamma C terminal
+PF12606	RELT	Tumour necrosis factor receptor superfamily member 19
+PF12607	DUF3772	Protein of unknown function (DUF3772)
+PF12608	T4bSS_IcmS	Type IVb secretion, IcmS, effector-recruitment
+PF12609	DUF3774	Wound-induced protein
+PF12610	SOCS	Suppressor of cytokine signalling
+PF12611	Flagellar_put	Putative flagellar 
+PF12612	TFCD_C	Tubulin folding cofactor D C terminal
+PF12613	FliC_SP	Flagellin structural protein
+PF12614	RRF_GI	Ribosome recycling factor 
+PF12615	TraD_N	F sex factor protein N terminal
+PF12616	DUF3775	Protein of unknown function (DUF3775)
+PF12617	LdpA_C	Iron-Sulfur binding protein C terminal
+PF12618	DUF3776	Protein of unknown function (DUF3776)
+PF12619	MCM2_N	Mini-chromosome maintenance protein 2
+PF12620	DUF3778	Protein of unknown function (DUF3778)
+PF12621	PHM7_ext	Extracellular tail, of 10TM putative phosphate transporter
+PF12622	NpwBP	mRNA biogenesis factor
+PF12623	Hen1_L	RNA repair, ligase-Pnkp-associating, region of Hen1
+PF12624	Chorein_N	N-terminal region of Chorein or VPS13
+PF12625	Arabinose_bd	Arabinose-binding domain of AraC transcription regulator, N-term
+PF12626	PolyA_pol_arg_C	Polymerase A arginine-rich C-terminus
+PF12627	PolyA_pol_RNAbd	Probable RNA and SrmB- binding site of polymerase A
+PF12628	Inhibitor_I71	Falstatin, cysteine peptidase inhibitor
+PF12629	Pox_polyA_pol_C	Poxvirus poly(A) polymerase C-terminal domain
+PF12630	Pox_polyA_pol_N	Poxvirus poly(A) polymerase N-terminal domain
+PF12631	MnmE_helical	MnmE helical domain
+PF12632	Vezatin	Mysoin-binding motif of peroxisomes
+PF12633	Adenyl_cycl_N	Adenylate cyclase NT domain
+PF12634	Inp1	Inheritance of peroxisomes protein 1
+PF12635	DUF3780	Protein of unknown function (DUF3780)
+PF12636	DUF3781	Protein of unknown function (DUF3781)
+PF12637	TSCPD	TSCPD domain
+PF12638	Staygreen	Staygreen protein
+PF12639	Colicin-DNase	DNase/tRNase domain of colicin-like bacteriocin
+PF12640	UPF0489	UPF0489 domain
+PF12641	Flavodoxin_3	Flavodoxin domain
+PF12642	TpcC	Conjugative transposon protein TcpC
+PF12643	MazG-like	MazG-like family
+PF12644	DUF3782	Protein of unknown function (DUF3782)
+PF12645	HTH_16	Helix-turn-helix domain
+PF12646	DUF3783	Domain of unknown function (DUF3783)
+PF12647	RNHCP	RNHCP domain
+PF12648	TcpE	TcpE family
+PF12650	DUF3784	Domain of unknown function (DUF3784)
+PF12651	RHH_3	Ribbon-helix-helix domain
+PF12652	CotJB	CotJB protein
+PF12653	DUF3785	Protein of unknown function (DUF3785)
+PF12654	DUF3786	Domain of unknown function (DUF3786)
+PF12655	DUF3787	Domain of unknown function (DUF3787)
+PF12656	G-patch_2	G-patch domain
+PF12657	TFIIIC_delta	Transcription factor IIIC subunit delta N-term
+PF12658	Ten1	Telomere capping, CST complex subunit
+PF12659	Stn1_C	Telomere capping C-terminal wHTH
+PF12660	zf-TFIIIC	Putative zinc-finger of transcription factor IIIC complex
+PF12661	hEGF	Human growth factor-like EGF
+PF12662	cEGF	Complement Clr-like EGF-like
+PF12663	DUF3788	Protein of unknown function (DUF3788)
+PF12664	DUF3789	Protein of unknown function (DUF3789)
+PF12666	PrgI	PrgI family protein
+PF12667	NigD_N	NigD-like N-terminal OB domain
+PF12668	DUF3791	Protein of unknown function (DUF3791)
+PF12669	P12	Virus attachment protein p12 family
+PF12670	DUF3792	Protein of unknown function (DUF3792)
+PF12671	Amidase_6	Putative amidase domain
+PF12672	DUF3793	Protein of unknown function (DUF3793)
+PF12673	DUF3794	Domain of unknown function (DUF3794)
+PF12674	Zn_ribbon_2	Putative zinc ribbon domain
+PF12675	DUF3795	Protein of unknown function (DUF3795)
+PF12676	DUF3796	Protein of unknown function (DUF3796)
+PF12677	DUF3797	Domain of unknown function (DUF3797)
+PF12678	zf-rbx1	RING-H2 zinc finger domain
+PF12679	ABC2_membrane_2	ABC-2 family transporter protein
+PF12680	SnoaL_2	SnoaL-like domain
+PF12681	Glyoxalase_2	Glyoxalase-like domain
+PF12682	Flavodoxin_4	Flavodoxin
+PF12683	DUF3798	Protein of unknown function (DUF3798)
+PF12684	DUF3799	PDDEXK-like domain of unknown function (DUF3799)
+PF12685	SpoIIIAH	SpoIIIAH-like protein
+PF12686	DUF3800	Protein of unknown function (DUF3800)
+PF12687	DUF3801	Protein of unknown function (DUF3801)
+PF12688	TPR_5	Tetratrico peptide repeat
+PF12689	Acid_PPase	Acid Phosphatase
+PF12690	BsuPI	Intracellular proteinase inhibitor
+PF12691	Minor_capsid_3	Minor capsid protein from bacteriophage
+PF12692	Methyltransf_17	S-adenosyl-L-methionine methyltransferase
+PF12693	GspL_C	GspL periplasmic domain
+PF12694	MoCo_carrier	Putative molybdenum carrier
+PF12695	Abhydrolase_5	Alpha/beta hydrolase family
+PF12696	TraG-D_C	TraM recognition site of TraD and TraG
+PF12697	Abhydrolase_6	Alpha/beta hydrolase family
+PF12698	ABC2_membrane_3	ABC-2 family transporter protein
+PF12699	phiKZ_IP	phiKZ-like phage internal head proteins
+PF12700	HlyD_2	HlyD family secretion protein
+PF12701	LSM14	Scd6-like Sm domain
+PF12702	Lipocalin_3	Lipocalin-like
+PF12703	ptaRNA1_toxin	Toxin of toxin-antitoxin type 1 system
+PF12704	MacB_PCD	MacB-like periplasmic core domain
+PF12705	PDDEXK_1	PD-(D/E)XK nuclease superfamily
+PF12706	Lactamase_B_2	Beta-lactamase superfamily domain
+PF12707	DUF3804	Protein of unknown function (DUF3804)
+PF12708	Pectate_lyase_3	Pectate lyase superfamily protein
+PF12709	Kinetocho_Slk19	Central kinetochore-associated
+PF12710	HAD	haloacid dehalogenase-like hydrolase
+PF12712	DUF3805	Domain of unknown function (DUF3805)
+PF12713	DUF3806	Domain of unknown function (DUF3806)
+PF12714	TILa	TILa domain
+PF12715	Abhydrolase_7	Abhydrolase family
+PF12716	Apq12	Nuclear pore assembly and biogenesis
+PF12717	Cnd1	non-SMC mitotic condensation complex subunit 1
+PF12718	Tropomyosin_1	Tropomyosin like
+PF12719	Cnd3	Nuclear condensing complex subunits, C-term domain
+PF12720	DUF3807	Protein of unknown function (DUF3807)
+PF12721	RHIM	RIP homotypic interaction motif
+PF12722	Hid1	High-temperature-induced dauer-formation protein
+PF12723	DUF3809	Protein of unknown function (DUF3809)
+PF12724	Flavodoxin_5	Flavodoxin domain
+PF12725	DUF3810	Protein of unknown function (DUF3810)
+PF12726	SEN1_N	SEN1 N terminal
+PF12727	PBP_like	PBP superfamily domain
+PF12728	HTH_17	Helix-turn-helix domain
+PF12729	4HB_MCP_1	Four helix bundle sensory module for signal transduction
+PF12730	ABC2_membrane_4	ABC-2 family transporter protein
+PF12731	Mating_N	Mating-type protein beta 1
+PF12732	YtxH	YtxH-like protein
+PF12733	Cadherin-like	Cadherin-like beta sandwich domain
+PF12734	CYSTM	Cysteine-rich TM module stress tolerance
+PF12735	Trs65	TRAPP trafficking subunit Trs65
+PF12736	CABIT	Cell-cycle sustaining, positive selection, 
+PF12737	Mating_C	C-terminal domain of homeodomain 1
+PF12738	PTCB-BRCT	twin BRCT domain
+PF12739	TRAPPC-Trs85	ER-Golgi trafficking TRAPP I complex 85 kDa subunit
+PF12740	Chlorophyllase2	Chlorophyllase enzyme
+PF12741	SusD-like	Susd and RagB outer membrane lipoprotein 
+PF12742	Gryzun-like	Gryzun, putative Golgi trafficking
+PF12743	ESR1_C	Oestrogen-type nuclear receptor final C-terminal 
+PF12744	ATG19_autophagy	Autophagy protein Atg19, Atg8-binding
+PF12745	HGTP_anticodon2	Anticodon binding domain of tRNAs
+PF12746	GNAT_acetyltran	GNAT acetyltransferase
+PF12747	DdrB	DdrB-like protein
+PF12749	Metallothio_Euk	Eukaryotic metallothionein
+PF12750	Maff2	Maff2 family
+PF12751	Vac7	Vacuolar segregation subunit 7
+PF12752	SUZ	SUZ domain
+PF12753	Nro1	Nuclear pore complex subunit Nro1
+PF12754	Blt1	Blt1 N-terminal domain
+PF12755	Vac14_Fab1_bd	Vacuolar 14 Fab1-binding region
+PF12756	zf-C2H2_2	C2H2 type zinc-finger (2 copies)
+PF12757	Eisosome1	Eisosome protein 1 
+PF12758	DUF3813	Protein of unknown function (DUF3813)
+PF12759	HTH_Tnp_IS1	InsA C-terminal domain
+PF12760	Zn_Tnp_IS1595	Transposase zinc-ribbon domain
+PF12761	End3	Actin cytoskeleton-regulatory complex protein END3
+PF12762	DDE_Tnp_IS1595	ISXO2-like transposase domain
+PF12763	EF-hand_4	Cytoskeletal-regulatory complex EF hand
+PF12764	Gly-rich_Ago1	Glycine-rich region of argonaut
+PF12765	Cohesin_HEAT	HEAT repeat associated with sister chromatid cohesion
+PF12766	Pyridox_oxase_2	Pyridoxamine 5'-phosphate oxidase
+PF12767	SAGA-Tad1	Transcriptional regulator of RNA polII, SAGA, subunit
+PF12768	Rax2	Cortical protein marker for cell polarity
+PF12769	PNTB_4TM	4TM region of pyridine nucleotide transhydrogenase, mitoch
+PF12770	CHAT	CHAT domain
+PF12771	SusD-like_2	Starch-binding associating with outer membrane
+PF12772	GHBP	Growth hormone receptor binding
+PF12773	DZR	Double zinc ribbon
+PF12774	AAA_6	Hydrolytic ATP binding site of dynein motor region D1
+PF12775	AAA_7	P-loop containing dynein motor region D3
+PF12776	Myb_DNA-bind_3	Myb/SANT-like DNA-binding domain
+PF12777	MT	Microtubule-binding stalk of dynein motor
+PF12778	PXPV	PXPV repeat (3 copies)
+PF12779	YXWGXW	YXWGXW repeat (2 copies)
+PF12780	AAA_8	P-loop containing dynein motor region D4
+PF12781	AAA_9	ATP-binding dynein motor region D5
+PF12782	Innate_immun	Invertebrate innate immunity transcript family
+PF12783	Sec7_N	Guanine nucleotide exchange factor in Golgi transport N-terminal
+PF12784	PDDEXK_2	PD-(D/E)XK nuclease family transposase
+PF12785	VESA1_N	Variant erythrocyte surface antigen-1
+PF12786	GBV-C_env	GB virus C genotype envelope
+PF12787	EcsC	EcsC protein family
+PF12788	YmaF	YmaF family
+PF12789	PTR	Phage tail repeat like
+PF12790	T6SS-SciN	Type VI secretion lipoprotein, VasD, EvfM, TssJ, VC_A0113
+PF12791	RsgI_N	Anti-sigma factor N-terminus
+PF12792	CSS-motif	CSS motif domain associated with EAL 
+PF12793	SgrR_N	Sugar transport-related sRNA regulator N-term
+PF12794	MscS_TM	Mechanosensitive ion channel inner membrane domain 1
+PF12795	MscS_porin	Mechanosensitive ion channel porin domain
+PF12796	Ank_2	Ankyrin repeats (3 copies)
+PF12797	Fer4_2	4Fe-4S binding domain
+PF12798	Fer4_3	4Fe-4S binding domain
+PF12799	LRR_4	Leucine Rich repeats (2 copies)
+PF12800	Fer4_4	4Fe-4S binding domain
+PF12801	Fer4_5	4Fe-4S binding domain
+PF12802	MarR_2	MarR family
+PF12803	G-7-MTase	mRNA (guanine-7-)methyltransferase (G-7-MTase)
+PF12804	NTP_transf_3	MobA-like NTP transferase domain
+PF12805	FUSC-like	FUSC-like inner membrane protein yccS
+PF12806	Acyl-CoA_dh_C	Acetyl-CoA dehydrogenase C-terminal like
+PF12807	eIF3_p135	Translation initiation factor eIF3 subunit 135
+PF12808	Mto2_bdg	Micro-tubular organiser Mto1 C-term Mto2-binding region
+PF12809	Metallothi_Euk2	Eukaryotic metallothionein
+PF12810	Gly_rich	Glycine rich protein
+PF12811	BaxI_1	Bax inhibitor 1 like 
+PF12812	PDZ_1	PDZ-like domain
+PF12813	XPG_I_2	XPG domain containing
+PF12814	Mcp5_PH	Meiotic cell cortex C-terminal pleckstrin homology
+PF12815	CTD	Spt5 C-terminal nonapeptide repeat binding Spt4
+PF12816	Vps8	Golgi CORVET complex core vacuolar protein 8
+PF12818	Tegument_dsDNA	dsDNA viral tegument protein
+PF12819	Malectin_like	Carbohydrate-binding protein of the ER
+PF12820	BRCT_assoc	Serine-rich domain associated with BRCT
+PF12821	ThrE_2	Threonine/Serine exporter, ThrE
+PF12822	ECF_trnsprt	ECF transporter, substrate-specific component
+PF12823	DUF3817	Domain of unknown function (DUF3817)
+PF12824	MRP-L20	Mitochondrial ribosomal protein subunit L20
+PF12825	DUF3818	Domain of unknown function in PX-proteins (DUF3818)
+PF12826	HHH_2	Helix-hairpin-helix motif
+PF12827	Peroxin-22	Peroxisomal biogenesis protein family
+PF12828	PXB	PX-associated
+PF12829	Mhr1	Transcriptional regulation of mitochondrial recombination
+PF12830	Nipped-B_C	Sister chromatid cohesion C-terminus
+PF12831	FAD_oxidored	FAD dependent oxidoreductase
+PF12832	MFS_1_like	MFS_1 like family
+PF12833	HTH_18	Helix-turn-helix domain
+PF12834	Phage_int_SAM_2	Phage integrase, N-terminal
+PF12835	Integrase_1	Integrase
+PF12836	HHH_3	Helix-hairpin-helix motif
+PF12837	Fer4_6	4Fe-4S binding domain
+PF12838	Fer4_7	4Fe-4S dicluster domain
+PF12840	HTH_20	Helix-turn-helix domain
+PF12841	YvrJ	YvrJ protein family
+PF12842	DUF3819	Domain of unknown function (DUF3819)
+PF12843	QSregVF_b	Putative quorum-sensing-regulated virulence factor
+PF12844	HTH_19	Helix-turn-helix domain
+PF12845	TBD	TBD domain
+PF12846	AAA_10	AAA-like domain
+PF12847	Methyltransf_18	Methyltransferase domain
+PF12848	ABC_tran_Xtn	ABC transporter
+PF12849	PBP_like_2	PBP superfamily domain
+PF12850	Metallophos_2	Calcineurin-like phosphoesterase superfamily domain
+PF12851	Tet_JBP	Oxygenase domain of the 2OGFeDO superfamily 
+PF12852	Cupin_6	Cupin
+PF12853	NADH_u_ox_C	C-terminal of NADH-ubiquinone oxidoreductase 21 kDa subunit
+PF12854	PPR_1	PPR repeat
+PF12855	Ecl1	Life-span regulatory factor
+PF12856	ANAPC9	Anaphase-promoting complex subunit 9
+PF12857	TOBE_3	TOBE-like domain
+PF12859	ANAPC1	Anaphase-promoting complex subunit 1
+PF12860	PAS_7	PAS fold
+PF12861	zf-ANAPC11	Anaphase-promoting complex subunit 11 RING-H2 finger
+PF12862	ANAPC5	Anaphase-promoting complex subunit 5
+PF12863	DUF3821	Domain of unknown function (DUF3821)
+PF12864	DUF3822	Protein of unknown function (DUF3822)
+PF12866	DUF3823	Protein of unknown function (DUF3823)
+PF12867	DinB_2	DinB superfamily
+PF12868	DUF3824	Domain of unknwon function (DUF3824)
+PF12869	tRNA_anti-like	tRNA_anti-like
+PF12870	DUF4878	Domain of unknown function (DUF4878)
+PF12871	PRP38_assoc	Pre-mRNA-splicing factor 38-associated hydrophilic C-term
+PF12872	OST-HTH	OST-HTH/LOTUS domain
+PF12873	DUF3825	Domain of unknown function (DUF3825)
+PF12874	zf-met	Zinc-finger of C2H2 type
+PF12875	DUF3826	Protein of unknown function (DUF3826)
+PF12876	Cellulase-like	Sugar-binding cellulase-like
+PF12877	DUF3827	Domain of unknown function (DUF3827)
+PF12878	SICA_beta	SICA extracellular beta domain
+PF12879	SICA_C	SICA C-terminal inner membrane domain 
+PF12881	NUT	NUT protein
+PF12883	DUF3828	Protein of unknown function (DUF3828)
+PF12884	TORC_N	Transducer of regulated CREB activity, N terminus
+PF12885	TORC_M	Transducer of regulated CREB activity middle domain
+PF12886	TORC_C	Transducer of regulated CREB activity, C terminus
+PF12887	SICA_alpha	SICA extracellular alpha domain
+PF12888	Lipid_bd	Lipid-binding putative hydrolase
+PF12889	DUF3829	Protein of unknown function (DUF3829)
+PF12890	DHOase	Dihydro-orotase-like
+PF12891	Glyco_hydro_44	Glycoside hydrolase family 44
+PF12892	FctA	Spy0128-like isopeptide containing domain
+PF12893	Lumazine_bd_2	Putative lumazine-binding
+PF12894	ANAPC4_WD40	Anaphase-promoting complex subunit 4 WD40 domain
+PF12895	ANAPC3	Anaphase-promoting complex, cyclosome, subunit 3
+PF12896	ANAPC4	Anaphase-promoting complex, cyclosome, subunit 4
+PF12897	Aminotran_MocR	Alanine-glyoxylate amino-transferase
+PF12898	Stc1	Stc1 domain
+PF12899	Glyco_hydro_100	Alkaline and neutral invertase
+PF12900	Pyridox_ox_2	Pyridoxamine 5'-phosphate oxidase
+PF12901	SUZ-C	SUZ-C motif
+PF12902	Ferritin-like	Ferritin-like
+PF12903	DUF3830	Protein of unknown function (DUF3830)
+PF12904	Collagen_bind_2	Putative collagen-binding domain of a collagenase 
+PF12905	Glyco_hydro_101	Endo-alpha-N-acetylgalactosaminidase
+PF12906	RINGv	RING-variant domain
+PF12907	zf-met2	Zinc-binding
+PF12910	PHD_like	Antitoxin of toxin-antitoxin, RelE / RelB, TA system
+PF12911	OppC_N	N-terminal TM domain of oligopeptide transport permease C
+PF12912	N_NLPC_P60	NLPC_P60 stabilising domain, N term
+PF12913	SH3_6	SH3 domain (SH3b1 type)
+PF12914	SH3_7	SH3 domain of SH3b2 type
+PF12915	DUF3833	Protein of unknown function (DUF3833)
+PF12916	DUF3834	Protein of unknown function (DUF3834)
+PF12917	HD_2	HD containing hydrolase-like enzyme 
+PF12918	TcdB_N	TcdB toxin N-terminal helical domain
+PF12919	TcdA_TcdB	TcdA/TcdB catalytic glycosyltransferase domain
+PF12920	TcdA_TcdB_pore	TcdA/TcdB pore forming domain
+PF12921	ATP13	Mitochondrial ATPase expression
+PF12922	Cnd1_N	non-SMC mitotic condensation complex subunit 1, N-term
+PF12923	RRP7	Ribosomal RNA-processing protein 7 (RRP7)
+PF12924	APP_Cu_bd	Copper-binding of amyloid precursor, CuBD
+PF12925	APP_E2	E2 domain of amyloid precursor protein
+PF12926	MOZART2	Mitotic-spindle organizing gamma-tubulin ring associated
+PF12927	DUF3835	Domain of unknown function (DUF3835)
+PF12928	tRNA_int_end_N2	tRNA-splicing endonuclease subunit sen54 N-term
+PF12929	Mid1	Stretch-activated Ca2+-permeable channel component
+PF12930	DUF3836	Family of unknown function (DUF3836)
+PF12931	Sec16_C	Sec23-binding domain of Sec16
+PF12932	Sec16	Vesicle coat trafficking protein Sec16 mid-region
+PF12933	FTO_NTD	FTO catalytic domain
+PF12934	FTO_CTD	FTO C-terminal domain
+PF12935	Sec16_N	Vesicle coat trafficking protein Sec16 N-terminus
+PF12936	Kri1_C	KRI1-like family C-terminal
+PF12937	F-box-like	F-box-like
+PF12938	M_domain	M domain of GW182
+PF12939	DUF3837	Domain of unknown function (DUF3837)
+PF12940	RAG1	Recombination-activation protein 1 (RAG1), recombinase
+PF12941	HCV_NS5a_C	HCV NS5a protein C-terminal region
+PF12942	Archaeal_AmoA	Archaeal ammonia monooxygenase subunit A (AmoA)
+PF12943	DUF3839	Protein of unknown function (DUF3839)
+PF12944	HAV_VP	Hepatitis A virus viral protein VP
+PF12945	YcgR_2	Flagellar protein YcgR
+PF12946	EGF_MSP1_1	MSP1 EGF domain 1
+PF12947	EGF_3	EGF domain
+PF12948	MSP7_C	MSP7-like protein C-terminal domain
+PF12949	HeH	HeH/LEM domain
+PF12950	TaqI_C	TaqI-like C-terminal specificity domain
+PF12951	PATR	Passenger-associated-transport-repeat
+PF12952	DUF3841	Domain of unknown function (DUF3841)
+PF12953	DUF3842	Domain of unknown function (DUF3842)
+PF12954	DUF3843	Protein of unknown function (DUF3843)
+PF12955	DUF3844	Domain of unknown function (DUF3844)
+PF12956	DUF3845	Domain of Unknown Function with PDB structure
+PF12957	DUF3846	Domain of unknown function (DUF3846)
+PF12958	DUF3847	Protein of unknown function (DUF3847)
+PF12959	DUF3848	Protein of unknown function (DUF3848)
+PF12960	DUF3849	Protein of unknown function (DUF3849)
+PF12961	DUF3850	Domain of Unknown Function with PDB structure (DUF3850)
+PF12962	DUF3851	Protein of unknown function (DUF3851)
+PF12963	DUF3852	Protein of unknown function (DUF3852)
+PF12964	DUF3853	Protein of unknown function (DUF3853)
+PF12965	DUF3854	Domain of unknown function (DUF3854)
+PF12966	AtpR	N-ATPase, AtpR subunit 
+PF12967	DUF3855	Domain of Unknown Function with PDB structure (DUF3855)
+PF12968	DUF3856	Domain of Unknown Function (DUF3856)
+PF12969	DUF3857	Domain of Unknown Function with PDB structure (DUF3857)
+PF12970	DUF3858	Domain of Unknown Function with PDB structure (DUF3858)
+PF12971	NAGLU_N	Alpha-N-acetylglucosaminidase (NAGLU) N-terminal domain
+PF12972	NAGLU_C	Alpha-N-acetylglucosaminidase (NAGLU) C-terminal domain
+PF12973	Cupin_7	ChrR Cupin-like domain
+PF12974	Phosphonate-bd	ABC transporter, phosphonate, periplasmic substrate-binding protein 
+PF12975	DUF3859	Domain of unknown function (DUF3859)
+PF12976	DUF3860	Domain of Unknown Function with PDB structure (DUF3860)
+PF12977	DUF3861	Domain of Unknown Function with PDB structure (DUF3861)
+PF12978	DUF3862	Domain of Unknown Function with PDB structure (DUF3862)
+PF12979	DUF3863	Domain of Unknown Function with PDB structure (DUF3863)
+PF12980	DUF3864	Domain of Unknown Function with PDB structure (DUF3864)
+PF12981	DUF3865	Domain of Unknown Function with PDB structure (DUF3865)
+PF12982	DUF3866	Protein of unknown function (DUF3866)
+PF12983	DUF3867	Protein of unknown function (DUF3867)
+PF12984	DUF3868	Domain of unknown function, B. Theta Gene description (DUF3868)
+PF12985	DUF3869	Domain of unknown function (DUF3869)
+PF12986	DUF3870	Domain of unknown function (DUF3870)
+PF12987	DUF3871	Domain of unknown function, B. Theta Gene description (DUF3871)
+PF12988	DUF3872	Domain of unknown function, B. Theta Gene description (DUF3872)
+PF12989	DUF3873	Domain of unknown function, B. Theta Gene description (DUF3873)
+PF12990	DUF3874	Domain of unknonw function from B. Theta Gene description (DUF3874)
+PF12991	DUF3875	Domain of unknown function, B. Theta Gene description (DUF3875)
+PF12992	DUF3876	Domain of unknown function, B. Theta Gene description (DUF3876)
+PF12993	DUF3877	Domain of unknown function, E. rectale Gene description (DUF3877)
+PF12994	DUF3878	Domain of unknown function, E. rectale Gene description (DUF3878)
+PF12995	DUF3879	Domain of unknown function, E. rectale Gene description (DUF3879)
+PF12996	DUF3880	DUF based on E. rectale Gene description (DUF3880)
+PF12997	DUF3881	Domain of unknown function, E. rectale Gene description (DUF3881)
+PF12998	ING	Inhibitor of growth proteins N-terminal histone-binding
+PF12999	PRKCSH-like	Glucosidase II beta subunit-like
+PF13000	Acatn	Acetyl-coenzyme A transporter 1
+PF13001	Ecm29	Proteasome stabiliser
+PF13002	LDB19	Arrestin_N terminal like
+PF13004	BACON	Putative binding domain, N-terminal
+PF13005	zf-IS66	zinc-finger binding domain of transposase IS66 
+PF13006	Nterm_IS4	Insertion element 4 transposase N-terminal
+PF13007	LZ_Tnp_IS66	Transposase C of IS166 homeodomain
+PF13008	zf-Paramyx-P	Zinc-binding domain of Paramyxoviridae V protein
+PF13009	Phage_Integr_2	Putative phage integrase
+PF13010	pRN1_helical	Primase helical domain
+PF13011	LZ_Tnp_IS481	leucine-zipper of insertion element IS481
+PF13012	MitMem_reg	Maintenance of mitochondrial structure and function
+PF13013	F-box-like_2	F-box-like domain
+PF13015	PRKCSH_1	Glucosidase II beta subunit-like protein
+PF13016	Gliadin	Cys-rich Gliadin N-terminal
+PF13017	Maelstrom	piRNA pathway germ-plasm component
+PF13018	ESPR	Extended Signal Peptide of Type V secretion system
+PF13019	Telomere_Sde2	Telomere stability and silencing
+PF13020	DUF3883	Domain of unknown function (DUF3883)
+PF13021	DUF3885	Domain of unknown function (DUF3885)
+PF13022	HTH_Tnp_1_2	Helix-turn-helix of insertion element transposase
+PF13023	HD_3	HD domain
+PF13024	DUF3884	Protein of unknown function (DUF3884)
+PF13025	DUF3886	Protein of unknown function (DUF3886)
+PF13026	DUF3887	Protein of unknown function (DUF3887)
+PF13027	DUF3888	Protein of unknown function (DUF3888)
+PF13028	DUF3889	Protein of unknown function (DUF3889)
+PF13029	DUF3890	Domain of unknown function (DUF3890)
+PF13030	DUF3891	Protein of unknown function (DUF3891)
+PF13031	DUF3892	Protein of unknown function (DUF3892)
+PF13032	DUF3893	Domain of unknown function (DUF3893)
+PF13033	DUF3894	Protein of unknown function (DUF3894)
+PF13034	DUF3895	Protein of unknown function (DUF3895)
+PF13035	DUF3896	Protein of unknown function (DUF3896)
+PF13036	LpoB	Peptidoglycan-synthase activator LpoB
+PF13037	DUF3898	Domain of unknown function (DUF3898)
+PF13038	DUF3899	Domain of unknown function (DUF3899)
+PF13039	DUF3900	Protein of unknown function (DUF3900)
+PF13040	Fur_reg_FbpB	Fur-regulated basic protein B
+PF13041	PPR_2	PPR repeat family 
+PF13042	DUF3902	Protein of unknown function (DUF3902)
+PF13043	DUF3903	Domain of unknown function (DUF3903)
+PF13044	Fusion_F0	Fusion glycoprotein F0, Isavirus 
+PF13045	DUF3905	Protein of unknown function (DUF3905)
+PF13046	DUF3906	Protein of unknown function (DUF3906)
+PF13047	DUF3907	Protein of unknown function (DUF3907)
+PF13048	DUF3908	Protein of unknown function (DUF3908)
+PF13049	DUF3910	Protein of unknown function (DUF3910)
+PF13050	DUF3911	Protein of unknown function (DUF3911)
+PF13051	DUF3912	Protein of unknown function (DUF3912)
+PF13052	DUF3913	Protein of unknown function (DUF3913)
+PF13053	DUF3914	Protein of unknown function (DUF3914)
+PF13054	DUF3915	Protein of unknown function (DUF3915)
+PF13055	DUF3917	Protein of unknown function (DUF3917)
+PF13056	DUF3918	Protein of unknown function (DUF3918)
+PF13057	DUF3919	Protein of unknown function (DUF3919)
+PF13058	DUF3920	Protein of unknown function (DUF3920)
+PF13059	DUF3922	Protein of unknown function (DUF3992)
+PF13060	DUF3921	Protein of unknown function (DUF3921)
+PF13061	DUF3923	Protein of unknown function (DUF3923)
+PF13062	DUF3924	Protein of unknown function (DUF3924)
+PF13063	DUF3925	Protein of unknown function (DUF3925)
+PF13064	DUF3927	Protein of unknown function (DUF3927)
+PF13065	DUF3928	Protein of unknown function (DUF3928)
+PF13066	DUF3929	Protein of unknown function (DUF3929)
+PF13067	DUF3930	Protein of unknown function (DUF3930)
+PF13068	DUF3932	Protein of unknown function (DUF3932)
+PF13069	DUF3933	Protein of unknown function (DUF3933)
+PF13070	DUF3934	Protein of unknown function (DUF3934)
+PF13071	DUF3935	Protein of unknown function (DUF3935)
+PF13072	DUF3936	Protein of unknown function (DUF3936)
+PF13073	DUF3937	Protein of unknown function (DUF3937)
+PF13074	DUF3938	Protein of unknown function (DUF3938)
+PF13075	DUF3939	Protein of unknown function (DUF3939)
+PF13076	Fur_reg_FbpA	Fur-regulated basic protein A
+PF13077	DUF3909	Protein of unknown function (DUF3909)
+PF13078	DUF3942	Protein of unknown function (DUF3942)
+PF13079	DUF3916	Protein of unknown function (DUF3916)
+PF13080	DUF3926	Protein of unknown function (DUF3926)
+PF13081	DUF3941	Domain of unknown function (DUF3941)
+PF13082	DUF3931	Protein of unknown function (DUF3931)
+PF13083	KH_4	KH domain
+PF13084	DUF3943	Domain of unknown function (DUF3943)
+PF13085	Fer2_3	2Fe-2S iron-sulfur cluster binding domain
+PF13086	AAA_11	AAA domain
+PF13087	AAA_12	AAA domain
+PF13088	BNR_2	BNR repeat-like domain
+PF13089	PP_kinase_N	Polyphosphate kinase N-terminal domain
+PF13090	PP_kinase_C	Polyphosphate kinase C-terminal domain
+PF13091	PLDc_2	PLD-like domain
+PF13092	CENP-L	Kinetochore complex Sim4 subunit Fta1
+PF13093	FTA4	Kinetochore complex Fta4 of Sim4 subunit, or CENP-50
+PF13094	CENP-Q	CENP-Q, a CENPA-CAD centromere complex subunit
+PF13095	FTA2	Kinetochore Sim4 complex subunit FTA2
+PF13096	CENP-P	CENP-A-nucleosome distal (CAD) centromere subunit, CENP-P
+PF13097	CENP-U	CENP-A nucleosome associated complex (NAC) subunit
+PF13098	Thioredoxin_2	Thioredoxin-like domain
+PF13099	DUF3944	Domain of unknown function (DUF3944)
+PF13100	OstA_2	OstA-like protein
+PF13101	DUF3945	Protein of unknown function (DUF3945)
+PF13102	Phage_int_SAM_5	Phage integrase SAM-like domain
+PF13103	TonB_2	TonB C terminal
+PF13104	DUF3956	Protein of unknown function (DUF3956)
+PF13105	DUF3959	Protein of unknown function (DUF3959)
+PF13106	DUF3961	Domain of unknown function (DUF3961)
+PF13107	DUF3964	Protein of unknown function (DUF3964)
+PF13108	DUF3969	Protein of unknown function (DUF3969)
+PF13109	AsmA_1	AsmA-like C-terminal region
+PF13110	DUF3966	Protein of unknown function (DUF3966)
+PF13111	DUF3962	Protein of unknown function (DUF3962)
+PF13112	DUF3965	Protein of unknown function (DUF3965)
+PF13113	DUF3970	Protein of unknown function (DUF3970)
+PF13114	RecO_N_2	RecO N terminal
+PF13115	YtkA	YtkA-like
+PF13116	DUF3971	Protein of unknown function
+PF13117	Cag12	Cag pathogenicity island protein Cag12
+PF13118	DUF3972	Protein of unknown function (DUF3972) 
+PF13119	DUF3973	Domain of unknown function (DUF3973)
+PF13120	DUF3974	Domain of unknown function (DUF3974)
+PF13121	DUF3976	Domain of unknown function (DUF3976)
+PF13122	DUF3977	Protein of unknown function (DUF3977)
+PF13123	DUF3978	Protein of unknown function (DUF3978)
+PF13124	DUF3963	Protein of unknown function (DUF3963)
+PF13125	DUF3958	Protein of unknown function (DUF3958)
+PF13126	DUF3975	Protein of unknown function (DUF3975)
+PF13127	DUF3955	Protein of unknown function (DUF3955)
+PF13128	DUF3954	Protein of unknown function (DUF3954)
+PF13129	DUF3953	Protein of unknown function (DUF3953)
+PF13130	DUF3952	Domain of unknown function (DUF3952)
+PF13131	DUF3951	Protein of unknown function (DUF3951)
+PF13132	DUF3950	Domain of unknown function (DUF3950)
+PF13133	DUF3949	Protein of unknown function (DUF3949)
+PF13134	DUF3948	Protein of unknown function (DUF3948)
+PF13135	DUF3947	Protein of unknown function (DUF3947)
+PF13136	DUF3984	Protein of unknown function (DUF3984)
+PF13137	DUF3983	Protein of unknown function (DUF3983)
+PF13138	DUF3982	Protein of unknown function (DUF3982)
+PF13139	DUF3981	Domain of unknown function (DUF3981)
+PF13140	DUF3980	Domain of unknown function (DUF3980)
+PF13141	DUF3979	Protein of unknown function (DUF3979)
+PF13142	DUF3960	Domain of unknown function (DUF3960)
+PF13143	DUF3986	Protein of unknown function (DUF3986)
+PF13144	ChapFlgA	Chaperone for flagella basal body P-ring formation
+PF13145	Rotamase_2	PPIC-type PPIASE domain
+PF13146	TRL	TRL-like protein family
+PF13148	DUF3987	Protein of unknown function (DUF3987)
+PF13149	Mfa_like_1	Fimbrillin-like
+PF13150	DUF3989	Protein of unknown function (DUF3989)
+PF13151	DUF3990	Protein of unknown function (DUF3990)
+PF13152	DUF3967	Protein of unknown function (DUF3967)
+PF13153	DUF3985	Protein of unknown function (DUF3985)
+PF13154	DUF3991	Protein of unknown function (DUF3991)
+PF13155	Toprim_2	Toprim-like
+PF13156	Mrr_cat_2	Restriction endonuclease
+PF13157	DUF3992	Protein of unknown function (DUF3992)
+PF13158	DUF3993	Protein of unknown function (DUF3993)
+PF13159	DUF3994	Domain of unknown function (DUF3994)
+PF13160	DUF3995	Protein of unknown function (DUF3995)
+PF13161	DUF3996	Protein of unknown function (DUF3996)
+PF13162	DUF3997	Protein of unknown function (DUF3997)
+PF13163	DUF3999	Protein of unknown function (DUF3999)
+PF13164	Diedel	Diedel 
+PF13165	SCIFF	Six-cysteine peptide SCIFF 
+PF13166	AAA_13	AAA domain
+PF13167	GTP-bdg_N	GTP-binding GTPase N-terminal
+PF13168	Poxvirus_B22R_C	Poxvirus B22R protein C-terminal
+PF13169	Poxvirus_B22R_N	Poxvirus B22R protein N-terminal
+PF13170	DUF4003	Protein of unknown function (DUF4003)
+PF13171	DUF4004	Protein of unknown function (DUF4004)
+PF13173	AAA_14	AAA domain
+PF13174	TPR_6	Tetratricopeptide repeat
+PF13175	AAA_15	AAA ATPase domain
+PF13176	TPR_7	Tetratricopeptide repeat
+PF13177	DNA_pol3_delta2	DNA polymerase III, delta subunit
+PF13178	DUF4005	Protein of unknown function (DUF4005)
+PF13179	DUF4006	Family of unknown function (DUF4006)
+PF13180	PDZ_2	PDZ domain
+PF13181	TPR_8	Tetratricopeptide repeat
+PF13182	DUF4007	Protein of unknown function (DUF4007)
+PF13183	Fer4_8	4Fe-4S dicluster domain
+PF13184	KH_5	NusA-like KH domain
+PF13185	GAF_2	GAF domain
+PF13186	SPASM	Iron-sulfur cluster-binding domain
+PF13187	Fer4_9	4Fe-4S dicluster domain
+PF13188	PAS_8	PAS domain
+PF13189	Cytidylate_kin2	Cytidylate kinase-like family
+PF13190	PDGLE	PDGLE domain
+PF13191	AAA_16	AAA ATPase domain
+PF13192	Thioredoxin_3	Thioredoxin domain
+PF13193	AMP-binding_C	AMP-binding enzyme C-terminal domain
+PF13194	DUF4010	Domain of unknown function (DUF4010)
+PF13195	DUF4011	Protein of unknown function (DUF4011)
+PF13196	DUF4012	Protein of unknown function (DUF4012)
+PF13197	DUF4013	Protein of unknown function (DUF4013)
+PF13198	DUF4014	Protein of unknown function (DUF4014)
+PF13199	Glyco_hydro_66	Glycosyl hydrolase family 66
+PF13200	DUF4015	Putative glycosyl hydrolase domain
+PF13201	PCMD	Putative carbohydrate metabolism domain
+PF13202	EF-hand_5	EF hand
+PF13203	DUF2201_N	Putative metallopeptidase domain
+PF13204	DUF4038	Protein of unknown function (DUF4038)
+PF13205	Big_5	Bacterial Ig-like domain
+PF13206	VSG_B	Trypanosomal VSG domain
+PF13207	AAA_17	AAA domain
+PF13208	TerB_N	TerB N-terminal domain
+PF13209	DUF4017	Protein of unknown function (DUF4017)
+PF13210	DUF4018	Domain of unknown function (DUF4018)
+PF13211	DUF4019	Protein of unknown function (DUF4019)
+PF13212	DUF4020	Domain of unknown function (DUF4020)
+PF13213	DUF4021	Protein of unknown function (DUF4021)
+PF13214	DUF4022	Protein of unknown function (DUF4022)
+PF13215	DUF4023	Protein of unknown function (DUF4023)
+PF13216	DUF4024	Protein of unknown function (DUF4024)
+PF13217	DUF4025	Protein of unknown function (DUF4025)
+PF13218	DUF4026	Protein of unknown function (DUF4026)
+PF13219	DUF4027	Protein of unknown function (DUF4027)
+PF13220	DUF4028	Protein of unknown function (DUF4028)
+PF13221	DUF4029	Protein of unknown function (DUF4029)
+PF13222	DUF4030	Protein of unknown function (DUF4030)
+PF13223	DUF4031	Protein of unknown function (DUF4031)
+PF13224	DUF4032	Domain of unknown function (DUF4032)
+PF13225	DUF4033	Domain of unknown function (DUF4033)
+PF13226	DUF4034	Domain of unknown function (DUF4034)
+PF13227	DUF4035	Protein of unknown function (DUF4035)
+PF13228	DUF4037	Domain of unknown function (DUF4037)
+PF13229	Beta_helix	Right handed beta helix region
+PF13230	GATase_4	Glutamine amidotransferases class-II
+PF13231	PMT_2	Dolichyl-phosphate-mannose-protein mannosyltransferase
+PF13232	Complex1_LYR_1	Complex1_LYR-like
+PF13233	Complex1_LYR_2	Complex1_LYR-like
+PF13234	rRNA_proc-arch	rRNA-processing arch domain
+PF13236	CLU	Clustered mitochondria
+PF13237	Fer4_10	4Fe-4S dicluster domain
+PF13238	AAA_18	AAA domain
+PF13239	2TM	2TM domain
+PF13240	zinc_ribbon_2	zinc-ribbon domain
+PF13241	NAD_binding_7	Putative NAD(P)-binding
+PF13242	Hydrolase_like	HAD-hyrolase-like
+PF13243	SQHop_cyclase_C	Squalene-hopene cyclase C-terminal domain
+PF13244	DUF4040	Domain of unknown function (DUF4040)
+PF13245	AAA_19	AAA domain
+PF13246	Cation_ATPase	Cation transport ATPase (P-type)
+PF13247	Fer4_11	4Fe-4S dicluster domain
+PF13248	zf-ribbon_3	zinc-ribbon domain
+PF13249	SQHop_cyclase_N	Squalene-hopene cyclase N-terminal domain
+PF13250	DUF4041	Domain of unknown function (DUF4041)
+PF13251	DUF4042	Domain of unknown function (DUF4042)
+PF13252	DUF4043	Protein of unknown function (DUF4043)
+PF13253	DUF4044	Protein of unknown function (DUF4044)
+PF13254	DUF4045	Domain of unknown function (DUF4045)
+PF13255	DUF4046	Protein of unknown function (DUF4046)
+PF13256	DUF4047	Domain of unknown function (DUF4047)
+PF13257	DUF4048	Domain of unknown function (DUF4048)
+PF13258	DUF4049	Domain of unknown function (DUF4049)
+PF13259	DUF4050	Protein of unknown function (DUF4050)
+PF13260	DUF4051	Protein of unknown function (DUF4051)
+PF13261	DUF4052	Protein of unknown function (DUF4052)
+PF13262	DUF4054	Protein of unknown function (DUF4054)
+PF13263	PHP_C	PHP-associated
+PF13264	DUF4055	Domain of unknown function (DUF4055)
+PF13265	DUF4056	Protein of unknown function (DUF4056)
+PF13266	DUF4057	Protein of unknown function (DUF4057)
+PF13267	DUF4058	Protein of unknown function (DUF4058)
+PF13268	DUF4059	Protein of unknown function (DUF4059)
+PF13269	DUF4060	Protein of unknown function (DUF4060)
+PF13270	DUF4061	Domain of unknown function (DUF4061)
+PF13271	DUF4062	Domain of unknown function (DUF4062)
+PF13272	Holin_2-3	Putative 2/3 transmembrane domain holin
+PF13273	DUF4064	Protein of unknown function (DUF4064)
+PF13274	DUF4065	Protein of unknown function (DUF4065)
+PF13275	S4_2	S4 domain
+PF13276	HTH_21	HTH-like domain
+PF13277	YmdB	YmdB-like protein
+PF13279	4HBT_2	Thioesterase-like superfamily
+PF13280	WYL	WYL domain
+PF13281	DUF4071	Domain of unknown function (DUF4071)
+PF13282	DUF4070	Domain of unknown function (DUF4070)
+PF13283	NfrA_C	Bacteriophage N adsorption protein A C-term
+PF13284	DUF4072	Domain of unknown function (DUF4072)
+PF13285	DUF4073	Domain of unknown function (DUF4073)
+PF13286	HD_assoc	Phosphohydrolase-associated domain
+PF13287	Fn3_assoc	Fn3 associated
+PF13288	DXPR_C	DXP reductoisomerase C-terminal domain
+PF13289	SIR2_2	SIR2-like domain
+PF13290	CHB_HEX_C_1	Chitobiase/beta-hexosaminidase C-terminal domain
+PF13291	ACT_4	ACT domain
+PF13292	DXP_synthase_N	1-deoxy-D-xylulose-5-phosphate synthase
+PF13293	DUF4074	Domain of unknown function (DUF4074)
+PF13294	DUF4075	Domain of unknown function (DUF4075)
+PF13295	DUF4077	Domain of unknown function (DUF4077)
+PF13296	T6SS_Vgr	Putative type VI secretion system Rhs element Vgr
+PF13297	Telomere_Sde2_2	Telomere stability C-terminal
+PF13298	LigD_N	DNA polymerase Ligase (LigD)
+PF13299	CPSF100_C	Cleavage and polyadenylation factor 2 C-terminal
+PF13300	DUF4078	Domain of unknown function (DUF4078)
+PF13301	DUF4079	Protein of unknown function (DUF4079)
+PF13302	Acetyltransf_3	Acetyltransferase (GNAT) domain
+PF13303	PTS_EIIC_2	Phosphotransferase system, EIIC
+PF13304	AAA_21	AAA domain, putative AbiEii toxin, Type IV TA system
+PF13305	WHG	WHG domain
+PF13306	LRR_5	Leucine rich repeats (6 copies)
+PF13307	Helicase_C_2	Helicase C-terminal domain
+PF13308	YARHG	YARHG domain
+PF13309	HTH_22	HTH domain
+PF13310	Virulence_RhuM	Virulence protein RhuM family
+PF13311	DUF4080	Protein of unknown function (DUF4080)
+PF13312	DUF4081	Domain of unknown function (DUF4081)
+PF13313	DUF4082	Domain of unknown function (DUF4082)
+PF13314	DUF4083	Domain of unknown function (DUF4083)
+PF13315	DUF4085	Protein of unknown function (DUF4085)
+PF13316	DUF4087	Protein of unknown function (DUF4087)
+PF13317	DUF4088	Protein of unknown function (DUF4088)
+PF13318	DUF4089	Protein of unknown function (DUF4089)
+PF13319	DUF4090	Protein of unknown function (DUF4090)
+PF13320	DUF4091	Domain of unknown function (DUF4091)
+PF13321	DUF4084	Domain of unknown function (DUF4084)
+PF13322	DUF4092	Domain of unknown function (DUF4092)
+PF13323	HPIH	N-terminal domain with HPIH motif
+PF13324	GCIP	Grap2 and cyclin-D-interacting
+PF13325	MCRS_N	N-terminal region of micro-spherule protein
+PF13326	PSII_Pbs27	Photosystem II Pbs27
+PF13327	T3SS_LEE_assoc	Type III secretion system subunit
+PF13328	HD_4	HD domain
+PF13329	ATG2_CAD	Autophagy-related protein 2 CAD motif
+PF13330	Mucin2_WxxW	Mucin-2 protein WxxW repeating region
+PF13331	DUF4093	Domain of unknown function (DUF4093)
+PF13332	Fil_haemagg_2	Haemagluttinin repeat
+PF13333	rve_2	Integrase core domain
+PF13334	DUF4094	Domain of unknown function (DUF4094)
+PF13335	Mg_chelatase_C	Magnesium chelatase, subunit ChlI C-terminal
+PF13336	AcetylCoA_hyd_C	Acetyl-CoA hydrolase/transferase C-terminal domain
+PF13337	Lon_2	Putative ATP-dependent Lon protease
+PF13338	AbiEi_4	Transcriptional regulator, AbiEi antitoxin
+PF13339	AATF-Che1	Apoptosis antagonizing transcription factor
+PF13340	DUF4096	Putative transposase of IS4/5 family (DUF4096)
+PF13341	RAG2_PHD	RAG2 PHD domain
+PF13342	Toprim_Crpt	C-terminal repeat of topoisomerase
+PF13343	SBP_bac_6	Bacterial extracellular solute-binding protein
+PF13344	Hydrolase_6	Haloacid dehalogenase-like hydrolase
+PF13346	ABC2_membrane_5	ABC-2 family transporter protein
+PF13347	MFS_2	MFS/sugar transport protein
+PF13349	DUF4097	Putative adhesin
+PF13350	Y_phosphatase3	Tyrosine phosphatase family
+PF13351	DUF4099	Protein of unknown function (DUF4099)
+PF13352	DUF4100	Protein of unknown function (DUF4100)
+PF13353	Fer4_12	4Fe-4S single cluster domain
+PF13354	Beta-lactamase2	Beta-lactamase enzyme family
+PF13355	DUF4101	Protein of unknown function (DUF4101)
+PF13356	Arm-DNA-bind_3	Arm DNA-binding domain
+PF13358	DDE_3	DDE superfamily endonuclease
+PF13359	DDE_Tnp_4	DDE superfamily endonuclease
+PF13360	PQQ_2	PQQ-like domain
+PF13361	UvrD_C	UvrD-like helicase C-terminal domain
+PF13362	Toprim_3	Toprim domain
+PF13363	BetaGal_dom3	Beta-galactosidase, domain 3
+PF13364	BetaGal_dom4_5	Beta-galactosidase jelly roll domain
+PF13365	Trypsin_2	Trypsin-like peptidase domain
+PF13366	PDDEXK_3	PD-(D/E)XK nuclease superfamily
+PF13367	PrsW-protease	Protease prsW family
+PF13368	Toprim_C_rpt	Topoisomerase C-terminal repeat
+PF13369	Transglut_core2	Transglutaminase-like superfamily
+PF13370	Fer4_13	4Fe-4S single cluster domain of Ferredoxin I
+PF13371	TPR_9	Tetratricopeptide repeat
+PF13372	Alginate_exp	Alginate export 
+PF13373	DUF2407_C	DUF2407 C-terminal domain
+PF13374	TPR_10	Tetratricopeptide repeat
+PF13375	RnfC_N	RnfC Barrel sandwich hybrid domain
+PF13376	OmdA	Bacteriocin-protection, YdeI or OmpD-Associated
+PF13377	Peripla_BP_3	Periplasmic binding protein-like domain
+PF13378	MR_MLE_C	Enolase C-terminal domain-like
+PF13379	NMT1_2	NMT1-like family
+PF13380	CoA_binding_2	CoA binding domain
+PF13382	Adenine_deam_C	Adenine deaminase C-terminal domain
+PF13383	Methyltransf_22	Methyltransferase domain
+PF13384	HTH_23	Homeodomain-like domain
+PF13385	Laminin_G_3	Concanavalin A-like lectin/glucanases superfamily
+PF13386	DsbD_2	Cytochrome C biogenesis protein transmembrane region 
+PF13387	DUF4105	Domain of unknown function (DUF4105)
+PF13388	DUF4106	Protein of unknown function (DUF4106)
+PF13389	DUF4107	Protein of unknown function (DUF4107)
+PF13390	DUF4108	Protein of unknown function (DUF4108)
+PF13391	HNH_2	HNH endonuclease
+PF13392	HNH_3	HNH endonuclease
+PF13393	tRNA-synt_His	Histidyl-tRNA synthetase
+PF13394	Fer4_14	4Fe-4S single cluster domain
+PF13395	HNH_4	HNH endonuclease
+PF13396	PLDc_N	Phospholipase_D-nuclease N-terminal
+PF13397	RbpA	RNA polymerase-binding protein
+PF13398	Peptidase_M50B	Peptidase M50B-like
+PF13399	LytR_C	LytR cell envelope-related transcriptional attenuator
+PF13400	Tad	Putative Flp pilus-assembly TadE/G-like
+PF13401	AAA_22	AAA domain
+PF13402	Peptidase_M60	Peptidase M60, enhancin and enhancin-like
+PF13403	Hint_2	Hint domain
+PF13404	HTH_AsnC-type	AsnC-type helix-turn-helix domain
+PF13405	EF-hand_6	EF-hand domain
+PF13406	SLT_2	Transglycosylase SLT domain
+PF13407	Peripla_BP_4	Periplasmic binding protein domain
+PF13408	Zn_ribbon_recom	Recombinase zinc beta ribbon domain
+PF13409	GST_N_2	Glutathione S-transferase, N-terminal domain
+PF13410	GST_C_2	Glutathione S-transferase, C-terminal domain
+PF13411	MerR_1	MerR HTH family regulatory protein
+PF13412	HTH_24	Winged helix-turn-helix DNA-binding
+PF13413	HTH_25	Helix-turn-helix domain
+PF13414	TPR_11	TPR repeat
+PF13415	Kelch_3	Galactose oxidase, central domain
+PF13416	SBP_bac_8	Bacterial extracellular solute-binding protein
+PF13417	GST_N_3	Glutathione S-transferase, N-terminal domain
+PF13418	Kelch_4	Galactose oxidase, central domain
+PF13419	HAD_2	Haloacid dehalogenase-like hydrolase
+PF13420	Acetyltransf_4	Acetyltransferase (GNAT) domain
+PF13421	Band_7_1	SPFH domain-Band 7 family
+PF13422	DUF4110	Domain of unknown function (DUF4110)
+PF13423	UCH_1	Ubiquitin carboxyl-terminal hydrolase
+PF13424	TPR_12	Tetratricopeptide repeat
+PF13425	O-antigen_lig	O-antigen ligase like membrane protein
+PF13426	PAS_9	PAS domain
+PF13427	DUF4111	Domain of unknown function (DUF4111)
+PF13428	TPR_14	Tetratricopeptide repeat
+PF13429	TPR_15	Tetratricopeptide repeat
+PF13430	DUF4112	Domain of unknown function (DUF4112)
+PF13431	TPR_17	Tetratricopeptide repeat
+PF13432	TPR_16	Tetratricopeptide repeat
+PF13433	Peripla_BP_5	Periplasmic binding protein domain
+PF13434	K_oxygenase	L-lysine 6-monooxygenase (NADPH-requiring)
+PF13435	Cytochrome_C554	Cytochrome c554 and c-prime
+PF13436	Gly-zipper_OmpA	Glycine-zipper domain
+PF13437	HlyD_3	HlyD family secretion protein
+PF13438	DUF4113	Domain of unknown function (DUF4113)
+PF13439	Glyco_transf_4	Glycosyltransferase Family 4
+PF13440	Polysacc_synt_3	Polysaccharide biosynthesis protein
+PF13441	Gly-zipper_YMGG	YMGG-like Gly-zipper
+PF13442	Cytochrome_CBB3	Cytochrome C oxidase, cbb3-type, subunit III 
+PF13443	HTH_26	Cro/C1-type HTH DNA-binding domain
+PF13444	Acetyltransf_5	Acetyltransferase (GNAT) domain
+PF13445	zf-RING_UBOX	RING-type zinc-finger
+PF13446	RPT	A repeated domain in UCH-protein
+PF13447	Multi-haem_cyto	Seven times multi-haem cytochrome CxxCH
+PF13448	DUF4114	Domain of unknown function (DUF4114)
+PF13449	Phytase-like	Esterase-like activity of phytase
+PF13450	NAD_binding_8	NAD(P)-binding Rossmann-like domain
+PF13451	zf-trcl	Probable zinc-ribbon domain
+PF13452	MaoC_dehydrat_N	N-terminal half of MaoC dehydratase
+PF13453	zf-TFIIB	Transcription factor zinc-finger
+PF13454	NAD_binding_9	FAD-NAD(P)-binding
+PF13455	MUG113	Meiotically up-regulated gene 113
+PF13456	RVT_3	Reverse transcriptase-like
+PF13457	SH3_8	SH3-like domain
+PF13458	Peripla_BP_6	Periplasmic binding protein
+PF13459	Fer4_15	4Fe-4S single cluster domain
+PF13460	NAD_binding_10	NAD(P)H-binding 
+PF13462	Thioredoxin_4	Thioredoxin
+PF13463	HTH_27	Winged helix DNA-binding domain
+PF13464	DUF4115	Domain of unknown function (DUF4115)
+PF13465	zf-H2C2_2	Zinc-finger double domain
+PF13466	STAS_2	STAS domain
+PF13467	RHH_4	Ribbon-helix-helix domain
+PF13468	Glyoxalase_3	Glyoxalase-like domain
+PF13469	Sulfotransfer_3	Sulfotransferase family
+PF13470	PIN_3	PIN domain
+PF13471	Transglut_core3	Transglutaminase-like superfamily
+PF13472	Lipase_GDSL_2	GDSL-like Lipase/Acylhydrolase family
+PF13473	Cupredoxin_1	Cupredoxin-like domain
+PF13474	SnoaL_3	SnoaL-like domain
+PF13475	DUF4116	Domain of unknown function (DUF4116)
+PF13476	AAA_23	AAA domain
+PF13477	Glyco_trans_4_2	Glycosyl transferase 4-like
+PF13478	XdhC_C	XdhC Rossmann domain
+PF13479	AAA_24	AAA domain
+PF13480	Acetyltransf_6	Acetyltransferase (GNAT) domain
+PF13481	AAA_25	AAA domain
+PF13482	RNase_H_2	RNase_H superfamily
+PF13483	Lactamase_B_3	Beta-lactamase superfamily domain
+PF13484	Fer4_16	4Fe-4S double cluster binding domain
+PF13485	Peptidase_MA_2	Peptidase MA superfamily
+PF13486	Dehalogenase	Reductive dehalogenase subunit
+PF13487	HD_5	HD domain
+PF13488	Gly-zipper_Omp	Glycine zipper
+PF13489	Methyltransf_23	Methyltransferase domain
+PF13490	zf-HC2	Putative zinc-finger
+PF13491	FtsK_4TM	4TM region of DNA translocase FtsK/SpoIIIE
+PF13492	GAF_3	GAF domain
+PF13493	DUF4118	Domain of unknown function (DUF4118)
+PF13494	DUF4119	Domain of unknown function, B. Theta Gene description (DUF4119)
+PF13495	Phage_int_SAM_4	Phage integrase, N-terminal SAM-like domain
+PF13496	DUF4120	Domain of unknown function (DUF4120)
+PF13497	DUF4121	Domain of unknown function (DUF4121)
+PF13498	DUF4122	Domain of unknown function (DUF4122)
+PF13499	EF-hand_7	EF-hand domain pair
+PF13500	AAA_26	AAA domain
+PF13501	SoxY	Sulfur oxidation protein SoxY
+PF13502	AsmA_2	AsmA-like C-terminal region
+PF13503	DUF4123	Domain of unknown function (DUF4123)
+PF13505	OMP_b-brl	Outer membrane protein beta-barrel domain
+PF13506	Glyco_transf_21	Glycosyl transferase family 21
+PF13507	GATase_5	CobB/CobQ-like glutamine amidotransferase domain
+PF13508	Acetyltransf_7	Acetyltransferase (GNAT) domain
+PF13509	S1_2	S1 domain
+PF13510	Fer2_4	2Fe-2S iron-sulfur cluster binding domain
+PF13511	DUF4124	Domain of unknown function (DUF4124)
+PF13512	TPR_18	Tetratricopeptide repeat
+PF13513	HEAT_EZ	HEAT-like repeat
+PF13514	AAA_27	AAA domain
+PF13515	FUSC_2	Fusaric acid resistance protein-like
+PF13516	LRR_6	Leucine Rich repeat
+PF13517	VCBS	Repeat domain in Vibrio, Colwellia, Bradyrhizobium and Shewanella
+PF13518	HTH_28	Helix-turn-helix domain
+PF13519	VWA_2	von Willebrand factor type A domain
+PF13520	AA_permease_2	Amino acid permease
+PF13521	AAA_28	AAA domain
+PF13522	GATase_6	Glutamine amidotransferase domain
+PF13523	Acetyltransf_8	Acetyltransferase (GNAT) domain
+PF13524	Glyco_trans_1_2	Glycosyl transferases group 1
+PF13525	YfiO	Outer membrane lipoprotein
+PF13526	DUF4125	Protein of unknown function (DUF4125)
+PF13527	Acetyltransf_9	Acetyltransferase (GNAT) domain
+PF13528	Glyco_trans_1_3	Glycosyl transferase family 1
+PF13529	Peptidase_C39_2	Peptidase_C39 like family
+PF13530	SCP2_2	Sterol carrier protein domain
+PF13531	SBP_bac_11	Bacterial extracellular solute-binding protein
+PF13532	2OG-FeII_Oxy_2	2OG-Fe(II) oxygenase superfamily
+PF13533	Biotin_lipoyl_2	Biotin-lipoyl like
+PF13534	Fer4_17	4Fe-4S dicluster domain
+PF13535	ATP-grasp_4	ATP-grasp domain
+PF13536	EmrE	Putative multidrug resistance efflux transporter
+PF13537	GATase_7	Glutamine amidotransferase domain
+PF13538	UvrD_C_2	UvrD-like helicase C-terminal domain
+PF13539	Peptidase_M15_4	D-alanyl-D-alanine carboxypeptidase
+PF13540	RCC1_2	Regulator of chromosome condensation (RCC1) repeat
+PF13541	ChlI	Subunit ChlI of Mg-chelatase
+PF13542	HTH_Tnp_ISL3	Helix-turn-helix domain of transposase family ISL3
+PF13543	KSR1-SAM	SAM like domain present in kinase suppressor RAS 1
+PF13545	HTH_Crp_2	Crp-like helix-turn-helix domain
+PF13546	DDE_5	DDE superfamily endonuclease
+PF13547	GTA_TIM	GTA TIM-barrel-like domain
+PF13548	DUF4126	Domain of unknown function (DUF4126)
+PF13549	ATP-grasp_5	ATP-grasp domain
+PF13550	Phage-tail_3	Putative phage tail protein
+PF13551	HTH_29	Winged helix-turn helix
+PF13552	DUF4127	Protein of unknown function (DUF4127)
+PF13553	FIIND	Function to find
+PF13554	DUF4128	Bacteriophage related domain of unknown function
+PF13555	AAA_29	P-loop containing region of AAA domain
+PF13556	HTH_30	PucR C-terminal helix-turn-helix domain
+PF13557	Phenol_MetA_deg	Putative MetA-pathway of phenol degradation
+PF13558	SbcCD_C	Putative exonuclease SbcCD, C subunit
+PF13559	DUF4129	Domain of unknown function (DUF4129)
+PF13560	HTH_31	Helix-turn-helix domain
+PF13561	adh_short_C2	Enoyl-(Acyl carrier protein) reductase
+PF13562	NTP_transf_4	Sugar nucleotidyl transferase
+PF13563	2_5_RNA_ligase2	2'-5' RNA ligase superfamily
+PF13564	DoxX_2	DoxX-like family
+PF13565	HTH_32	Homeodomain-like domain
+PF13566	DUF4130	Domain of unknown function (DUF4130
+PF13567	DUF4131	Domain of unknown function (DUF4131)
+PF13568	OMP_b-brl_2	Outer membrane protein beta-barrel domain
+PF13569	DUF4132	Domain of unknown function (DUF4132)
+PF13570	PQQ_3	PQQ-like domain
+PF13571	DUF4133	Domain of unknown function (DUF4133)
+PF13572	DUF4134	Domain of unknown function (DUF4134)
+PF13573	SprB	SprB repeat
+PF13574	Reprolysin_2	Metallo-peptidase family M12B Reprolysin-like
+PF13575	DUF4135	Domain of unknown function (DUF4135)
+PF13576	Pentapeptide_3	Pentapeptide repeats (9 copies)
+PF13577	SnoaL_4	SnoaL-like domain
+PF13578	Methyltransf_24	Methyltransferase domain
+PF13579	Glyco_trans_4_4	Glycosyl transferase 4-like domain
+PF13580	SIS_2	SIS domain
+PF13581	HATPase_c_2	Histidine kinase-like ATPase domain
+PF13582	Reprolysin_3	Metallo-peptidase family M12B Reprolysin-like
+PF13583	Reprolysin_4	Metallo-peptidase family M12B Reprolysin-like
+PF13584	BatD	Oxygen tolerance
+PF13585	CHU_C	C-terminal domain of CHU protein family
+PF13586	DDE_Tnp_1_2	Transposase DDE domain
+PF13588	HSDR_N_2	Type I restriction enzyme R protein N terminus (HSDR_N)
+PF13589	HATPase_c_3	Histidine kinase-, DNA gyrase B-, and HSP90-like ATPase
+PF13590	DUF4136	Domain of unknown function (DUF4136)
+PF13591	MerR_2	MerR HTH family regulatory protein
+PF13592	HTH_33	Winged helix-turn helix
+PF13593	SBF_like	SBF-like CPA transporter family (DUF4137)
+PF13595	DUF4138	Domain of unknown function (DUF4138)
+PF13596	PAS_10	PAS domain
+PF13597	NRDD	Anaerobic ribonucleoside-triphosphate reductase
+PF13598	DUF4139	Domain of unknown function (DUF4139)
+PF13599	Pentapeptide_4	Pentapeptide repeats (9 copies)
+PF13600	DUF4140	N-terminal domain of unknown function (DUF4140)
+PF13601	HTH_34	Winged helix DNA-binding domain
+PF13602	ADH_zinc_N_2	Zinc-binding dehydrogenase
+PF13603	tRNA-synt_1_2	Leucyl-tRNA synthetase, Domain 2
+PF13604	AAA_30	AAA domain
+PF13605	DUF4141	Domain of unknown function (DUF4141)
+PF13606	Ank_3	Ankyrin repeat
+PF13607	Succ_CoA_lig	Succinyl-CoA ligase like flavodoxin domain
+PF13608	Potyvirid-P3	Protein P3 of Potyviral polyprotein
+PF13609	Porin_4	Gram-negative porin
+PF13610	DDE_Tnp_IS240	DDE domain
+PF13611	Peptidase_S76	Serine peptidase of plant viral polyprotein, P1
+PF13612	DDE_Tnp_1_3	Transposase DDE domain
+PF13613	HTH_Tnp_4	Helix-turn-helix of DDE superfamily endonuclease
+PF13614	AAA_31	AAA domain
+PF13616	Rotamase_3	PPIC-type PPIASE domain
+PF13617	Lipoprotein_19	YnbE-like lipoprotein
+PF13618	Gluconate_2-dh3	Gluconate 2-dehydrogenase subunit 3
+PF13619	KTSC	KTSC domain
+PF13620	CarboxypepD_reg	Carboxypeptidase regulatory-like domain
+PF13621	Cupin_8	Cupin-like domain
+PF13622	4HBT_3	Thioesterase-like superfamily
+PF13623	SurA_N_2	SurA N-terminal domain
+PF13624	SurA_N_3	SurA N-terminal domain
+PF13625	Helicase_C_3	Helicase conserved C-terminal domain
+PF13627	LPAM_2	Prokaryotic lipoprotein-attachment site
+PF13628	DUF4142	Domain of unknown function (DUF4142)
+PF13629	T2SS-T3SS_pil_N	Pilus formation protein N terminal region
+PF13630	SdpI	SdpI/YhfL protein family
+PF13631	Cytochrom_B_N_2	Cytochrome b(N-terminal)/b6/petB
+PF13632	Glyco_trans_2_3	Glycosyl transferase family group 2
+PF13634	Nucleoporin_FG	Nucleoporin FG repeat region
+PF13635	DUF4143	Domain of unknown function (DUF4143)
+PF13636	Methyltranf_PUA	RNA-binding PUA-like domain of methyltransferase RsmF
+PF13637	Ank_4	Ankyrin repeats (many copies)
+PF13638	PIN_4	PIN domain
+PF13639	zf-RING_2	Ring finger domain
+PF13640	2OG-FeII_Oxy_3	2OG-Fe(II) oxygenase superfamily
+PF13641	Glyco_tranf_2_3	Glycosyltransferase like family 2
+PF13642	DUF4144	protein structure with unknown function
+PF13643	DUF4145	Domain of unknown function (DUF4145)
+PF13644	DKNYY	DKNYY family
+PF13645	YkuD_2	L,D-transpeptidase catalytic domain
+PF13646	HEAT_2	HEAT repeats
+PF13647	Glyco_hydro_80	Glycosyl hydrolase family 80 of chitosanase A
+PF13648	Lipocalin_4	Lipocalin-like domain
+PF13649	Methyltransf_25	Methyltransferase domain
+PF13650	Asp_protease_2	Aspartyl protease
+PF13651	EcoRI_methylase	Adenine-specific methyltransferase EcoRI
+PF13652	QSregVF	Putative quorum-sensing-regulated virulence factor
+PF13653	GDPD_2	Glycerophosphoryl diester phosphodiesterase family
+PF13654	AAA_32	AAA domain
+PF13655	RVT_N	N-terminal domain of reverse transcriptase
+PF13656	RNA_pol_L_2	RNA polymerase Rpb3/Rpb11 dimerisation domain
+PF13657	Couple_hipA	HipA N-terminal domain
+PF13660	DUF4147	Domain of unknown function (DUF4147)
+PF13661	2OG-FeII_Oxy_4	2OG-Fe(II) oxygenase superfamily
+PF13662	Toprim_4	Toprim domain
+PF13663	DUF4148	Domain of unknown function (DUF4148)
+PF13664	DUF4149	Domain of unknown function (DUF4149)
+PF13665	DUF4150	Domain of unknown function (DUF4150)
+PF13667	ThiC-associated	ThiC-associated domain 
+PF13668	Ferritin_2	Ferritin-like domain
+PF13669	Glyoxalase_4	Glyoxalase/Bleomycin resistance protein/Dioxygenase superfamily
+PF13670	PepSY_2	Peptidase propeptide and YPEB domain
+PF13671	AAA_33	AAA domain
+PF13672	PP2C_2	Protein phosphatase 2C
+PF13673	Acetyltransf_10	Acetyltransferase (GNAT) domain
+PF13675	PilJ	Type IV pili methyl-accepting chemotaxis transducer N-term
+PF13676	TIR_2	TIR domain
+PF13677	MotB_plug	Membrane MotB of proton-channel complex MotA/MotB 
+PF13678	Peptidase_M85	NFkB-p65-degrading zinc protease
+PF13679	Methyltransf_32	Methyltransferase domain
+PF13680	DUF4152	Protein of unknown function (DUF4152)
+PF13681	PilX	Type IV pilus assembly protein PilX C-term
+PF13682	CZB	Chemoreceptor zinc-binding domain
+PF13683	rve_3	Integrase core domain
+PF13684	Dak1_2	Dihydroxyacetone kinase family
+PF13685	Fe-ADH_2	Iron-containing alcohol dehydrogenase
+PF13686	DrsE_2	DsrE/DsrF/DrsH-like family
+PF13687	DUF4153	Domain of unknown function (DUF4153)
+PF13688	Reprolysin_5	Metallo-peptidase family M12
+PF13689	DUF4154	Domain of unknown function (DUF4154)
+PF13690	CheX	Chemotaxis phosphatase CheX
+PF13691	Lactamase_B_4	tRNase Z endonuclease
+PF13692	Glyco_trans_1_4	Glycosyl transferases group 1
+PF13693	HTH_35	Winged helix-turn-helix DNA-binding
+PF13694	Hph	Sec63/Sec62 complex-interacting family
+PF13695	zf-3CxxC	Zinc-binding domain
+PF13696	zf-CCHC_2	Zinc knuckle
+PF13698	DUF4156	Domain of unknown function (DUF4156)
+PF13699	DUF4157	Domain of unknown function (DUF4157)
+PF13700	DUF4158	Domain of unknown function (DUF4158)
+PF13701	DDE_Tnp_1_4	Transposase DDE domain group 1
+PF13702	Lysozyme_like	Lysozyme-like
+PF13704	Glyco_tranf_2_4	Glycosyl transferase family 2
+PF13705	TRC8_N	TRC8 N-terminal domain
+PF13707	RloB	RloB-like protein
+PF13708	DUF4942	Domain of unknown function (DUF4942)
+PF13709	DUF4159	Domain of unknown function (DUF4159)
+PF13710	ACT_5	ACT domain
+PF13711	DUF4160	Domain of unknown function (DUF4160)
+PF13712	Glyco_tranf_2_5	Glycosyltransferase like family
+PF13713	BRX_N	Transcription factor BRX N-terminal domain
+PF13714	PEP_mutase	Phosphoenolpyruvate phosphomutase
+PF13715	CarbopepD_reg_2	CarboxypepD_reg-like domain
+PF13716	CRAL_TRIO_2	Divergent CRAL/TRIO domain
+PF13717	zinc_ribbon_4	zinc-ribbon domain
+PF13718	GNAT_acetyltr_2	GNAT acetyltransferase 2
+PF13719	zinc_ribbon_5	zinc-ribbon domain
+PF13720	Acetyltransf_11	Udp N-acetylglucosamine O-acyltransferase; Domain 2
+PF13721	SecD-TM1	SecD export protein N-terminal TM region
+PF13722	CstA_5TM	5TM C-terminal transporter carbon starvation CstA
+PF13723	Ketoacyl-synt_2	Beta-ketoacyl synthase, N-terminal domain
+PF13724	DNA_binding_2	DNA-binding domain
+PF13725	tRNA_bind_2	Possible tRNA binding domain
+PF13726	Na_H_antiport_2	Na+-H+ antiporter family
+PF13727	CoA_binding_3	CoA-binding domain
+PF13728	TraF	F plasmid transfer operon protein
+PF13729	TraF_2	F plasmid transfer operon, TraF, protein
+PF13730	HTH_36	Helix-turn-helix domain
+PF13731	WxL	WxL domain surface cell wall-binding
+PF13732	DUF4162	Domain of unknown function (DUF4162)
+PF13733	Glyco_transf_7N	N-terminal region of glycosyl transferase group 7
+PF13734	Inhibitor_I69	Spi protease inhibitor
+PF13735	tRNA_NucTran2_2	tRNA nucleotidyltransferase domain 2 putative
+PF13737	DDE_Tnp_1_5	Transposase DDE domain
+PF13738	Pyr_redox_3	Pyridine nucleotide-disulphide oxidoreductase
+PF13739	DUF4163	Domain of unknown function (DUF4163)
+PF13740	ACT_6	ACT domain
+PF13741	MRP-S25	Mitochondrial ribosomal protein S25
+PF13742	tRNA_anti_2	OB-fold nucleic acid binding domain
+PF13743	Thioredoxin_5	Thioredoxin
+PF13744	HTH_37	Helix-turn-helix domain
+PF13746	Fer4_18	4Fe-4S dicluster domain
+PF13747	DUF4164	Domain of unknown function (DUF4164)
+PF13748	ABC_membrane_3	ABC transporter transmembrane region
+PF13749	HATPase_c_4	Putative ATP-dependent DNA helicase recG C-terminal
+PF13750	Big_3_3	Bacterial Ig-like domain (group 3)
+PF13751	DDE_Tnp_1_6	Transposase DDE domain
+PF13752	DUF4165	Domain of unknown function (DUF4165)
+PF13753	SWM_repeat	Putative flagellar system-associated repeat
+PF13754	Big_3_4	Domain of unknown function
+PF13755	Sensor_TM1	Sensor N-terminal transmembrane domain
+PF13756	Stimulus_sens_1	Stimulus-sensing domain
+PF13757	VIT_2	Vault protein inter-alpha-trypsin domain
+PF13758	Prefoldin_3	Prefoldin subunit
+PF13759	2OG-FeII_Oxy_5	Putative 2OG-Fe(II) oxygenase
+PF13761	DUF4166	Domain of unknown function (DUF4166)
+PF13762	MNE1	Mitochondrial splicing apparatus component
+PF13763	DUF4167	Domain of unknown function (DUF4167)
+PF13764	E3_UbLigase_R4	E3 ubiquitin-protein ligase UBR4
+PF13765	PRY	SPRY-associated domain
+PF13767	DUF4168	Domain of unknown function (DUF4168)
+PF13768	VWA_3	von Willebrand factor type A domain
+PF13769	Virulence_fact	Virulence factor
+PF13770	DUF4169	Domain of unknown function (DUF4169)
+PF13771	zf-HC5HC2H	PHD-like zinc-binding domain
+PF13772	AIG2_2	AIG2-like family
+PF13773	DUF4170	Domain of unknown function (DUF4170)
+PF13774	Longin	Regulated-SNARE-like domain
+PF13775	DUF4171	Domain of unknown function (DUF4171)
+PF13776	DUF4172	Domain of unknown function (DUF4172)
+PF13777	DUF4173	Domain of unknown function (DUF4173)
+PF13778	DUF4174	Domain of unknown function (DUF4174)
+PF13779	DUF4175	Domain of unknown function (DUF4175)
+PF13780	DUF4176	Domain of unknown function (DUF4176)
+PF13781	DoxX_3	DoxX-like family
+PF13782	SpoVAB	Stage V sporulation protein AB
+PF13783	DUF4177	Domain of unknown function (DUF4177)
+PF13784	Fic_N	Fic/DOC family N-terminal
+PF13785	DUF4178	Domain of unknown function (DUF4178)
+PF13786	DUF4179	Domain of unknown function (DUF4179)
+PF13787	HXXEE	Protein of unknown function with HXXEE motif
+PF13788	DUF4180	Domain of unknown function (DUF4180)
+PF13789	DUF4181	Domain of unknown function (DUF4181)
+PF13790	SR1P	SR1 protein
+PF13791	Sigma_reg_C	Sigma factor regulator C-terminal
+PF13793	Pribosyltran_N	N-terminal domain of ribose phosphate pyrophosphokinase
+PF13794	MiaE_2	tRNA-(MS[2]IO[6]A)-hydroxylase (MiaE)-like
+PF13795	HupE_UreJ_2	HupE / UreJ protein
+PF13796	Sensor	Putative sensor
+PF13797	Post_transc_reg	Post-transcriptional regulator
+PF13798	PCYCGC	Protein of unknown function with PCYCGC motif
+PF13799	DUF4183	Domain of unknown function (DUF4183)
+PF13800	Sigma_reg_N	Sigma factor regulator N-terminal
+PF13801	Metal_resist	Heavy-metal resistance
+PF13802	Gal_mutarotas_2	Galactose mutarotase-like
+PF13803	DUF4184	Domain of unknown function (DUF4184)
+PF13804	HERV-K_env_2	Retro-transcribing viruses envelope glycoprotein
+PF13805	Pil1	Eisosome component PIL1
+PF13806	Rieske_2	Rieske-like [2Fe-2S] domain
+PF13807	GNVR	G-rich domain on putative tyrosine kinase
+PF13808	DDE_Tnp_1_assoc	DDE_Tnp_1-associated
+PF13809	Tubulin_2	Tubulin like
+PF13810	DUF4185	Domain of unknown function (DUF4185)
+PF13811	DUF4186	Domain of unknown function (DUF4186)
+PF13812	PPR_3	Pentatricopeptide repeat domain
+PF13813	MBOAT_2	Membrane bound O-acyl transferase family
+PF13814	Replic_Relax	Replication-relaxation
+PF13815	Dzip-like_N	Iguana/Dzip1-like DAZ-interacting protein N-terminal
+PF13816	Dehydratase_hem	Haem-containing dehydratase
+PF13817	DDE_Tnp_IS66_C	IS66 C-terminal element
+PF13820	Nucleic_acid_bd	Putative nucleic acid-binding region
+PF13821	DUF4187	Domain of unknown function (DUF4187)
+PF13822	ACC_epsilon	Acyl-CoA carboxylase epsilon subunit
+PF13823	ADH_N_assoc	Alcohol dehydrogenase GroES-associated
+PF13824	zf-Mss51	Zinc-finger of mitochondrial splicing suppressor 51
+PF13825	Paramyxo_PNT	Paramyxovirus structural protein V/P N-terminus
+PF13826	DUF4188	Domain of unknown function (DUF4188)
+PF13827	DUF4189	Domain of unknown function (DUF4189)
+PF13828	DUF4190	Domain of unknown function (DUF4190)
+PF13829	DUF4191	Domain of unknown function (DUF4191)
+PF13830	DUF4192	Domain of unknown function (DUF4192)
+PF13831	PHD_2	PHD-finger
+PF13832	zf-HC5HC2H_2	PHD-zinc-finger like domain
+PF13833	EF-hand_8	EF-hand domain pair
+PF13834	DUF4193	Domain of unknown function (DUF4193)
+PF13835	DUF4194	Domain of unknown function (DUF4194)
+PF13836	DUF4195	Domain of unknown function (DUF4195)
+PF13837	Myb_DNA-bind_4	Myb/SANT-like DNA-binding domain
+PF13838	Clathrin_H_link	Clathrin-H-link
+PF13839	PC-Esterase	GDSL/SGNH-like Acyl-Esterase family found in Pmr5 and Cas1p
+PF13840	ACT_7	ACT domain 
+PF13841	Defensin_beta_2	Beta defensin
+PF13842	Tnp_zf-ribbon_2	DDE_Tnp_1-like zinc-ribbon
+PF13843	DDE_Tnp_1_7	Transposase IS4
+PF13844	Glyco_transf_41	Glycosyl transferase family 41
+PF13845	Septum_form	Septum formation
+PF13846	DUF4196	Domain of unknown function (DUF4196)
+PF13847	Methyltransf_31	Methyltransferase domain
+PF13848	Thioredoxin_6	Thioredoxin-like domain
+PF13850	ERGIC_N	Endoplasmic Reticulum-Golgi Intermediate Compartment (ERGIC)
+PF13851	GAS	Growth-arrest specific micro-tubule binding
+PF13852	DUF4197	Protein of unknown function (DUF4197)
+PF13853	7tm_4	Olfactory receptor
+PF13854	Kelch_5	Kelch motif
+PF13855	LRR_8	Leucine rich repeat
+PF13856	Gifsy-2	ATP-binding sugar transporter from pro-phage
+PF13857	Ank_5	Ankyrin repeats (many copies)
+PF13858	DUF4199	Protein of unknown function (DUF4199)
+PF13859	BNR_3	BNR repeat-like domain
+PF13860	FlgD_ig	FlgD Ig-like domain
+PF13861	FLgD_tudor	FlgD Tudor-like domain
+PF13862	BCIP	p21-C-terminal region-binding protein
+PF13863	DUF4200	Domain of unknown function (DUF4200)
+PF13864	Enkurin	Calmodulin-binding
+PF13865	FoP_duplication	C-terminal duplication domain of Friend of PRMT1
+PF13866	zf-SAP30	SAP30 zinc-finger
+PF13867	SAP30_Sin3_bdg	Sin3 binding region of histone deacetylase complex subunit SAP30
+PF13868	TPH	Trichohyalin-plectin-homology domain
+PF13869	NUDIX_2	Nucleotide hydrolase
+PF13870	DUF4201	Domain of unknown function (DUF4201)
+PF13871	Helicase_C_4	C-terminal domain on Strawberry notch homologue
+PF13872	AAA_34	P-loop containing NTP hydrolase pore-1
+PF13873	Myb_DNA-bind_5	Myb/SANT-like DNA-binding domain
+PF13874	Nup54	Nucleoporin complex subunit 54
+PF13875	DUF4202	Domain of unknown function (DUF4202)
+PF13876	Phage_gp49_66	Phage protein (N4 Gp49/phage Sf6 gene 66) family
+PF13877	RPAP3_C	Potential Monad-binding region of RPAP3
+PF13878	zf-C2H2_3	zinc-finger of acetyl-transferase ESCO
+PF13879	KIAA1430	KIAA1430 homologue
+PF13880	Acetyltransf_13	ESCO1/2 acetyl-transferase
+PF13881	Rad60-SLD_2	Ubiquitin-2 like Rad60 SUMO-like
+PF13882	Bravo_FIGEY	Bravo-like intracellular region
+PF13883	Pyrid_oxidase_2	Pyridoxamine 5'-phosphate oxidase
+PF13884	Peptidase_S74	Chaperone of endosialidase
+PF13885	Keratin_B2_2	Keratin, high sulfur B2 protein
+PF13886	DUF4203	Domain of unknown function (DUF4203)
+PF13887	MRF_C1	Myelin gene regulatory factor -C-terminal domain 1
+PF13888	MRF_C2	Myelin gene regulatory factor C-terminal domain 2
+PF13889	Chromosome_seg	Chromosome segregation during meiosis
+PF13890	Rab3-GTPase_cat	Rab3 GTPase-activating protein catalytic subunit
+PF13891	zf-C3Hc3H	Potential DNA-binding domain
+PF13892	DBINO	DNA-binding domain
+PF13893	RRM_5	RNA recognition motif. (a.k.a. RRM, RBD, or RNP domain)
+PF13894	zf-C2H2_4	C2H2-type zinc finger
+PF13895	Ig_2	Immunoglobulin domain
+PF13896	Glyco_transf_49	Glycosyl-transferase for dystroglycan
+PF13897	GOLD_2	Golgi-dynamics membrane-trafficking
+PF13898	DUF4205	Domain of unknown function (DUF4205)
+PF13899	Thioredoxin_7	Thioredoxin-like
+PF13901	zf-RING_9	Putative zinc-RING and/or ribbon
+PF13902	R3H-assoc	R3H-associated N-terminal domain
+PF13903	Claudin_2	PMP-22/EMP/MP20/Claudin tight junction
+PF13904	DUF4207	Domain of unknown function (DUF4207)
+PF13905	Thioredoxin_8	Thioredoxin-like
+PF13906	AA_permease_C	C-terminus of AA_permease
+PF13907	DUF4208	Domain of unknown function (DUF4208)
+PF13908	Shisa	Wnt and FGF inhibitory regulator
+PF13909	zf-H2C2_5	C2H2-type zinc-finger domain
+PF13910	DUF4209	Domain of unknown function (DUF4209)
+PF13911	AhpC-TSA_2	AhpC/TSA antioxidant enzyme
+PF13912	zf-C2H2_6	C2H2-type zinc finger
+PF13913	zf-C2HC_2	zinc-finger of a C2HC-type
+PF13914	Phostensin	Phostensin PP1-binding and SH3-binding region
+PF13915	DUF4210	Domain of unknown function (DUF4210)
+PF13916	Phostensin_N	PP1-regulatory protein, Phostensin N-terminal
+PF13917	zf-CCHC_3	Zinc knuckle
+PF13918	PLDc_3	PLD-like domain
+PF13919	ASXH	Asx homology domain
+PF13920	zf-C3HC4_3	Zinc finger, C3HC4 type (RING finger)
+PF13921	Myb_DNA-bind_6	Myb-like DNA-binding domain
+PF13922	PHD_3	PHD domain of transcriptional enhancer, Asx
+PF13923	zf-C3HC4_2	Zinc finger, C3HC4 type (RING finger)
+PF13924	Lipocalin_5	Lipocalin-like domain
+PF13925	Katanin_con80	con80 domain of Katanin
+PF13926	DUF4211	Domain of unknown function (DUF4211)
+PF13927	Ig_3	Immunoglobulin domain
+PF13928	Flocculin_t3	Flocculin type 3 repeat
+PF13929	mRNA_stabil	mRNA stabilisation
+PF13930	Endonuclea_NS_2	DNA/RNA non-specific endonuclease
+PF13931	Microtub_bind	Kinesin-associated microtubule-binding
+PF13932	GIDA_assoc	GidA associated domain
+PF13933	HRXXH	Putative peptidase family
+PF13934	ELYS	Nuclear pore complex assembly
+PF13935	Ead_Ea22	Ead/Ea22-like protein
+PF13936	HTH_38	Helix-turn-helix domain
+PF13937	DUF4212	Domain of unknown function (DUF4212)
+PF13938	DUF4213	Putative heavy-metal chelation
+PF13939	TisB_toxin	Toxin TisB, type I toxin-antitoxin system
+PF13940	Ldr_toxin	Toxin Ldr, type I toxin-antitoxin system
+PF13941	MutL	MutL protein
+PF13942	Lipoprotein_20	YfhG lipoprotein
+PF13943	WPP	WPP domain
+PF13944	Calycin_like	Calycin-like beta-barrel domain
+PF13945	NST1	Salt tolerance down-regulator
+PF13946	DUF4214	Domain of unknown function (DUF4214)
+PF13947	GUB_WAK_bind	Wall-associated receptor kinase galacturonan-binding
+PF13948	DUF4215	Domain of unknown function (DUF4215)
+PF13949	ALIX_LYPXL_bnd	ALIX V-shaped domain binding to HIV 
+PF13952	DUF4216	Domain of unknown function (DUF4216)
+PF13953	PapC_C	PapC C-terminal domain
+PF13954	PapC_N	PapC N-terminal domain
+PF13955	Fst_toxin	Toxin Fst, type I toxin-antitoxin system
+PF13956	Ibs_toxin	Toxin Ibs, type I toxin-antitoxin system
+PF13957	YafO_toxin	Toxin YafO, type II toxin-antitoxin system
+PF13958	ToxN_toxin	Toxin ToxN, type III toxin-antitoxin system
+PF13959	DUF4217	Domain of unknown function (DUF4217)
+PF13960	DUF4218	Domain of unknown function (DUF4218)
+PF13961	DUF4219	Domain of unknown function (DUF4219)
+PF13962	PGG	Domain of unknown function
+PF13963	Transpos_assoc	Transposase-associated domain
+PF13964	Kelch_6	Kelch motif
+PF13965	SID-1_RNA_chan	dsRNA-gated channel SID-1
+PF13966	zf-RVT	zinc-binding in reverse transcriptase
+PF13967	RSN1_TM	Late exocytosis, associated with Golgi transport 
+PF13968	DUF4220	Domain of unknown function (DUF4220)
+PF13969	Pab87_oct	Pab87 octamerisation domain
+PF13970	DUF4221	Domain of unknown function (DUF4221)
+PF13971	Mei4	Meiosis-specific protein Mei4
+PF13972	TetR	Bacterial transcriptional repressor
+PF13973	DUF4222	Domain of unknown function (DUF4222)
+PF13974	YebO	YebO-like protein
+PF13975	gag-asp_proteas	gag-polyprotein putative aspartyl protease
+PF13976	gag_pre-integrs	GAG-pre-integrase domain
+PF13977	TetR_C_6	BetI-type transcriptional repressor, C-terminal
+PF13978	DUF4223	Protein of unknown function (DUF4223)
+PF13979	SopA_C	SopA-like catalytic domain
+PF13980	UPF0370	Uncharacterised protein family (UPF0370)
+PF13981	SopA	SopA-like central domain
+PF13982	YbfN	YbfN-like lipoprotein
+PF13983	YsaB	YsaB-like lipoprotein
+PF13984	MsyB	MsyB protein
+PF13985	YbgS	YbgS-like protein
+PF13986	DUF4224	Domain of unknown function (DUF4224)
+PF13987	YedD	YedD-like protein
+PF13988	DUF4225	Protein of unknown function (DUF4225)
+PF13989	YejG	YejG-like protein
+PF13990	YjcZ	YjcZ-like protein
+PF13991	BssS	BssS protein family
+PF13992	YecR	YecR-like lipoprotein
+PF13993	YccJ	YccJ-like protein
+PF13994	PgaD	PgaD-like protein
+PF13995	YebF	YebF-like protein
+PF13996	YobH	YobH-like protein
+PF13997	YqjK	YqjK-like protein
+PF13998	MgrB	MgrB protein
+PF13999	MarB	MarB protein
+PF14000	Packaging_FI	DNA packaging protein FI
+PF14001	YdfZ	YdfZ protein
+PF14002	YniB	YniB-like protein
+PF14003	YlbE	YlbE-like protein
+PF14004	DUF4227	Protein of unknown function (DUF4227)
+PF14005	YpjP	YpjP-like protein
+PF14006	YqzL	YqzL-like protein
+PF14007	YtpI	YtpI-like protein
+PF14008	Metallophos_C	Iron/zinc purple acid phosphatase-like protein C
+PF14009	DUF4228	Domain of unknown function (DUF4228)
+PF14010	PEPcase_2	Phosphoenolpyruvate carboxylase
+PF14011	ESX-1_EspG	EspG family
+PF14012	DUF4229	Protein of unknown function (DUF4229)
+PF14013	MT0933_antitox	MT0933-like antitoxin protein
+PF14014	DUF4230	Protein of unknown function (DUF4230)
+PF14015	DUF4231	Protein of unknown function (DUF4231)
+PF14016	DUF4232	Protein of unknown function (DUF4232)
+PF14017	DUF4233	Protein of unknown function (DUF4233)
+PF14018	DUF4234	Domain of unknown function (DUF4234)
+PF14019	DUF4235	Protein of unknown function (DUF4235)
+PF14020	DUF4236	Protein of unknown function (DUF4236)
+PF14021	TNT	Tuberculosis necrotizing toxin
+PF14022	DUF4238	Protein of unknown function (DUF4238)
+PF14023	DUF4239	Protein of unknown function (DUF4239)
+PF14024	DUF4240	Protein of unknown function (DUF4240)
+PF14025	DUF4241	Protein of unknown function (DUF4241)
+PF14026	DUF4242	Protein of unknown function (DUF4242)
+PF14027	DUF4243	Protein of unknown function (DUF4243)
+PF14028	Lant_dehydr_C	Lantibiotic biosynthesis dehydratase C-term
+PF14029	DUF4244	Protein of unknown function (DUF4244)
+PF14030	DUF4245	Protein of unknown function (DUF4245)
+PF14031	D-ser_dehydrat	Putative serine dehydratase domain
+PF14032	PknH_C	PknH-like extracellular domain
+PF14033	DUF4246	Protein of unknown function (DUF4246)
+PF14034	Spore_YtrH	Sporulation protein YtrH
+PF14035	YlzJ	YlzJ-like protein
+PF14036	YlaH	YlaH-like protein
+PF14037	YoqO	YoqO-like protein
+PF14038	YqzE	YqzE-like protein
+PF14039	YusW	YusW-like protein
+PF14040	DNase_NucA_NucB	Deoxyribonuclease NucA/NucB
+PF14041	Lipoprotein_21	LppP/LprE lipoprotein
+PF14042	DUF4247	Domain of unknown function (DUF4247)
+PF14043	WVELL	WVELL protein
+PF14044	NETI	NETI protein
+PF14045	YIEGIA	YIEGIA protein
+PF14046	NR_Repeat	Nuclear receptor repeat
+PF14047	DCR	Dppa2/4 conserved region
+PF14048	MBD_C	C-terminal domain of methyl-CpG binding protein 2 and 3
+PF14049	Dppa2_A	Dppa2/4 conserved region in higher vertebrates
+PF14050	Nudc_N	N-terminal conserved domain of Nudc.
+PF14051	Requiem_N	N-terminal domain of DPF2/REQ.
+PF14052	Caps_assemb_Wzi	Capsule assembly protein Wzi
+PF14053	DUF4248	Domain of unknown function (DUF4248)
+PF14054	DUF4249	Domain of unknown function (DUF4249)
+PF14055	NVEALA	NVEALA protein
+PF14056	DUF4250	Domain of unknown function (DUF4250)
+PF14057	GGGtGRT	GGGtGRT protein
+PF14058	PcfK	PcfK-like protein
+PF14059	DUF4251	Domain of unknown function (DUF4251)
+PF14060	DUF4252	Domain of unknown function (DUF4252)
+PF14061	Mtf2_C	Polycomb-like MTF2 factor 2
+PF14062	DUF4253	Domain of unknown function (DUF4253)
+PF14063	DUF4254	Protein of unknown function (DUF4254)
+PF14064	HmuY	HmuY protein
+PF14065	DUF4255	Protein of unknown function (DUF4255)
+PF14066	DUF4256	Protein of unknown function (DUF4256)
+PF14067	LssY_C	LssY C-terminus
+PF14068	YuiB	Putative membrane protein
+PF14069	SpoVIF	Stage VI sporulation protein F
+PF14070	YjfB_motility	Putative motility protein
+PF14071	YlbD_coat	Putative coat protein
+PF14072	DndB	DNA-sulfur modification-associated
+PF14073	Cep57_CLD	Centrosome localisation domain of Cep57
+PF14074	DUF4257	Protein of unknown function (DUF4257)
+PF14075	UBN_AB	Ubinuclein conserved middle domain
+PF14076	DUF4258	Domain of unknown function (DUF4258)
+PF14077	WD40_alt	Alternative WD40 repeat motif
+PF14078	DUF4259	Domain of unknown function (DUF4259)
+PF14079	DUF4260	Domain of unknown function (DUF4260)
+PF14080	DUF4261	Domain of unknown function (DUF4261)
+PF14081	DUF4262	Domain of unknown function (DUF4262)
+PF14082	DUF4263	Domain of unknown function (DUF4263)
+PF14083	PGDYG	PGDYG protein
+PF14084	DUF4264	Protein of unknown function (DUF4264)
+PF14085	DUF4265	Domain of unknown function (DUF4265)
+PF14086	DUF4266	Domain of unknown function (DUF4266)
+PF14087	DUF4267	Domain of unknown function (DUF4267)
+PF14088	DUF4268	Domain of unknown function (DUF4268)
+PF14089	KbaA	KinB-signalling pathway activation in sporulation
+PF14090	HTH_39	Helix-turn-helix domain
+PF14091	DUF4269	Domain of unknown function (DUF4269)
+PF14092	DUF4270	Domain of unknown function (DUF4270)
+PF14093	DUF4271	Domain of unknown function (DUF4271)
+PF14094	DUF4272	Domain of unknown function (DUF4272)
+PF14096	DUF4274	Domain of unknown function (DUF4274)
+PF14097	SpoVAE	Stage V sporulation protein AE1
+PF14098	SSPI	Small, acid-soluble spore protein I
+PF14099	Polysacc_lyase	Polysaccharide lyase
+PF14100	PmoA	Methane oxygenase PmoA
+PF14101	DUF4275	Domain of unknown function (DUF4275)
+PF14102	Caps_synth_CapC	Capsule biosynthesis CapC
+PF14103	DUF4276	Domain of unknown function (DUF4276)
+PF14104	DUF4277	Domain of unknown function (DUF4277)
+PF14105	DUF4278	Domain of unknown function (DUF4278)
+PF14106	DUF4279	Domain of unknown function (DUF4279)
+PF14107	DUF4280	Domain of unknown function (DUF4280)
+PF14108	DUF4281	Domain of unknown function (DUF4281)
+PF14109	GldH_lipo	GldH lipoprotein
+PF14110	DUF4282	Domain of unknown function (DUF4282)
+PF14111	DUF4283	Domain of unknown function (DUF4283)
+PF14112	DUF4284	Immunity protein 22
+PF14113	Tae4	Type VI secretion system (T6SS), amidase effector protein 4
+PF14114	DUF4286	Domain of unknown function (DUF4286)
+PF14115	YuzL	YuzL-like protein
+PF14116	YyzF	YyzF-like protein
+PF14117	DUF4287	Domain of unknown function (DUF4287)
+PF14118	YfzA	YfzA-like protein
+PF14119	DUF4288	Domain of unknown function (DUF4288)
+PF14120	YhzD	YhzD-like protein
+PF14121	Porin_10	Putative porin
+PF14122	YokU	YokU-like protein, putative antitoxin
+PF14123	DUF4290	Domain of unknown function (DUF4290)
+PF14124	DUF4291	Domain of unknown function (DUF4291)
+PF14125	DUF4292	Domain of unknown function (DUF4292)
+PF14126	DUF4293	Domain of unknown function (DUF4293)
+PF14127	DUF4294	Domain of unknown function (DUF4294)
+PF14128	DUF4295	Domain of unknown function (DUF4295)
+PF14129	DUF4296	Domain of unknown function (DUF4296)
+PF14130	DUF4297	Domain of unknown function (DUF4297)
+PF14131	DUF4298	Domain of unknown function (DUF4298)
+PF14132	DUF4299	Domain of unknown function (DUF4299)
+PF14133	DUF4300	Domain of unknown function (DUF4300)
+PF14134	DUF4301	Domain of unknown function (DUF4301)
+PF14135	DUF4302	Domain of unknown function (DUF4302)
+PF14136	DUF4303	Domain of unknown function (DUF4303)
+PF14137	DUF4304	Domain of unknown function (DUF4304)
+PF14138	COX16	Cytochrome c oxidase assembly protein COX16
+PF14139	YpzG	YpzG-like protein
+PF14140	YpzI	YpzI-like protein
+PF14141	YqzM	YqzM-like protein
+PF14142	YrzO	YrzO-like protein
+PF14143	YrhC	YrhC-like protein
+PF14144	DOG1	Seed dormancy control
+PF14145	YrhK	YrhK-like protein
+PF14146	DUF4305	Domain of unknown function (DUF4305)
+PF14147	Spore_YhaL	Sporulation protein YhaL
+PF14148	YhdB	YhdB-like protein
+PF14149	YhfH	YhfH-like protein
+PF14150	YesK	YesK-like protein
+PF14151	YfhD	YfhD-like protein
+PF14152	YfhE	YfhE-like protein
+PF14153	Spore_coat_CotO	Spore coat protein CotO
+PF14154	DUF4306	Domain of unknown function (DUF4306)
+PF14155	DUF4307	Domain of unknown function (DUF4307)
+PF14156	AbbA_antirepres	Antirepressor AbbA
+PF14157	YmzC	YmzC-like protein
+PF14158	YndJ	YndJ-like protein
+PF14159	CAAD	CAAD domains of cyanobacterial aminoacyl-tRNA synthetase
+PF14160	FAM110_C	Centrosome-associated C terminus
+PF14161	FAM110_N	Centrosome-associated N terminus
+PF14162	YozD	YozD-like protein
+PF14163	SieB	Super-infection exclusion protein B
+PF14164	YqzH	YqzH-like protein
+PF14165	YtzH	YtzH-like protein
+PF14166	YueH	YueH-like protein
+PF14167	YfkD	YfkD-like protein
+PF14168	YjzC	YjzC-like protein
+PF14169	YdjO	Cold-inducible protein YdjO
+PF14171	SpoIISA_toxin	Toxin SpoIISA, type II toxin-antitoxin system
+PF14172	DUF4309	Domain of unknown function (DUF4309)
+PF14173	ComGG	ComG operon protein 7
+PF14174	YycC	YycC-like protein
+PF14175	YaaC	YaaC-like Protein
+PF14176	YxiJ	YxiJ-like protein
+PF14177	YkyB	YkyB-like protein
+PF14178	YppF	YppF-like protein
+PF14179	YppG	YppG-like protein
+PF14181	YqfQ	YqfQ-like protein
+PF14182	YgaB	YgaB-like protein
+PF14183	YwpF	YwpF-like protein
+PF14184	YrvL	Regulatory protein YrvL
+PF14185	SpoIISB_antitox	Antitoxin SpoIISB, type II toxin-antitoxin system 
+PF14186	Aida_C2	Cytoskeletal adhesion
+PF14187	DUF4310	Domain of unknown function (DUF4310)
+PF14188	DUF4311	Domain of unknown function (DUF4311)
+PF14189	DUF4312	Domain of unknown function (DUF4312)
+PF14190	DUF4313	Domain of unknown function (DUF4313)
+PF14191	YodL	YodL-like
+PF14192	DUF4314	Domain of unknown function (DUF4314)
+PF14193	DUF4315	Domain of unknown function (DUF4315)
+PF14194	Cys_rich_VLP	Cysteine-rich VLP
+PF14195	DUF4316	Domain of unknown function (DUF4316)
+PF14196	ATC_hydrolase	L-2-amino-thiazoline-4-carboxylic acid hydrolase
+PF14197	Cep57_CLD_2	Centrosome localisation domain of PPC89 
+PF14198	TnpV	Transposon-encoded protein TnpV
+PF14199	DUF4317	Domain of unknown function (DUF4317)
+PF14200	RicinB_lectin_2	Ricin-type beta-trefoil lectin domain-like
+PF14201	DUF4318	Domain of unknown function (DUF4318)
+PF14202	TnpW	Transposon-encoded protein TnpW
+PF14203	TTRAP	Putative tranposon-transfer assisting protein
+PF14204	Ribosomal_L18_c	Ribosomal L18 C-terminal region
+PF14205	Cys_rich_KTR	Cysteine-rich KTR
+PF14206	Cys_rich_CPCC	Cysteine-rich CPCC
+PF14207	DpnD-PcfM	DpnD/PcfM-like protein
+PF14208	DUF4320	Domain of unknown function (DUF4320)
+PF14209	DUF4321	Domain of unknown function (DUF4321)
+PF14210	DUF4322	Domain of unknown function (DUF4322)
+PF14213	DUF4325	STAS-like domain of unknown function (DUF4325)
+PF14214	Helitron_like_N	Helitron helicase-like domain at N-terminus
+PF14215	bHLH-MYC_N	bHLH-MYC and R2R3-MYB transcription factors N-terminal
+PF14216	DUF4326	Domain of unknown function (DUF4326)
+PF14217	DUF4327	Domain of unknown function (DUF4327)
+PF14218	COP23	Circadian oscillating protein COP23
+PF14219	DUF4328	Domain of unknown function (DUF4328)
+PF14220	DUF4329	Domain of unknown function (DUF4329)
+PF14221	DUF4330	Domain of unknown function (DUF4330)
+PF14222	MOR2-PAG1_N	Cell morphogenesis N-terminal
+PF14223	Retrotran_gag_2	gag-polypeptide of LTR copia-type
+PF14224	DUF4331	Domain of unknown function (DUF4331)
+PF14225	MOR2-PAG1_C	Cell morphogenesis C-terminal
+PF14226	DIOX_N	non-haem dioxygenase in morphine synthesis N-terminal
+PF14228	MOR2-PAG1_mid	Cell morphogenesis central region
+PF14229	DUF4332	Domain of unknown function (DUF4332)
+PF14230	DUF4333	Domain of unknown function (DUF4333)
+PF14231	GXWXG	GXWXG protein
+PF14232	DUF4334	Domain of unknown function (DUF4334)
+PF14233	DUF4335	Domain of unknown function (DUF4335)
+PF14234	DUF4336	Domain of unknown function (DUF4336)
+PF14235	DUF4337	Domain of unknown function (DUF4337)
+PF14236	DUF4338	Domain of unknown function (DUF4338)
+PF14237	DUF4339	Domain of unknown function (DUF4339)
+PF14238	DUF4340	Domain of unknown function (DUF4340)
+PF14239	RRXRR	RRXRR protein
+PF14240	YHYH	YHYH protein
+PF14242	DUF4342	Domain of unknown function (DUF4342)
+PF14243	DUF4343	Domain of unknown function (DUF4343)
+PF14244	Retrotran_gag_3	gag-polypeptide of LTR copia-type
+PF14245	Pilin_PilA	Type IV pilin PilA
+PF14246	TetR_C_7	AefR-like transcriptional repressor, C-terminal region
+PF14247	DUF4344	Putative metallopeptidase
+PF14248	DUF4345	Domain of unknown function (DUF4345)
+PF14249	Tocopherol_cycl	Tocopherol cyclase
+PF14250	AbrB-like	AbrB-like transcriptional regulator
+PF14251	DUF4346	Domain of unknown function (DUF4346)
+PF14252	DUF4347	Domain of unknown function (DUF4347)
+PF14253	AbiH	Bacteriophage abortive infection AbiH
+PF14254	DUF4348	Domain of unknown function (DUF4348)
+PF14255	Cys_rich_CPXG	Cysteine-rich CPXCG
+PF14256	YwiC	YwiC-like protein
+PF14257	DUF4349	Domain of unknown function (DUF4349)
+PF14258	DUF4350	Domain of unknown function (DUF4350)
+PF14260	zf-C4pol	C4-type zinc-finger of DNA polymerase delta
+PF14261	DUF4351	Domain of unknown function (DUF4351)
+PF14262	Cthe_2159	Carbohydrate-binding domain-containing protein Cthe_2159
+PF14263	DUF4354	Domain of unknown function (DUF4354)
+PF14264	Glucos_trans_II	Glucosyl transferase GtrII
+PF14265	DUF4355	Domain of unknown function (DUF4355)
+PF14266	YceG_bac	Putative component of 'biosynthetic module'
+PF14267	DUF4357	Domain of unknown function (DUF4357)
+PF14268	YoaP	YoaP-like
+PF14269	Arylsulfotran_2	Arylsulfotransferase (ASST)
+PF14270	DUF4358	Domain of unknown function (DUF4358)
+PF14271	DUF4359	Domain of unknown function (DUF4359)
+PF14272	Gly_rich_SFCGS	Glycine-rich SFCGS
+PF14273	DUF4360	Domain of unknown function (DUF4360)
+PF14274	DUF4361	Domain of unknown function (DUF4361)
+PF14275	DUF4362	Domain of unknown function (DUF4362)
+PF14276	DUF4363	Domain of unknown function (DUF4363)
+PF14277	DUF4364	Domain of unknown function (DUF4364)
+PF14278	TetR_C_8	Transcriptional regulator C-terminal region
+PF14279	HNH_5	HNH endonuclease
+PF14280	DUF4365	Domain of unknown function (DUF4365)
+PF14281	PDDEXK_4	PD-(D/E)XK nuclease superfamily
+PF14282	FlxA	FlxA-like protein
+PF14283	DUF4366	Domain of unknown function (DUF4366)
+PF14284	PcfJ	PcfJ-like protein
+PF14285	DUF4367	Domain of unknown function (DUF4367)
+PF14286	DHHW	DHHW protein
+PF14287	DUF4368	Domain of unknown function (DUF4368)
+PF14288	FKS1_dom1	1,3-beta-glucan synthase subunit FKS1, domain-1
+PF14289	DUF4369	Domain of unknown function (DUF4369)
+PF14290	DUF4370	Domain of unknown function (DUF4370)
+PF14291	DUF4371	Domain of unknown function (DUF4371)
+PF14292	SusE	SusE outer membrane protein
+PF14293	YWFCY	YWFCY protein
+PF14294	DUF4372	Domain of unknown function (DUF4372)
+PF14295	PAN_4	PAN domain
+PF14296	O-ag_pol_Wzy	O-antigen polysaccharide polymerase Wzy
+PF14297	DUF4373	Domain of unknown function (DUF4373)
+PF14298	DUF4374	Domain of unknown function (DUF4374)
+PF14299	PP2	Phloem protein 2
+PF14300	DUF4375	Domain of unknown function (DUF4375)
+PF14301	DUF4376	Domain of unknown function (DUF4376)
+PF14302	DUF4377	Domain of unknown function (DUF4377)
+PF14303	NAM-associated	No apical meristem-associated C-terminal domain
+PF14304	CSTF_C	Transcription termination and cleavage factor C-terminal
+PF14305	ATPgrasp_TupA	TupA-like ATPgrasp
+PF14306	PUA_2	PUA-like domain
+PF14307	Glyco_tran_WbsX	Glycosyltransferase WbsX
+PF14308	DnaJ-X	X-domain of DnaJ-containing
+PF14309	DUF4378	Domain of unknown function (DUF4378)
+PF14310	Fn3-like	Fibronectin type III-like domain
+PF14311	DUF4379	Probable Zinc-ribbon domain
+PF14312	FG-GAP_2	FG-GAP repeat
+PF14313	Soyouz_module	N-terminal region of Paramyxovirinae phosphoprotein (P)
+PF14314	Methyltrans_Mon	Virus-capping methyltransferase
+PF14315	DUF4380	Domain of unknown function (DUF4380)
+PF14316	DUF4381	Domain of unknown function (DUF4381)
+PF14317	YcxB	YcxB-like protein
+PF14318	Mononeg_mRNAcap	Mononegavirales mRNA-capping region V
+PF14319	Zn_Tnp_IS91	Transposase zinc-binding domain
+PF14320	Paramyxo_PCT	Phosphoprotein P region PCT disordered
+PF14321	DUF4382	Domain of unknown function (DUF4382)
+PF14322	SusD-like_3	Starch-binding associating with outer membrane
+PF14323	GxGYxYP_C	GxGYxYP putative glycoside hydrolase C-terminal domain
+PF14324	PINIT	PINIT domain
+PF14325	DUF4383	Domain of unknown function (DUF4383)
+PF14326	DUF4384	Domain of unknown function (DUF4384)
+PF14327	CSTF2_hinge	Hinge domain of cleavage stimulation factor subunit 2
+PF14328	DUF4385	Domain of unknown function (DUF4385)
+PF14329	DUF4386	Domain of unknown function (DUF4386)
+PF14330	DUF4387	Domain of unknown function (DUF4387)
+PF14331	ImcF-related_N	ImcF-related N-terminal domain
+PF14332	DUF4388	Domain of unknown function (DUF4388)
+PF14333	DUF4389	Domain of unknown function (DUF4389)
+PF14334	DUF4390	Domain of unknown function (DUF4390)
+PF14335	DUF4391	Domain of unknown function (DUF4391)
+PF14336	DUF4392	Domain of unknown function (DUF4392)
+PF14337	DUF4393	Domain of unknown function (DUF4393)
+PF14338	Mrr_N	Mrr N-terminal domain
+PF14339	DUF4394	Domain of unknown function (DUF4394)
+PF14340	DUF4395	Domain of unknown function (DUF4395)
+PF14341	PilX_N	PilX N-terminal
+PF14342	DUF4396	Domain of unknown function (DUF4396)
+PF14343	PrcB_C	PrcB C-terminal
+PF14344	DUF4397	Domain of unknown function (DUF4397)
+PF14345	GDYXXLXY	GDYXXLXY protein
+PF14346	DUF4398	Domain of unknown function (DUF4398)
+PF14347	DUF4399	Domain of unknown function (DUF4399)
+PF14348	DUF4400	Domain of unknown function (DUF4400)
+PF14349	SprA_N	Motility related/secretion protein
+PF14350	Beta_protein	Beta protein
+PF14351	DUF4401	Domain of unknown function (DUF4401)
+PF14352	DUF4402	Domain of unknown function (DUF4402)
+PF14353	CpXC	CpXC protein
+PF14354	Lar_restr_allev	Restriction alleviation protein Lar
+PF14355	Abi_C	Abortive infection C-terminus
+PF14356	DUF4403	Domain of unknown function (DUF4403)
+PF14357	DUF4404	Domain of unknown function (DUF4404)
+PF14358	DUF4405	Domain of unknown function (DUF4405)
+PF14359	DUF4406	Domain of unknown function (DUF4406)
+PF14360	PAP2_C	PAP2 superfamily C-terminal
+PF14361	RsbRD_N	RsbT co-antagonist protein rsbRD N-terminal domain
+PF14362	DUF4407	Domain of unknown function (DUF4407)
+PF14363	AAA_assoc	Domain associated at C-terminal with AAA
+PF14364	DUF4408	Domain of unknown function (DUF4408)
+PF14365	Neprosin_AP	Neprosin activation peptide
+PF14366	DUF4410	Domain of unknown function (DUF4410)
+PF14367	DUF4411	Domain of unknown function (DUF4411)
+PF14368	LTP_2	Probable lipid transfer
+PF14369	zinc_ribbon_9	zinc-ribbon
+PF14370	Topo_C_assoc	C-terminal topoisomerase domain
+PF14371	DUF4412	Domain of unknown function (DUF4412)
+PF14372	DUF4413	Domain of unknown function (DUF4413)
+PF14373	Imm_superinfect	Superinfection immunity protein
+PF14374	Ribos_L4_asso_C	60S ribosomal protein L4 C-terminal domain
+PF14375	Cys_rich_CWC	Cysteine-rich CWC
+PF14376	Haem_bd	Haem-binding domain
+PF14377	DUF4414	Domain of unknown function (DUF4414)
+PF14378	PAP2_3	PAP2 superfamily
+PF14379	Myb_CC_LHEQLE	MYB-CC type transfactor, LHEQLE motif
+PF14380	WAK_assoc	Wall-associated receptor kinase C-terminal
+PF14381	EDR1	Ethylene-responsive protein kinase Le-CTR1
+PF14382	ECR1_N	Exosome complex exonuclease RRP4 N-terminal region
+PF14383	VARLMGL	DUF761-associated sequence motif 
+PF14384	BrnA_antitoxin	BrnA antitoxin of type II toxin-antitoxin system
+PF14385	DUF4416	Domain of unknown function (DUF4416)
+PF14386	DUF4417	Domain of unknown function (DUF4417)
+PF14387	DUF4418	Domain of unknown function (DUF4418)
+PF14388	DUF4419	Domain of unknown function (DUF4419)
+PF14389	Lzipper-MIP1	Leucine-zipper of ternary complex factor MIP1
+PF14390	DUF4420	Putative  PD-(D/E)XK family member, (DUF4420)
+PF14391	DUF4421	Domain of unknown function (DUF4421)
+PF14392	zf-CCHC_4	Zinc knuckle
+PF14393	DUF4422	Domain of unknown function (DUF4422)
+PF14394	DUF4423	Domain of unknown function (DUF4423)
+PF14395	COOH-NH2_lig	Phage phiEco32-like COOH.NH2 ligase-type 2
+PF14396	CFTR_R	Cystic fibrosis TM conductance regulator (CFTR), regulator domain
+PF14397	ATPgrasp_ST	Sugar-transfer associated ATP-grasp
+PF14398	ATPgrasp_YheCD	YheC/D like ATP-grasp
+PF14399	BtrH_N	Butirosin biosynthesis protein H, N-terminal
+PF14400	Transglut_i_TM	Inactive transglutaminase fused to 7 transmembrane helices
+PF14401	RLAN	RimK-like ATPgrasp N-terminal domain
+PF14402	7TM_transglut	7 transmembrane helices usually fused to an inactive transglutaminase
+PF14403	CP_ATPgrasp_2	Circularly permuted ATP-grasp type 2 
+PF14404	Strep_pep	Ribosomally synthesized peptide in Streptomyces species
+PF14406	Bacteroid_pep	Ribosomally synthesized peptide in Bacteroidetes
+PF14407	Frankia_peptide	Ribosomally synthesized peptide prototyped by Frankia Franean1_4349.
+PF14408	Actino_peptide	Ribosomally synthesised peptide in actinomycetes
+PF14409	Herpeto_peptide	Ribosomally synthesized peptide in Herpetosiphon
+PF14410	GH-E	HNH/ENDO VII superfamily nuclease with conserved GHE residues
+PF14411	LHH	A nuclease of the HNH/ENDO VII superfamily with conserved LHH
+PF14412	AHH	A nuclease family of the HNH/ENDO VII superfamily with conserved AHH
+PF14413	Thg1C	Thg1 C terminal domain
+PF14414	WHH	A nuclease of the HNH/ENDO VII superfamily with conserved WHH
+PF14415	DUF4424	Domain of unknown function (DUF4424)
+PF14416	PMR5N	PMR5 N terminal Domain
+PF14417	MEDS	MEDS: MEthanogen/methylotroph, DcmR Sensory domain
+PF14418	OHA	OST-HTH Associated domain
+PF14419	SPOUT_MTase_2	AF2226-like SPOUT RNA Methylase fused to THUMP
+PF14420	Clr5	Clr5 domain
+PF14421	LmjF365940-deam	A distinct subfamily of CDD/CDA-like deaminases
+PF14423	Imm5	Immunity protein Imm5
+PF14424	Toxin-deaminase	The  BURPS668_1122 family of deaminases
+PF14425	Imm3	Immunity protein Imm3
+PF14426	Imm2	Immunity protein Imm2
+PF14427	Pput2613-deam	Pput_2613-like deaminase
+PF14428	SCP1201-deam	SCP1.201-like deaminase
+PF14429	DOCK-C2	C2 domain in Dock180 and Zizimin proteins
+PF14430	Imm1	Immunity protein Imm1
+PF14431	YwqJ-deaminase	YwqJ-like deaminase
+PF14432	DYW_deaminase	DYW family of nucleic acid deaminases
+PF14433	SUKH-3	SUKH-3 immunity protein
+PF14434	Imm6	Immunity protein Imm6
+PF14435	SUKH-4	SUKH-4 immunity protein
+PF14436	EndoU_bacteria	Bacterial EndoU nuclease
+PF14437	MafB19-deam	MafB19-like deaminase
+PF14438	SM-ATX	Ataxin 2 SM domain
+PF14439	Bd3614-deam	Bd3614-like deaminase
+PF14440	XOO_2897-deam	Xanthomonas XOO_2897-like deaminase
+PF14441	OTT_1508_deam	OTT_1508-like deaminase
+PF14442	Bd3614_N	Bd3614-like deaminase N-terminal
+PF14443	DBC1	DBC1
+PF14444	S1-like	S1-like
+PF14445	Prok-RING_2	Prokaryotic RING finger family 2
+PF14446	Prok-RING_1	Prokaryotic RING finger family 1
+PF14447	Prok-RING_4	Prokaryotic RING finger family 4
+PF14448	Nuc_N	Nuclease N terminal
+PF14449	PT-TG	Pre-toxin TG
+PF14450	FtsA	Cell division protein FtsA
+PF14451	Ub-Mut7C	Mut7-C ubiquitin
+PF14452	Multi_ubiq	Multiubiquitin
+PF14453	ThiS-like	ThiS-like ubiquitin 
+PF14454	Prok_Ub	Prokaryotic Ubiquitin
+PF14455	Metal_CEHH	Predicted metal binding domain
+PF14456	alpha-hel2	Alpha-helical domain 2
+PF14457	Prok-E2_A	Prokaryotic E2 family A
+PF14459	Prok-E2_C	Prokaryotic E2 family C
+PF14460	Prok-E2_D	Prokaryotic E2 family D
+PF14461	Prok-E2_B	Prokaryotic E2 family B
+PF14462	Prok-E2_E	Prokaryotic E2 family E
+PF14463	E1-N	E1 N-terminal domain
+PF14464	Prok-JAB	Prokaryotic homologs of the JAB domain
+PF14465	NFRKB_winged	NFRKB Winged Helix-like
+PF14466	PLCC	PLAT/LH2 and C2-like Ca2+-binding lipoprotein
+PF14467	DUF4426	Domain of unknown function (DUF4426)
+PF14468	DUF4427	Protein of unknown function (DUF4427)
+PF14469	AKAP28	28 kDa A-kinase anchor 
+PF14470	bPH_3	Bacterial PH domain
+PF14471	DUF4428	Domain of unknown function (DUF4428)
+PF14472	DUF4429	Domain of unknown function (DUF4429)
+PF14473	RD3	RD3 protein
+PF14474	RTC4	RTC4-like domain
+PF14475	Mso1_Sec1_bdg	Sec1-binding region of Mso1
+PF14476	Chloroplast_duf	Petal formation-expressed
+PF14477	Mso1_C	Membrane-polarising domain of Mso1
+PF14478	DUF4430	Domain of unknown function (DUF4430)
+PF14479	HeLo	Prion-inhibition and propagation
+PF14480	DNA_pol3_a_NI	DNA polymerase III polC-type N-terminus I
+PF14481	Fimbrial_PilY2	Type 4 fimbrial biogenesis protein PilY2
+PF14484	FISNA	Fish-specific NACHT associated domain
+PF14485	DUF4431	Domain of unknown function (DUF4431)
+PF14486	DUF4432	Domain of unknown function (DUF4432)
+PF14487	DUF4433	Domain of unknown function (DUF4433)
+PF14488	DUF4434	Domain of unknown function (DUF4434)
+PF14489	QueF	QueF-like protein
+PF14490	HHH_4	Helix-hairpin-helix containing domain
+PF14491	DUF4435	Protein of unknown function (DUF4435)
+PF14492	EFG_II	Elongation Factor G, domain II
+PF14493	HTH_40	Helix-turn-helix domain
+PF14494	DUF4436	Domain of unknown function (DUF4436)
+PF14495	Cytochrom_C550	Cytochrome c-550 domain
+PF14496	NEL	C-terminal novel E3 ligase, LRR-interacting
+PF14497	GST_C_3	Glutathione S-transferase, C-terminal domain
+PF14498	Glyco_hyd_65N_2	Glycosyl hydrolase family 65, N-terminal domain
+PF14499	DUF4437	Domain of unknown function (DUF4437)
+PF14500	MMS19_N	Dos2-interacting transcription regulator of RNA-Pol-II
+PF14501	HATPase_c_5	GHKL domain
+PF14502	HTH_41	Helix-turn-helix domain
+PF14503	YhfZ_C	YhfZ C-terminal domain
+PF14504	CAP_assoc_N	CAP-associated N-terminal
+PF14505	DUF4438	Domain of unknown function (DUF4438)
+PF14506	CppA_N	CppA N-terminal
+PF14507	CppA_C	CppA C-terminal
+PF14508	GH97_N	Glycosyl-hydrolase 97 N-terminal
+PF14509	GH97_C	Glycosyl-hydrolase 97 C-terminal, oligomerisation
+PF14510	ABC_trans_N	ABC-transporter extracellular N-terminal
+PF14511	RE_EcoO109I	Type II restriction endonuclease EcoO109I
+PF14512	TM1586_NiRdase	Putative TM nitroreductase
+PF14513	DAG_kinase_N	Diacylglycerol kinase N-terminus
+PF14514	TetR_C_9	Transcriptional regulator, TetR, C-terminal
+PF14515	HOASN	Haem-oxygenase-associated N-terminal helices
+PF14516	AAA_35	AAA-like domain
+PF14517	Tachylectin	Tachylectin
+PF14518	Haem_oxygenas_2	Iron-containing redox enzyme
+PF14519	Macro_2	Macro-like domain
+PF14520	HHH_5	Helix-hairpin-helix domain
+PF14521	Aspzincin_M35	Lysine-specific metallo-endopeptidase 
+PF14522	Cytochrome_C7	Cytochrome c7 and related cytochrome c
+PF14523	Syntaxin_2	Syntaxin-like protein
+PF14524	Wzt_C	Wzt C-terminal domain
+PF14525	AraC_binding_2	AraC-binding-like domain
+PF14526	Cass2	Integron-associated effector binding protein
+PF14527	LAGLIDADG_WhiA	WhiA LAGLIDADG-like domain
+PF14528	LAGLIDADG_3	LAGLIDADG-like domain
+PF14529	Exo_endo_phos_2	Endonuclease-reverse transcriptase 
+PF14530	DUF4439	Domain of unknown function (DUF4439)
+PF14531	Kinase-like	Kinase-like
+PF14532	Sigma54_activ_2	Sigma-54 interaction domain
+PF14533	USP7_C2	Ubiquitin-specific protease C-terminal
+PF14534	DUF4440	Domain of unknown function (DUF4440)
+PF14535	AMP-binding_C_2	AMP-binding enzyme C-terminal domain
+PF14536	DUF4441	Domain of unknown function (DUF4441)
+PF14537	Cytochrom_c3_2	Cytochrome c3
+PF14538	Raptor_N	Raptor N-terminal CASPase like domain
+PF14539	DUF4442	Domain of unknown function (DUF4442)
+PF14540	NTF-like	Nucleotidyltransferase-like
+PF14541	TAXi_C	Xylanase inhibitor C-terminal
+PF14542	Acetyltransf_CG	GCN5-related N-acetyl-transferase
+PF14543	TAXi_N	Xylanase inhibitor N-terminal
+PF14544	DUF4443	Domain of unknown function (DUF4443)
+PF14545	DBB	Dof, BCAP, and BANK (DBB) motif,
+PF14547	Hydrophob_seed	Hydrophobic seed protein
+PF14549	P22_Cro	DNA-binding transcriptional regulator Cro
+PF14550	Peptidase_S78_2	Putative phage serine protease XkdF
+PF14551	MCM_N	MCM N-terminal domain
+PF14552	Tautomerase_2	Tautomerase enzyme
+PF14553	YqbF	YqbF, hypothetical protein domain
+PF14554	VEGF_C	VEGF heparin-binding domain
+PF14555	UBA_4	UBA-like domain
+PF14556	AF2331-like	AF2331-like
+PF14557	AphA_like	Putative AphA-like transcriptional regulator
+PF14558	TRP_N	ML-like domain
+PF14559	TPR_19	Tetratricopeptide repeat
+PF14560	Ubiquitin_2	Ubiquitin-like domain
+PF14561	TPR_20	Tetratricopeptide repeat
+PF14562	Endonuc_BglI	Restriction endonuclease BglI
+PF14563	DUF4444	Domain of unknown function (DUF4444)
+PF14564	Membrane_bind	Membrane binding
+PF14565	IL22	Interleukin 22 IL-10-related T-cell-derived-inducible factor
+PF14566	PTPlike_phytase	Inositol hexakisphosphate
+PF14567	SUKH_5	SMI1-KNR4 cell-wall
+PF14568	SUKH_6	SMI1-KNR4 cell-wall
+PF14569	zf-UDP	Zinc-binding RING-finger
+PF14570	zf-RING_4	RING/Ubox like zinc-binding domain
+PF14571	Di19_C	Stress-induced protein Di19, C-terminal
+PF14572	Pribosyl_synth	Phosphoribosyl synthetase-associated domain
+PF14573	PP-binding_2	Acyl-carrier
+PF14574	DUF4445	Domain of unknown function (DUF4445)
+PF14575	EphA2_TM	Ephrin type-A receptor 2 transmembrane domain
+PF14576	SEO_N	Sieve element occlusion N-terminus
+PF14577	SEO_C	Sieve element occlusion C-terminus
+PF14578	GTP_EFTU_D4	Elongation factor Tu domain 4
+PF14579	HHH_6	Helix-hairpin-helix motif
+PF14580	LRR_9	Leucine-rich repeat
+PF14581	SseB_C	SseB protein C-terminal domain
+PF14582	Metallophos_3	Metallophosphoesterase, calcineurin superfamily
+PF14583	Pectate_lyase22	Oligogalacturonate lyase
+PF14584	DUF4446	Protein of unknown function (DUF4446)
+PF14585	CagY_I	CagY type 1 repeat
+PF14586	MHC_I_2	Class I Histocompatibility antigen, NKG2D ligand, domains 1 and 2
+PF14587	Glyco_hydr_30_2	O-Glycosyl hydrolase family 30
+PF14588	YjgF_endoribonc	YjgF/chorismate_mutase-like, putative endoribonuclease
+PF14589	NrfD_2	Polysulfide reductase
+PF14590	DUF4447	Domain of unknown function (DUF4447)
+PF14591	AF0941-like	AF0941-like
+PF14592	Chondroitinas_B	Chondroitinase B
+PF14593	PH_3	PH domain
+PF14594	Sipho_Gp37	Siphovirus ReqiPepy6 Gp37-like protein
+PF14595	Thioredoxin_9	Thioredoxin
+PF14596	STAT6_C	STAT6 C-terminal
+PF14597	Lactamase_B_5	Metallo-beta-lactamase superfamily
+PF14598	PAS_11	PAS domain
+PF14599	zinc_ribbon_6	Zinc-ribbon
+PF14600	CBM_5_12_2	Cellulose-binding domain
+PF14601	TFX_C	DNA_binding protein, TFX, C-term
+PF14602	Hexapep_2	Hexapeptide repeat of succinyl-transferase
+PF14603	hSH3	Helically-extended SH3 domain
+PF14604	SH3_9	Variant SH3 domain
+PF14605	Nup35_RRM_2	Nup53/35/40-type RNA recognition motif
+PF14606	Lipase_GDSL_3	GDSL-like Lipase/Acylhydrolase family
+PF14607	GxDLY	N-terminus of Esterase_SGNH_hydro-type
+PF14608	zf-CCCH_2	RNA-binding, Nab2-type zinc finger
+PF14609	GCP5-Mod21	gamma-Tubulin ring complex non-core subunit mod21 
+PF14610	DUF4448	Protein of unknown function (DUF4448)
+PF14611	SLS	Mitochondrial inner-membrane-bound regulator
+PF14612	Ino80_Iec3	IEC3 subunit of the Ino80 complex, chromatin re-modelling
+PF14613	DUF4449	Protein of unknown function (DUF4449)
+PF14614	DUF4450	Domain of unknown function (DUF4450)
+PF14615	Rsa3	Ribosome-assembly protein 3
+PF14616	DUF4451	Domain of unknown function (DUF4451)
+PF14617	CMS1	U3-containing 90S pre-ribosomal complex subunit
+PF14618	DUF4452	Domain of unknown function (DUF4452)
+PF14619	SnAC	Snf2-ATP coupling, chromatin remodelling complex
+PF14620	YPEB	YpeB sporulation
+PF14621	RFX5_DNA_bdg	RFX5 DNA-binding domain
+PF14622	Ribonucleas_3_3	Ribonuclease-III-like
+PF14623	Vint	Hint-domain
+PF14624	Vwaint	VWA / Hh  protein intein-like
+PF14625	Lustrin_cystein	Lustrin, cysteine-rich repeated domain
+PF14626	RNase_Zc3h12a_2	Zc3h12a-like Ribonuclease NYN domain
+PF14627	DUF4453	Domain of unknown function (DUF4453)
+PF14628	DUF4454	Domain of unknown function (DUF4454)
+PF14629	ORC4_C	Origin recognition complex (ORC) subunit 4 C-terminus
+PF14630	ORC5_C	Origin recognition complex (ORC) subunit 5 C-terminus
+PF14631	FancD2	Fanconi anaemia protein FancD2 nuclease
+PF14632	SPT6_acidic	Acidic N-terminal SPT6
+PF14633	SH2_2	SH2 domain
+PF14634	zf-RING_5	zinc-RING finger domain
+PF14635	HHH_7	Helix-hairpin-helix motif                       
+PF14636	FNIP_N	Folliculin-interacting protein N-terminus
+PF14637	FNIP_M	Folliculin-interacting protein middle domain
+PF14638	FNIP_C	Folliculin-interacting protein C-terminus
+PF14639	YqgF	Holliday-junction resolvase-like of SPT6 
+PF14640	TMEM223	Transmembrane protein 223
+PF14641	HTH_44	Helix-turn-helix DNA-binding domain of SPT6
+PF14642	FAM47	FAM47 family
+PF14643	DUF4455	Domain of unknown function (DUF4455)
+PF14644	DUF4456	Domain of unknown function (DUF4456)
+PF14645	Chibby	Chibby family
+PF14646	MYCBPAP	MYCBP-associated protein family
+PF14647	FAM91_N	FAM91 N-terminus
+PF14648	FAM91_C	FAM91 C-terminus
+PF14649	Spatacsin_C	Spatacsin C-terminus
+PF14650	FAM75	FAM75 family
+PF14651	Lipocalin_7	Lipocalin / cytosolic fatty-acid binding protein family
+PF14652	DUF4457	Domain of unknown function (DUF4457)
+PF14653	IGFL	Insulin growth factor-like family
+PF14654	Epiglycanin_C	Mucin, catalytic, TM and cytoplasmic tail region
+PF14655	RAB3GAP2_N	Rab3 GTPase-activating protein regulatory subunit N-terminus
+PF14656	RAB3GAP2_C	Rab3 GTPase-activating protein regulatory subunit C-terminus
+PF14657	Arm-DNA-bind_4	Arm DNA-binding domain
+PF14658	EF-hand_9	EF-hand domain
+PF14659	Phage_int_SAM_3	Phage integrase, N-terminal SAM-like domain
+PF14660	DUF4458	Domain of unknown function (DUF4458)
+PF14661	HAUS6_N	HAUS augmin-like complex subunit 6 N-terminus
+PF14662	KASH_CCD	Coiled-coil region of CCDC155 or KASH
+PF14663	RasGEF_N_2	Rapamycin-insensitive companion of mTOR RasGEF_N domain
+PF14664	RICTOR_N	Rapamycin-insensitive companion of mTOR, N-term
+PF14665	RICTOR_phospho	Rapamycin-insensitive companion of mTOR, phosphorylation-site
+PF14666	RICTOR_M	Rapamycin-insensitive companion of mTOR, middle domain
+PF14667	Polysacc_synt_C	Polysaccharide biosynthesis C-terminal domain
+PF14668	RICTOR_V	Rapamycin-insensitive companion of mTOR, domain 5
+PF14669	Asp_Glu_race_2	Putative aspartate racemase
+PF14670	FXa_inhibition	Coagulation Factor Xa inhibitory site
+PF14671	DSPn	Dual specificity protein phosphatase, N-terminal half
+PF14672	LCE	Late cornified envelope 
+PF14673	DUF4459	Domain of unknown function (DUF4459)
+PF14674	FANCI_S1-cap	FANCI solenoid 1 cap
+PF14675	FANCI_S1	FANCI solenoid 1
+PF14676	FANCI_S2	FANCI solenoid 2
+PF14677	FANCI_S3	FANCI solenoid 3
+PF14678	FANCI_S4	FANCI solenoid 4
+PF14679	FANCI_HD1	FANCI helical domain 1
+PF14680	FANCI_HD2	FANCI helical domain 2
+PF14681	UPRTase	Uracil phosphoribosyltransferase
+PF14682	SPOB_ab	Sporulation initiation phospho-transferase B, C-terminal
+PF14683	CBM-like	Polysaccharide lyase family 4, domain III
+PF14684	Tricorn_C1	Tricorn protease C1 domain
+PF14685	Tricorn_PDZ	Tricorn protease PDZ domain
+PF14686	fn3_3	Polysaccharide lyase family 4, domain II
+PF14687	DUF4460	Domain of unknown function (DUF4460)
+PF14688	DUF4461	Domain of unknown function (DUF4461)
+PF14689	SPOB_a	Sensor_kinase_SpoOB-type, alpha-helical domain
+PF14690	zf-ISL3	zinc-finger of transposase IS204/IS1001/IS1096/IS1165
+PF14691	Fer4_20	Dihydroprymidine dehydrogenase domain II, 4Fe-4S cluster
+PF14692	DUF4462	Domain of unknown function (DUF4462)
+PF14693	Ribosomal_TL5_C	Ribosomal protein TL5, C-terminal domain
+PF14694	LINES_N	Lines N-terminus
+PF14695	LINES_C	Lines C-terminus
+PF14696	Glyoxalase_5	Hydroxyphenylpyruvate dioxygenase, HPPD, N-terminal 
+PF14697	Fer4_21	4Fe-4S dicluster domain
+PF14698	ASL_C2	Argininosuccinate lyase C-terminal
+PF14699	hGDE_N	N-terminal domain from the human glycogen debranching enzyme
+PF14700	RPOL_N	DNA-directed RNA polymerase N-terminal
+PF14701	hDGE_amylase	Glycogen debranching enzyme, glucanotransferase domain 
+PF14702	hGDE_central	Central domain of human glycogen debranching enzyme
+PF14703	PHM7_cyt	Cytosolic domain of 10TM putative phosphate transporter
+PF14704	DERM	Dermatopontin
+PF14705	Costars	Costars
+PF14706	Tnp_DNA_bind	Transposase DNA-binding
+PF14707	Sulfatase_C	C-terminal region of aryl-sulfatase
+PF14709	DND1_DSRM	double strand RNA binding domain from DEAD END PROTEIN 1
+PF14710	Nitr_red_alph_N	Respiratory nitrate reductase alpha N-terminal
+PF14711	Nitr_red_bet_C	Respiratory nitrate reductase beta C-terminal
+PF14712	Snapin_Pallidin	Snapin/Pallidin
+PF14713	DUF4464	Domain of unknown function (DUF4464)
+PF14714	KH_dom-like	KH-domain-like of EngA bacterial GTPase enzymes, C-terminal
+PF14715	FixP_N	N-terminal domain of cytochrome oxidase-cbb3, FixP 
+PF14716	HHH_8	Helix-hairpin-helix domain
+PF14717	DUF4465	Domain of unknown function (DUF4465)
+PF14718	SLT_L	Soluble lytic murein transglycosylase L domain
+PF14719	PID_2	Phosphotyrosine interaction domain (PTB/PID)
+PF14720	NiFe_hyd_SSU_C	NiFe/NiFeSe hydrogenase small subunit C-terminal
+PF14721	AIF_C	Apoptosis-inducing factor, mitochondrion-associated, C-term
+PF14722	KRAP_IP3R_bind	Ki-ras-induced actin-interacting protein-IP3R-interacting domain
+PF14723	SSFA2_C	Sperm-specific antigen 2 C-terminus
+PF14724	mit_SMPDase	Mitochondrial-associated sphingomyelin phosphodiesterase
+PF14725	DUF4466	Domain of unknown function (DUF4466)
+PF14726	RTTN_N	Rotatin, an armadillo repeat protein, centriole functioning 
+PF14727	PHTB1_N	PTHB1 N-terminus
+PF14728	PHTB1_C	PTHB1 C-terminus
+PF14729	DUF4467	Domain of unknown function with cystatin-like fold (DUF4467) 
+PF14730	DUF4468	Domain of unknown function (DUF4468) with TBP-like fold
+PF14731	Staphopain_pro	Staphopain proregion
+PF14732	UAE_UbL	Ubiquitin/SUMO-activating enzyme ubiquitin-like domain
+PF14733	ACDC	AP2-coincident C-terminal
+PF14734	DUF4469	Domain of unknown function (DUF4469) with IG-like fold
+PF14735	HAUS4	HAUS augmin-like complex subunit 4
+PF14736	N_Asn_amidohyd	Protein N-terminal asparagine amidohydrolase
+PF14737	DUF4470	Domain of unknown function (DUF4470)
+PF14738	PaaSYMP	Solute carrier (proton/amino acid symporter), TRAMD3 or PAT1
+PF14739	DUF4472	Domain of unknown function (DUF4472)
+PF14740	DUF4471	Domain of unknown function (DUF4471)
+PF14741	GH114_assoc	N-terminal glycosyl-hydrolase-114-associated domain
+PF14742	GDE_N_bis	N-terminal domain of (some) glycogen debranching enzymes
+PF14743	DNA_ligase_OB_2	DNA ligase OB-like domain
+PF14744	WASH-7_mid	WASH complex subunit 7
+PF14745	WASH-7_N	WASH complex subunit 7, N-terminal
+PF14746	WASH-7_C	WASH complex subunit 7, C-terminal
+PF14747	DUF4473	Domain of unknown function (DUF4473)
+PF14748	P5CR_dimer	Pyrroline-5-carboxylate reductase dimerisation
+PF14749	Acyl-CoA_ox_N	Acyl-coenzyme A oxidase N-terminal
+PF14750	INTS2	Integrator complex subunit 2
+PF14751	DUF4474	Domain of unknown function (DUF4474)
+PF14752	RBP_receptor	Retinol binding protein receptor
+PF14753	FAM221	Protein FAM221A/B
+PF14754	IFR3_antag	Papain-like auto-proteinase
+PF14755	ER-remodelling	Intracellular membrane remodeller 
+PF14756	Pdase_C33_assoc	Peptidase_C33-associated domain
+PF14757	NSP2-B_epitope	Immunogenic region of nsp2 protein of arterivirus polyprotein
+PF14758	NSP2_assoc	Non-essential region of nsp2 of arterivirus polyprotein 
+PF14759	Reductase_C	Reductase C-terminal
+PF14760	Rnk_N	Rnk N-terminus
+PF14761	HPS3_N	Hermansky-Pudlak syndrome 3
+PF14762	HPS3_Mid	Hermansky-Pudlak syndrome 3, middle region
+PF14763	HPS3_C	Hermansky-Pudlak syndrome 3, C-terminal
+PF14764	SPG48	AP-5 complex subunit, vesicle trafficking
+PF14765	PS-DH	Polyketide synthase dehydratase
+PF14766	RPA_interact_N	Replication protein A interacting N-terminal
+PF14767	RPA_interact_M	Replication protein A interacting middle
+PF14768	RPA_interact_C	Replication protein A interacting C-terminal
+PF14769	CLAMP	Flagellar C1a complex subunit C1a-32
+PF14770	TMEM18	Transmembrane protein 18
+PF14771	DUF4476	Domain of unknown function (DUF4476)
+PF14772	NYD-SP28	Sperm tail
+PF14773	VIGSSK	Helicase-associated putative binding domain, C-terminal
+PF14774	FAM177	FAM177 family
+PF14775	NYD-SP28_assoc	Sperm tail C-terminal domain
+PF14776	UNC-79	Cation-channel complex subunit UNC-79
+PF14777	BBIP10	Cilia BBSome complex subunit 10
+PF14778	ODR4-like	Olfactory receptor 4-like
+PF14779	BBS1	Ciliary BBSome complex subunit 1
+PF14780	DUF4477	Domain of unknown function (DUF4477)
+PF14781	BBS2_N	Ciliary BBSome complex subunit 2, N-terminal
+PF14782	BBS2_C	Ciliary BBSome complex subunit 2, C-terminal
+PF14783	BBS2_Mid	Ciliary BBSome complex subunit 2, middle region
+PF14784	ECSIT_C	C-terminal domain of the ECSIT protein
+PF14785	MalF_P2	Maltose transport system permease protein MalF P2 domain
+PF14786	Death_2	Tube Death domain
+PF14787	zf-CCHC_5	GAG-polyprotein viral zinc-finger
+PF14788	EF-hand_10	EF hand
+PF14789	THDPS_M	Tetrahydrodipicolinate N-succinyltransferase middle
+PF14790	THDPS_N	Tetrahydrodipicolinate N-succinyltransferase N-terminal
+PF14791	DNA_pol_B_thumb	DNA polymerase beta thumb 
+PF14792	DNA_pol_B_palm	DNA polymerase beta palm 
+PF14793	DUF4478	Domain of unknown function (DUF4478)
+PF14794	DUF4479	Domain of unknown function (DUF4479)
+PF14795	Leucyl-specific	Leucine-tRNA synthetase-specific domain
+PF14796	AP3B1_C	Clathrin-adaptor complex-3 beta-1 subunit C-terminal
+PF14797	SEEEED	Serine-rich region of AP3B1, clathrin-adaptor complex
+PF14798	Ca_hom_mod	Calcium homeostasis modulator
+PF14799	FAM195	FAM195 family
+PF14800	DUF4481	Domain of unknown function (DUF4481)
+PF14801	GCD14_N	tRNA methyltransferase complex GCD14 subunit N-term
+PF14802	TMEM192	TMEM192 family
+PF14803	Nudix_N_2	Nudix N-terminal
+PF14804	Jag_N	Jag N-terminus
+PF14805	THDPS_N_2	Tetrahydrodipicolinate N-succinyltransferase N-terminal
+PF14806	Coatomer_b_Cpla	Coatomer beta subunit appendage platform
+PF14807	AP4E_app_platf	Adaptin AP4 complex epsilon appendage platform
+PF14808	TMEM164	TMEM164 family
+PF14809	TGT_C1	C1 domain of tRNA-guanine transglycosylase dimerisation
+PF14810	TGT_C2	Patch-forming domain C2 of tRNA-guanine transglycosylase
+PF14811	TPD	Protein of unknown function TPD sequence-motif
+PF14812	PBP1_TM	Transmembrane domain of transglycosylase PBP1 at N-terminal
+PF14813	NADH_B2	NADH dehydrogenase 1 beta subcomplex subunit 2
+PF14814	UB2H	Bifunctional transglycosylase second domain
+PF14815	NUDIX_4	NUDIX domain
+PF14816	FAM178	Family of unknown function, FAM178
+PF14817	HAUS5	HAUS augmin-like complex subunit 5
+PF14818	DUF4482	Domain of unknown function (DUF4482)
+PF14819	QueF_N	Nitrile reductase, 7-cyano-7-deazaguanine-reductase N-term
+PF14820	SPRR2	Small proline-rich 2
+PF14821	Thr_synth_N	Threonine synthase N terminus
+PF14822	Vasohibin	Vasohibin
+PF14823	Sirohm_synth_C	Sirohaem biosynthesis protein C-terminal
+PF14824	Sirohm_synth_M	Sirohaem biosynthesis protein central
+PF14825	DUF4483	Domain of unknown function (DUF4483)
+PF14826	FACT-Spt16_Nlob	FACT complex subunit SPT16 N-terminal lobe domain
+PF14827	dCache_3	Double sensory domain of two-component sensor kinase
+PF14828	Amnionless	Amnionless
+PF14829	GPAT_N	Glycerol-3-phosphate acyltransferase N-terminal
+PF14830	Haemocyan_bet_s	Haemocyanin beta-sandwich
+PF14831	DUF4484	Domain of unknown function (DUF4484)
+PF14832	Tautomerase_3	Putative oxalocrotonate tautomerase enzyme
+PF14833	NAD_binding_11	NAD-binding of NADP-dependent 3-hydroxyisobutyrate dehydrogenase
+PF14834	GST_C_4	Glutathione S-transferase, C-terminal domain
+PF14835	zf-RING_6	zf-RING of BARD1-type protein
+PF14836	Ubiquitin_3	Ubiquitin-like domain
+PF14837	INTS5_N	Integrator complex subunit 5 N-terminus
+PF14838	INTS5_C	Integrator complex subunit 5 C-terminus
+PF14839	DOR	DOR family
+PF14840	DNA_pol3_delt_C	Processivity clamp loader gamma complex DNA pol III C-term
+PF14841	FliG_M	FliG middle domain
+PF14842	FliG_N	FliG N-terminal domain
+PF14843	GF_recep_IV	Growth factor receptor domain IV
+PF14844	PH_BEACH	PH domain associated with Beige/BEACH
+PF14845	Glycohydro_20b2	beta-acetyl hexosaminidase like
+PF14846	DUF4485	Domain of unknown function (DUF4485)
+PF14847	Ras_bdg_2	Ras-binding domain of Byr2
+PF14848	HU-DNA_bdg	DNA-binding domain
+PF14849	YidC_periplas	YidC periplasmic domain
+PF14850	Pro_dh-DNA_bdg	DNA-binding domain of Proline dehydrogenase
+PF14851	FAM176	FAM176 family
+PF14852	Fis1_TPR_N	Fis1 N-terminal tetratricopeptide repeat
+PF14853	Fis1_TPR_C	Fis1 C-terminal tetratricopeptide repeat
+PF14854	LURAP	Leucine rich adaptor protein 
+PF14855	PapJ	Pilus-assembly fibrillin subunit, chaperone
+PF14856	Hce2	Pathogen effector; putative necrosis-inducing factor
+PF14857	TMEM151	TMEM151 family
+PF14858	DUF4486	Domain of unknown function (DUF4486)
+PF14859	Colicin_M	Colicin M
+PF14860	DrrA_P4M	DrrA phosphatidylinositol 4-phosphate binding domain
+PF14861	Antimicrobial21	Plant antimicrobial peptide
+PF14862	Defensin_big	Big defensin
+PF14863	Alkyl_sulf_dimr	Alkyl sulfatase dimerisation
+PF14864	Alkyl_sulf_C	Alkyl sulfatase C-terminal
+PF14865	Macin	Macin
+PF14866	Toxin_38	Potassium channel toxin
+PF14867	Lantibiotic_a	Lantibiotic alpha
+PF14868	DUF4487	Domain of unknown function (DUF4487)
+PF14869	DUF4488	Domain of unknown function (DUF4488)
+PF14870	PSII_BNR	Photosynthesis system II assembly factor YCF48
+PF14871	GHL6	Hypothetical glycosyl hydrolase 6
+PF14872	GHL5	Hypothetical glycoside hydrolase 5
+PF14873	BNR_assoc_N	N-terminal domain of BNR-repeat neuraminidase
+PF14874	PapD-like	Flagellar-associated PapD-like
+PF14875	PIP49_N	N-term cysteine-rich ER, FAM69
+PF14876	RSF	Respiratory growth transcriptional regulator
+PF14877	mIF3	Mitochondrial translation initiation factor
+PF14878	DLD	Death-like domain of SPT6
+PF14879	DUF4489	Domain of unknown function (DUF4489)
+PF14880	COX14	Cytochrome oxidase c assembly
+PF14881	Tubulin_3	Tubulin domain
+PF14882	PHINT_rpt	Phage-integrase repeat unit
+PF14883	GHL13	Hypothetical glycosyl hydrolase family 13
+PF14884	EFF-AFF	Type I membrane glycoproteins cell-cell fusogen
+PF14885	GHL15	Hypothetical glycosyl hydrolase family 15
+PF14886	FAM183	FAM183A and FAM183B related
+PF14887	HMG_box_5	HMG (high mobility group) box 5
+PF14888	PBP-Tp47_c	Penicillin-binding protein Tp47 domain C
+PF14889	PBP-Tp47_a	Penicillin-binding protein Tp47 domain a
+PF14890	Intein_splicing	Intein splicing domain
+PF14891	Peptidase_M91	Effector protein
+PF14892	DUF4490	Domain of unknown function (DUF4490)
+PF14893	PNMA	PNMA
+PF14894	Lsm_C	Lsm C-terminal
+PF14895	PPPI_inhib	Protein phosphatase 1 inhibitor
+PF14896	Arabino_trans_C	EmbC C-terminal domain
+PF14897	EpsG	EpsG family
+PF14898	DUF4491	Domain of unknown function (DUF4491)
+PF14899	DUF4492	Domain of unknown function (DUF4492)
+PF14900	DUF4493	Domain of unknown function (DUF4493)
+PF14901	Jiv90	Cleavage inducing molecular chaperone
+PF14902	DUF4494	Domain of unknown function (DUF4494)
+PF14903	WG_beta_rep	WG containing repeat
+PF14904	FAM86	Family of unknown function
+PF14905	OMP_b-brl_3	Outer membrane protein beta-barrel family
+PF14906	DUF4495	Domain of unknown function (DUF4495)
+PF14907	NTP_transf_5	Uncharacterised nucleotidyltransferase
+PF14908	DUF4496	Domain of unknown function (DUF4496)
+PF14909	SPATA6	Spermatogenesis-assoc protein 6
+PF14910	MMS22L_N	S-phase genomic integrity recombination mediator, N-terminal
+PF14911	MMS22L_C	S-phase genomic integrity recombination mediator, C-terminal
+PF14912	THEG	Testicular haploid expressed repeat
+PF14913	DPCD	DPCD protein family
+PF14914	LRRC37AB_C	LRRC37A/B like protein 1 C-terminal domain
+PF14915	CCDC144C	CCDC144C protein coiled-coil region
+PF14916	CCDC92	Coiled-coil domain of unknown function
+PF14917	CCDC74_C	Coiled coil protein 74, C terminal
+PF14918	MTBP_N	MDM2-binding
+PF14919	MTBP_mid	MDM2-binding
+PF14920	MTBP_C	MDM2-binding
+PF14921	APCDDC	Adenomatosis polyposis coli down-regulated 1
+PF14922	FWWh	Protein of unknown function
+PF14923	CCDC142	Coiled-coil protein 142
+PF14924	DUF4497	Protein of unknown function (DUF4497)
+PF14925	HPHLAWLY	Domain of unknown function
+PF14926	DUF4498	Domain of unknown function (DUF4498)
+PF14927	Neurensin	Neurensin
+PF14928	S_tail_recep_bd	Short tail fibre protein receptor-binding domain
+PF14929	TAF1_subA	TAF RNA Polymerase I subunit A
+PF14930	Qn_am_d_aII	Quinohemoprotein amine dehydrogenase, alpha subunit domain II
+PF14931	IFT20	Intraflagellar transport complex B, subunit 20
+PF14932	HAUS-augmin3	HAUS augmin-like complex subunit 3
+PF14933	CEP19	CEP19-like protein
+PF14934	DUF4499	Domain of unknown function (DUF4499)
+PF14935	TMEM138	Transmembrane protein 138
+PF14936	p53-inducible11	Tumour protein p53-inducible protein 11
+PF14937	DUF4500	Domain of unknown function (DUF4500)
+PF14938	SNAP	Soluble NSF attachment protein, SNAP
+PF14939	DCAF15_WD40	DDB1-and CUL4-substrate receptor 15, WD repeat
+PF14940	TMEM219	Transmembrane 219
+PF14941	OAF	Transcriptional regulator, Out at first
+PF14942	Muted	Organelle biogenesis, Muted-like protein
+PF14943	MRP-S26	Mitochondrial ribosome subunit S26
+PF14944	TCRP1	Tongue Cancer Chemotherapy Resistant Protein 1
+PF14945	LLC1	Normal lung function maintenance, Low in Lung Cancer 1 protein
+PF14946	DUF4501	Domain of unknown function (DUF4501)
+PF14947	HTH_45	Winged helix-turn-helix
+PF14948	RESP18	RESP18 domain
+PF14949	ARF7EP_C	ARF7 effector protein C-terminus
+PF14950	DUF4502	Domain of unknown function (DUF4502)
+PF14951	DUF4503	Domain of unknown function (DUF4503)
+PF14952	zf-tcix	Putative treble-clef, zinc-finger, Zn-binding
+PF14953	DUF4504	Domain of unknown function (DUF4504)
+PF14954	LIX1	Limb expression 1
+PF14955	MRP-S24	Mitochondrial ribosome subunit S24
+PF14956	DUF4505	Domain of unknown function (DUF4505)
+PF14957	BORG_CEP	Cdc42 effector
+PF14958	DUF4506	Domain of unknown function (DUF4506)
+PF14959	GSAP-16	gamma-Secretase-activating protein C-term
+PF14960	ATP_synth_reg	ATP synthase regulation
+PF14961	BROMI	Broad-minded protein
+PF14962	AIF-MLS	Mitochondria Localisation Sequence
+PF14963	CAML	Calcium signal-modulating cyclophilin ligand
+PF14964	DUF4507	Domain of unknown function (DUF4507)
+PF14965	BRI3BP	Negative regulator of p53/TP53
+PF14966	DNA_repr_REX1B	DNA repair REX1-B
+PF14967	FAM70	FAM70 protein
+PF14968	CCDC84	Coiled coil protein 84
+PF14969	DUF4508	Domain of unknown function (DUF4508)
+PF14970	DUF4509	Domain of unknown function (DUF4509)
+PF14971	DUF4510	Domain of unknown function (DUF4510)
+PF14972	Mito_morph_reg	Mitochondrial morphogenesis regulator
+PF14973	TINF2_N	TERF1-interacting nuclear factor 2 N-terminus
+PF14974	P_C10	Protein C10 
+PF14975	DUF4512	Domain of unknown function (DUF4512)
+PF14976	FAM72	FAM72 protein
+PF14977	FAM194	FAM194 protein
+PF14978	MRP-63	Mitochondrial ribosome protein 63
+PF14979	TMEM52	Transmembrane 52
+PF14980	TIP39	TIP39 peptide
+PF14981	FAM165	FAM165 family
+PF14982	UPF0731	UPF0731 family
+PF14983	DUF4513	Domain of unknown function (DUF4513)
+PF14984	CD24	CD24 protein
+PF14985	TM140	TM140 protein family
+PF14986	DUF4514	Domain of unknown function (DUF4514)
+PF14987	NADHdh_A3	NADH dehydrogenase 1 alpha subcomplex subunit 3
+PF14988	DUF4515	Domain of unknown function (DUF4515)
+PF14989	CCDC32	Coiled-coil domain containing 32
+PF14990	DUF4516	Domain of unknown function (DUF4516)
+PF14991	MLANA	Protein melan-A
+PF14992	TMCO5	TMCO5 family
+PF14993	Neuropeptide_S	Neuropeptide S precursor protein
+PF14994	TSGA13	Testis-specific gene 13 protein
+PF14995	TMEM107	Transmembrane protein
+PF14996	RMP	Retinal Maintenance
+PF14997	CECR6_TMEM121	CECR6/TMEM121 family
+PF14998	Ripply	Transcription Regulator
+PF14999	Shadoo	Shadow of prion protein, neuroprotective
+PF15000	TUSC2	Tumour suppressor candidate 2
+PF15001	AP-5_subunit_s1	AP-5 complex subunit sigma-1
+PF15002	ERK-JNK_inhib	ERK and JNK pathways, inhibitor
+PF15003	HAUS2	HAUS augmin-like complex subunit 2 
+PF15004	MYEOV2	Myeloma-overexpressed-like
+PF15005	IZUMO	Izumo sperm-egg fusion, Ig domain-associated
+PF15006	DUF4517	Domain of unknown function (DUF4517)
+PF15007	CEP44	Centrosomal spindle body, CEP44
+PF15008	DUF4518	Domain of unknown function (DUF4518)
+PF15009	TMEM173	Transmembrane protein 173
+PF15010	FAM131	Putative cell signalling
+PF15011	CK2S	Casein Kinase 2 substrate
+PF15012	DUF4519	Domain of unknown function (DUF4519)
+PF15013	CCSMST1	CCSMST1 family
+PF15014	CLN5	Ceroid-lipofuscinosis neuronal protein 5
+PF15015	NYD-SP12_N	Spermatogenesis-associated, N-terminal
+PF15016	DUF4520	Domain of unknown function (DUF4520)
+PF15017	WRNPLPNID	Putative WW-binding domain and destruction box 
+PF15018	InaF-motif	TRP-interacting helix
+PF15019	C9orf72-like	C9orf72-like protein family
+PF15020	CATSPERD	Cation channel sperm-associated protein subunit delta
+PF15021	DUF4521	Protein of unknown function (DUF4521)
+PF15022	DUF4522	Protein of unknown function (DUF4522)
+PF15023	DUF4523	Protein of unknown function (DUF4523)
+PF15024	Glyco_transf_18	Glycosyltransferase family 18
+PF15025	DUF4524	Domain of unknown function (DUF4524)
+PF15027	DUF4525	Domain of unknown function (DUF4525)
+PF15028	PTCRA	Pre-T-cell antigen receptor
+PF15029	TMEM174	Transmembrane protein 174
+PF15030	DUF4527	Protein of unknown function (DUF4527)
+PF15031	DUF4528	Domain of unknown function (DUF4528)
+PF15032	DUF4529	Protein of unknown function (DUF4529)
+PF15033	Kinocilin	Kinocilin protein
+PF15034	KRTAP7	KRTAP type 7 family
+PF15035	Rootletin	Ciliary rootlet component, centrosome cohesion
+PF15036	IL34	Interleukin 34
+PF15037	IL17_R_N	Interleukin-17 receptor extracellular region
+PF15038	Jiraiya	Jiraiya
+PF15039	DUF4530	Domain of unknown function (DUF4530)
+PF15040	Humanin	Humanin family
+PF15041	DUF4531	Domain of unknown function (DUF4531)
+PF15042	LELP1	Late cornified envelope-like proline-rich protein 1
+PF15043	CNRIP1	CB1 cannabinoid receptor-interacting protein 1
+PF15044	CLU_N	Mitochondrial function, CLU-N-term
+PF15045	Clathrin_bdg	Clathrin-binding box of Aftiphilin, vesicle trafficking
+PF15046	DUF4532	Protein of unknown function (DUF4532)
+PF15047	DUF4533	Protein of unknown function (DUF4533)
+PF15048	OSTbeta	Organic solute transporter subunit beta protein
+PF15049	DUF4534	Protein of unknown function (DUF4534)
+PF15050	SCIMP	SCIMP protein
+PF15051	FAM198	FAM198 protein
+PF15052	TMEM169	TMEM169 protein family
+PF15053	Njmu-R1	Mjmu-R1-like protein family
+PF15054	DUF4535	Domain of unknown function (DUF4535)
+PF15055	DUF4536	Domain of unknown function (DUF4536)
+PF15056	NRN1	Neuritin protein family
+PF15057	DUF4537	Domain of unknown function (DUF4537)
+PF15058	Speriolin_N	Speriolin N terminus
+PF15059	Speriolin_C	Speriolin C-terminus
+PF15060	PPDFL	Differentiation and proliferation regulator
+PF15061	DUF4538	Domain of unknown function (DUF4538)
+PF15062	ARL6IP6	Haemopoietic lineage transmembrane helix
+PF15063	TC1	Thyroid cancer protein 1
+PF15064	CATSPERG	Cation channel sperm-associated protein subunit gamma
+PF15065	NCU-G1	Lysosomal transcription factor, NCU-G1
+PF15066	CAGE1	Cancer-associated gene protein 1 family
+PF15067	FAM124	FAM124 family
+PF15068	FAM101	FAM101 family
+PF15069	FAM163	FAM163 family
+PF15070	GOLGA2L5	Putative golgin subfamily A member 2-like protein 5
+PF15071	TMEM220	Transmembrane family 220, helix
+PF15072	DUF4539	Domain of unknown function (DUF4539)
+PF15073	DUF4540	Domain of unknown function (DUF4540)
+PF15074	DUF4541	Domain of unknown function (DUF4541)
+PF15075	DUF4542	Domain of unknown function (DUF4542)
+PF15076	DUF4543	Domain of unknown function (DUF4543)
+PF15077	MAJIN	Membrane-anchored junction protein 
+PF15078	DUF4545	Domain of unknown function (DUF4545)
+PF15079	Tsc35	Testis-specific protein 35
+PF15080	DUF4547	Domain of unknown function (DUF4547)
+PF15081	DUF4548	Domain of unknown function (DUF4548)
+PF15082	DUF4549	Domain of unknown function (DUF4549)
+PF15083	Colipase-like	Colipase-like
+PF15084	DUF4550	Domain of unknown function (DUF4550)
+PF15085	NPFF	Neuropeptide FF
+PF15086	UPF0542	Uncharacterised protein family UPF0542
+PF15087	DUF4551	Protein of unknown function (DUF4551)
+PF15088	NADH_dh_m_C1	NADH dehydrogenase [ubiquinone] 1 subunit C1, mitochondrial
+PF15089	DUF4552	Domain of unknown function (DUF4552)
+PF15090	DUF4553	Domain of unknown function (DUF4553)
+PF15091	DUF4554	Domain of unknown function (DUF4554)
+PF15092	UPF0728	Uncharacterised protein family UPF0728
+PF15093	DUF4555	Domain of unknown function (DUF4555)
+PF15094	DUF4556	Domain of unknown function (DUF4556)
+PF15095	IL33	Interleukin 33
+PF15096	G6B	G6B family
+PF15097	Ig_J_chain	Immunoglobulin J chain
+PF15098	TMEM89	TMEM89 protein family
+PF15099	PIRT	Phosphoinositide-interacting protein family
+PF15100	TMEM187	TMEM187 protein family
+PF15101	TERB2	Telomere-associated protein TERB2
+PF15102	TMEM154	TMEM154 protein family
+PF15103	G0-G1_switch_2	G0/G1 switch protein 2
+PF15104	DUF4558	Domain of unknown function (DUF4558)
+PF15105	TMEM61	TMEM61 protein family
+PF15106	TMEM156	TMEM156 protein family
+PF15107	FAM216B	FAM216B protein family
+PF15108	TMEM37	Voltage-dependent calcium channel gamma-like subunit protein family
+PF15109	TMEM125	TMEM125 protein family
+PF15110	TMEM141	TMEM141 protein family
+PF15111	TMEM101	TMEM101 protein family
+PF15112	DUF4559	Domain of unknown function (DUF4559)
+PF15113	TMEM117	TMEM117 protein family
+PF15114	UPF0640	Uncharacterised protein family UPF0640
+PF15115	HDNR	Domain of unknown function with conserved HDNR motif
+PF15116	CD52	CAMPATH-1 antigen
+PF15117	UPF0697	Uncharacterised protein family UPF0697   
+PF15118	DUF4560	Domain of unknown function (DUF4560)
+PF15119	APOC4	Apolipoprotein C4
+PF15120	SPACA9	Sperm acrosome-associated protein 9
+PF15121	TMEM71	TMEM71 protein family
+PF15122	TMEM206	TMEM206 protein family
+PF15123	DUF4562	Domain of unknown function (DUF4562)
+PF15124	FANCD2OS	FANCD2 opposite strand protein
+PF15125	TMEM238	TMEM238 protein family
+PF15127	SmAKAP	Small membrane A-kinase anchor protein
+PF15128	T_cell_tran_alt	T-cell leukemia translocation-altered
+PF15129	FAM150	FAM150 family
+PF15130	DUF4566	Domain of unknown function (DUF4566)
+PF15131	DUF4567	Domain of unknown function (DUF4567)
+PF15132	DUF4568	Domain of unknown function (DUF4568)
+PF15133	DUF4569	Domain of unknown function (DUF4569)
+PF15134	DUF4570	Domain of unknown function (DUF4570)
+PF15135	UPF0515	Uncharacterised protein UPF0515
+PF15136	UPF0449	Uncharacterised protein family UPF0449
+PF15137	DUF4571	Domain of unknown function (DUF4571)
+PF15138	Syncollin	Syncollin
+PF15139	DUF4572	Domain of unknown function (DUF4572)
+PF15140	DUF4573	Domain of unknown function (DUF4573)
+PF15141	DUF4574	Domain of unknown function (DUF4574)
+PF15142	INCA1	INCA1
+PF15143	DUF4575	Domain of unknown function (DUF4575)
+PF15144	DUF4576	Domain of unknown function (DUF4576)
+PF15145	DUF4577	Domain of unknown function (DUF4577)
+PF15146	FANCAA	Fanconi anemia-associated 
+PF15147	DUF4578	Domain of unknown function (DUF4578)
+PF15148	Apolipo_F	Apolipoprotein F
+PF15149	CATSPERB	Cation channel sperm-associated protein subunit beta protein family
+PF15150	PMAIP1	Phorbol-12-myristate-13-acetate-induced
+PF15151	RGCC	Response gene to complement 32 protein family
+PF15152	Kisspeptin	Kisspeptin
+PF15153	CYTL1	Cytokine-like protein 1
+PF15155	MRFAP1	MORF4 family-associated protein1
+PF15156	CLN6	Ceroid-lipofuscinosis neuronal protein 6
+PF15157	IQCJ-SCHIP1	Fusion protein IQCJ-SCHIP1 with IQ-like motif
+PF15158	DUF4579	Domain of unknown function (DUF4579)
+PF15159	PIG-Y	Phosphatidylinositol N-acetylglucosaminyltransferase subunit Y
+PF15160	SASRP1	Spermatogenesis-associated serine-rich protein 1
+PF15161	Neuropep_like	Neuropeptide-like
+PF15162	DUF4580	Domain of unknown function (DUF4580)
+PF15163	Meiosis_expr	Meiosis-expressed
+PF15164	WBS28	Williams-Beuren syndrome chromosomal region 28 protein homologue
+PF15165	REC114-like	Meiotic recombination protein REC114-like
+PF15167	DUF4581	Domain of unknown function (DUF4581)
+PF15168	TRIQK	Triple QxxK/R motif-containing protein family
+PF15169	DUF4564	Domain of unknown function (DUF4564)
+PF15170	CaM-KIIN	Calcium/calmodulin-dependent protein kinase II inhibitor
+PF15171	Spexin	Neuropeptide secretory protein family, NPQ, spexin
+PF15172	Prolactin_RP	Prolactin-releasing peptide
+PF15173	FAM180	FAM180 family
+PF15174	PRNT	Prion-related protein testis-specific
+PF15175	SPATA24	Spermatogenesis-associated protein 24
+PF15176	LRR19-TM	Leucine-rich repeat family 19 TM domain
+PF15177	IL28A	Interleukin-28A
+PF15178	TOM_sub5	Mitochondrial import receptor subunit TOM5 homolog
+PF15179	Myc_target_1	Myc target protein 1
+PF15180	NPBW	Neuropeptides B and W
+PF15181	SMRP1	Spermatid-specific manchette-related protein 1
+PF15182	OTOS	Otospiralin
+PF15183	MRAP	Melanocortin-2 receptor accessory protein family
+PF15184	TOM6p	Mitochondrial import receptor subunit TOM6 homolog
+PF15185	BMF	Bcl-2-modifying factor, apoptosis
+PF15186	TEX13	Testis-expressed sequence 13 protein family
+PF15187	Augurin	Oesophageal cancer-related gene 4
+PF15188	CCDC-167	Coiled-coil domain-containing protein 167
+PF15189	MEIOC	Meiosis-specific coiled-coil domain-containing protein MEIOC
+PF15190	TMEM251	Transmembrane protein 251
+PF15191	Synaptonemal_3	Synaptonemal complex central element protein 3
+PF15192	TMEM213	TMEM213 family
+PF15193	FAM24	FAM24 family
+PF15194	TMEM191C	TMEM191C family
+PF15195	TMEM210	TMEM210 family
+PF15196	Harakiri	Activator of apoptosis harakiri
+PF15198	Dexa_ind	Dexamethasone-induced
+PF15199	DAOA	D-amino acid oxidase activator
+PF15200	KRTDAP	Keratinocyte differentiation-associated
+PF15201	Rod_cone_degen	Progressive rod-cone degeneration
+PF15202	Adipogenin	Adipogenin
+PF15203	TMEM95	TMEM95 family
+PF15204	KKLCAg1	Kita-kyushu lung cancer antigen 1
+PF15205	PLAC9	Placenta-specific protein 9
+PF15206	FAM209	FAM209 family
+PF15207	TMEM240	TMEM240 family
+PF15208	Rab15_effector	Rab15 effector
+PF15209	IL31	Interleukin 31
+PF15210	SFTA2	Surfactant-associated protein 2
+PF15211	CXCL17	VEGF co-regulated chemokine 1
+PF15212	SPATA19	Spermatogenesis-associated protein 19, mitochondrial
+PF15213	CDRT4	CMT1A duplicated region transcript 4 protein
+PF15214	PXT1	Peroxisomal testis-specific protein 1
+PF15215	FDC-SP	Follicular dendritic cell secreted peptide
+PF15216	TSLP	Thymic stromal lymphopoietin
+PF15217	TSC21	TSC21 family
+PF15218	SPATA25	Spermatogenesis-associated protein 25
+PF15219	TEX12	Testis-expressed 12
+PF15220	HILPDA	Hypoxia-inducible lipid droplet-associated 
+PF15221	LEP503	Lens epithelial cell protein LEP503
+PF15222	KAR	Kidney androgen-regulated 
+PF15223	DUF4584	Domain of unknown function (DUF4584)
+PF15224	SCRG1	Scrapie-responsive protein 1
+PF15225	IL32	Interleukin 32
+PF15226	HPIP	HCF-1 beta-propeller-interacting protein family
+PF15227	zf-C3HC4_4	zinc finger of C3HC4-type, RING
+PF15228	DAP	Death-associated protein
+PF15229	POM121	POM121 family
+PF15230	SRRM_C	Serine/arginine repetitive matrix protein C-terminus
+PF15231	VCX_VCY	Variable charge X/Y family
+PF15232	DUF4585	Domain of unknown function (DUF4585)
+PF15233	SYCE1	Synaptonemal complex central element protein 1
+PF15234	LAT	Linker for activation of T-cells
+PF15235	GRIN_C	G protein-regulated inducer of neurite outgrowth C-terminus
+PF15236	CCDC66	Coiled-coil domain-containing protein 66
+PF15237	PTRF_SDPR	PTRF/SDPR family
+PF15238	FAM181	FAM181
+PF15239	DUF4586	Domain of unknown function (DUF4586)
+PF15240	Pro-rich	Proline-rich
+PF15241	Cylicin_N	Cylicin N-terminus
+PF15242	FAM53	Family of FAM53
+PF15243	ANAPC15	Anaphase-promoting complex subunit 15
+PF15244	HSD3	Spermatogenesis-associated protein 7, or HSD3
+PF15245	VGLL4	Transcription cofactor vestigial-like protein 4
+PF15246	NCKAP5	Nck-associated protein 5, Peripheral clock protein
+PF15247	SLBP_RNA_bind	Histone RNA hairpin-binding protein RNA-binding domain
+PF15248	DUF4587	Domain of unknown function (DUF4587)
+PF15249	GLTSCR1	Conserved region of unknown function on GLTSCR protein
+PF15250	Raftlin	Raftlin
+PF15251	DUF4588	Domain of unknown function (DUF4588)
+PF15252	DUF4589	Domain of unknown function (DUF4589)
+PF15253	STIL_N	SCL-interrupting locus protein N-terminus
+PF15254	CCDC14	Coiled-coil domain-containing protein 14
+PF15255	CAP-ZIP_m	WASH complex subunit CAP-Z interacting, central region
+PF15256	SPATIAL	SPATIAL
+PF15257	DUF4590	Domain of unknown function (DUF4590)
+PF15258	FAM222A	Protein family of FAM222A
+PF15259	GTSE1_N	G-2 and S-phase expressed 1
+PF15260	FAM219A	Protein family FAM219A
+PF15261	DUF4591	Domain of unknown function (DUF4591)
+PF15262	DUF4592	Domain of unknown function (DUF4592)
+PF15264	TSSC4	Tumour suppressing sub-chromosomal transferable candidate 4
+PF15265	FAM196	FAM196 family
+PF15266	DUF4594	Domain of unknown function (DUF4594)
+PF15268	Dapper	Dapper
+PF15269	zf-C2H2_7	Zinc-finger
+PF15270	ACI44	Metallo-carboxypeptidase inhibitor 
+PF15271	BBP1_N	Spindle pole body component BBP1, Mps2-binding protein
+PF15272	BBP1_C	Spindle pole body component BBP1, C-terminal
+PF15273	NHS	NHS-like
+PF15274	MLIP	Muscular LMNA-interacting protein
+PF15275	PEHE	PEHE domain
+PF15276	PP1_bind	Protein phosphatase 1 binding
+PF15277	Sec3-PIP2_bind	Exocyst complex component SEC3 N-terminal PIP2 binding PH
+PF15278	Sec3_C_2	Sec3 exocyst complex subunit
+PF15279	SOBP	Sine oculis-binding protein
+PF15280	BORA_N	Protein aurora borealis N-terminus
+PF15281	Consortin_C	Consortin C-terminus
+PF15282	BMP2K_C	BMP-2-inducible protein kinase C-terminus
+PF15283	DUF4595	Domain of unknown function (DUF4595) with porin-like fold
+PF15284	PAGK	Phage-encoded virulence factor
+PF15285	BH3	Beclin-1 BH3 domain, Bcl-2-interacting
+PF15286	Bcl-2_3	Apoptosis regulator M11, B cell 2 leukaemia/lymphoma like
+PF15287	KRBA1	KRBA1 family repeat
+PF15288	zf-CCHC_6	Zinc knuckle
+PF15289	RFXA_RFXANK_bdg	Regulatory factor X-associated C-terminal binding domain
+PF15290	Syntaphilin	Golgi-localised syntaxin-1-binding clamp
+PF15291	Dermcidin	Dermcidin, antibiotic peptide
+PF15292	Treslin_N	Treslin N-terminus
+PF15293	NUFIP2	Nuclear fragile X mental retardation-interacting protein 2
+PF15294	Leu_zip	Leucine zipper
+PF15295	CCDC50_N	Coiled-coil domain-containing protein 50  N-terminus
+PF15296	Codanin-1_C	Codanin-1 C-terminus
+PF15297	CKAP2_C	Cytoskeleton-associated protein 2 C-terminus
+PF15298	AJAP1_PANP_C	AJAP1/PANP C-terminus
+PF15299	ALS2CR8	Amyotrophic lateral sclerosis 2 chromosomal region candidate gene 8
+PF15300	INT_SG_DDX_CT_C	INTS6/SAGE1/DDX26B/CT45 C-terminus
+PF15301	SLAIN	SLAIN motif-containing family
+PF15302	P33MONOX	P33 mono-oxygenase
+PF15303	RNF111_N	E3 ubiquitin-protein ligase Arkadia N-terminus
+PF15304	AKAP2_C	A-kinase anchor protein 2 C-terminus
+PF15305	IFT43	Intraflagellar transport protein 43
+PF15306	LIN37	LIN37
+PF15307	SPACA7	Sperm acrosome-associated protein 7
+PF15308	CEP170_C	CEP170 C-terminus
+PF15309	ALMS_motif	ALMS motif
+PF15310	VAD1-2	Vitamin A-deficiency (VAD) rat model signalling
+PF15311	HYLS1_C	Hydrolethalus syndrome protein 1 C-terminus
+PF15312	JSRP	Junctional sarcoplasmic reticulum protein
+PF15313	HEXIM	Hexamethylene bis-acetamide-inducible protein
+PF15314	PRAP	Proline-rich acidic protein 1, pregnancy-specific uterine
+PF15315	FRG2	Facioscapulohumeral muscular dystrophy candidate 2
+PF15316	MDFI	MyoD family inhibitor
+PF15317	Lbh	Cardiac transcription factor regulator, Developmental protein
+PF15318	Bclt	Putative Bcl-2 like protein of testis
+PF15319	RHINO	RAD9, RAD1, HUS1-interacting nuclear orphan protein
+PF15320	RAM	mRNA cap methylation, RNMT-activating mini protein
+PF15321	ATAD4	ATPase family AAA domain containing 4
+PF15322	PMSI1	Protein missing in infertile sperm 1, putative
+PF15323	Ashwin	Developmental protein
+PF15324	TALPID3	Hedgehog signalling target
+PF15325	MRI	Modulator of retrovirus infection
+PF15326	TEX15	Testis expressed sequence 15
+PF15327	Tankyrase_bdg_C	Tankyrase binding protein C terminal domain
+PF15328	GCOM2	Putative GRINL1B complex locus protein 2
+PF15330	SIT	SHP2-interacting transmembrane adaptor protein, SIT
+PF15331	TP53IP5	Cellular tumour antigen p53-inducible 5
+PF15332	LIME1	Lck-interacting transmembrane adapter 1
+PF15333	TAF1D	TATA box-binding protein-associated factor 1D
+PF15334	AIB	Aurora kinase A and ninein interacting protein
+PF15335	CAAP1	Caspase activity and apoptosis inhibitor 1
+PF15336	Auts2	Autism susceptibility gene 2 protein
+PF15337	Vasculin	Vascular protein family Vasculin-like 1
+PF15338	TPIP1	p53-regulated apoptosis-inducing protein 1
+PF15339	Afaf	Acrosome formation-associated factor
+PF15340	COPR5	Cooperator of PRMT5 family
+PF15341	SLX9	Ribosome biogenesis protein SLX9
+PF15342	FAM212	FAM212 family
+PF15343	DEPP	Decidual protein induced by progesterone family
+PF15344	FAM217	FAM217 family
+PF15345	TMEM51	Transmembrane protein 51
+PF15346	ARGLU	Arginine and glutamate-rich 1
+PF15347	PAG	Phosphoprotein associated with glycosphingolipid-enriched
+PF15348	GEMIN8	Gemini of Cajal bodies-associated protein 8
+PF15349	DCA16	DDB1- and CUL4-associated factor 16
+PF15350	ETAA1	Ewing's tumour-associated antigen 1 homologue
+PF15351	JCAD	Junctional protein associated with coronary artery disease
+PF15352	K1377	Susceptibility to monomelic amyotrophy
+PF15353	HECA	Headcase protein family homologue
+PF15354	KAAG1	Kidney-associated antigen 1
+PF15355	Chisel	Stretch-responsive small skeletal muscle X protein, Chisel
+PF15356	SPR1	Psoriasis susceptibility locus 2
+PF15357	SEEK1	Psoriasis susceptibility 1 candidate 1
+PF15358	TSKS	Testis-specific serine kinase substrate
+PF15359	CDV3	Carnitine deficiency-associated protein 3
+PF15360	Apelin	APJ endogenous ligand
+PF15361	RIC3	Resistance to inhibitors of cholinesterase homologue 3
+PF15362	Enamelin	Enamelin
+PF15363	DUF4596	Domain of unknown function (DUF4596)
+PF15364	PAXIP1_C	PAXIP1-associated-protein-1 C term PTIP binding protein
+PF15365	PNRC	Proline-rich nuclear receptor coactivator motif
+PF15366	DUF4597	Domain of unknown function (DUF4597)
+PF15367	CABS1	Calcium-binding and spermatid-specific protein 1
+PF15368	BioT2	Spermatogenesis family BioT2
+PF15369	KIAA1328	Uncharacterised protein KIAA1328
+PF15370	DUF4598	Domain of unknown function (DUF4598)
+PF15371	DUF4599	Domain of unknown function (DUF4599)
+PF15372	DUF4600	Domain of unknown function (DUF4600)
+PF15373	DUF4601	Domain of unknown function (DUF4601)
+PF15374	CCDC71L	Coiled-coil domain-containing protein 71L
+PF15375	DUF4602	Domain of unknown function (DUF4602)
+PF15376	DUF4603	Domain of unknown function (DUF4603)
+PF15377	DUF4604	Domain of unknown function (DUF4604)
+PF15378	DUF4605	Domain of unknown function (DUF4605)
+PF15379	DUF4606	Domain of unknown function (DUF4606)
+PF15380	DUF4607	Domain of unknown function (DUF4607)
+PF15382	DUF4609	Domain of unknown function (DUF4609)
+PF15383	TMEM237	Transmembrane protein 237
+PF15384	PAXX	PAXX, PAralog of XRCC4 and XLF, also called C9orf142
+PF15385	SARG	Specifically androgen-regulated gene protein
+PF15386	Tantalus	Drosophila Tantalus-like
+PF15387	DUF4611	Domain of unknown function (DUF4611)
+PF15388	FAM117	Protein Family FAM117
+PF15389	DUF4612	Domain of unknown function (DUF4612)
+PF15390	WDCP	WD repeat and coiled-coil-containing protein family
+PF15391	DUF4614	Domain of unknown function (DUF4614)
+PF15392	Joubert	Joubert syndrome-associated
+PF15393	DUF4615	Domain of unknown function (DUF4615)
+PF15394	DUF4616	Domain of unknown function (DUF4616)
+PF15395	DUF4617	Domain of unknown function (DUF4617)
+PF15396	FAM60A	Protein Family FAM60A
+PF15397	DUF4618	Domain of unknown function (DUF4618)
+PF15398	DUF4619	Domain of unknown function (DUF4619)
+PF15399	DUF4620	Domain of unknown function (DUF4620)
+PF15400	TEX33	Testis-expressed sequence 33 protein family
+PF15401	TAA-Trp-ring	Tryptophan-ring motif of head of Trimeric autotransporter adhesin
+PF15402	Spc7_N	N-terminus of kinetochore NMS complex subunit Spc7
+PF15403	HiaBD2	HiaBD2_N domain of Trimeric autotransporter adhesin (GIN)
+PF15404	PH_4	Pleckstrin homology domain
+PF15405	PH_5	Pleckstrin homology domain
+PF15406	PH_6	Pleckstrin homology domain
+PF15407	Spo7_2_N	Sporulation protein family 7
+PF15409	PH_8	Pleckstrin homology domain
+PF15410	PH_9	Pleckstrin homology domain
+PF15411	PH_10	Pleckstrin homology domain
+PF15412	Nse4-Nse3_bdg	Binding domain of Nse4/EID3 to Nse3-MAGE
+PF15413	PH_11	Pleckstrin homology domain
+PF15414	DUF4621	Protein of unknown function (DUF4621)
+PF15415	Mfa_like_2	Fimbrillin-like
+PF15416	DUF4623	Domain of unknown function (DUF4623)
+PF15417	DUF4624	Domain of unknown function (DUF4624)
+PF15418	DUF4625	Domain of unknown function (DUF4625)
+PF15419	LNP1	Leukemia NUP98 fusion partner 1
+PF15420	Abhydrolase_9_N	Alpha/beta-hydrolase family N-terminus
+PF15421	Polysacc_deac_3	Putative polysaccharide deacetylase
+PF15423	FLYWCH_N	FLYWCH-type zinc finger-containing protein
+PF15424	ODAM	Odontogenic ameloblast-associated family
+PF15425	DUF4627	Domain of unknown function (DUF4627)
+PF15427	S100PBPR	S100P-binding protein
+PF15428	Imm26	Immunity protein 26
+PF15429	DUF4628	Domain of unknown function (DUF4628)
+PF15430	SVWC	Single domain von Willebrand factor type C
+PF15431	TMEM190	Transmembrane protein 190
+PF15432	Sec-ASP3	Accessory Sec secretory system ASP3
+PF15433	MRP-S31	Mitochondrial 28S ribosomal protein S31
+PF15434	FAM104	Family 104
+PF15435	UNC119_bdg	UNC119-binding protein C5orf30 homologue
+PF15436	PGBA_N	Plasminogen-binding protein pgbA N-terminal
+PF15437	PGBA_C	Plasminogen-binding protein pgbA C-terminal
+PF15438	Phyto-Amp	Antigenic membrane protein of phytoplasma
+PF15439	NYAP_N	Neuronal tyrosine-phosphorylated phosphoinositide-3-kinase adapter
+PF15440	THRAP3_BCLAF1	THRAP3/BCLAF1 family
+PF15441	ARHGEF5_35	Rho guanine nucleotide exchange factor 5/35
+PF15442	DUF4629	Domain of unknown function (DUF4629)
+PF15443	DUF4630	Domain of unknown function (DUF4630)
+PF15444	TMEM247	Transmembrane protein 247
+PF15445	ATS	acidic terminal segments, variant surface antigen of PfEMP1
+PF15446	zf-PHD-like	PHD/FYVE-zinc-finger like domain
+PF15447	NTS	N-terminal segments of PfEMP1
+PF15448	NTS_2	N-terminal segments of P. falciparum erythrocyte membrane protein
+PF15449	Retinal	Retinal protein
+PF15450	CCDC154	Coiled-coil domain-containing protein 154
+PF15451	DUF4632	Domain of unknown function (DUF4632)
+PF15452	NYAP_C	Neuronal tyrosine-phosphorylated phosphoinositide-3-kinase adapter
+PF15453	Pilt	Protein incorporated later into Tight Junctions
+PF15454	LAMTOR	Late endosomal/lysosomal adaptor and MAPK and MTOR activator
+PF15455	Pro-rich_19	Proline-rich 19
+PF15456	Uds1	Up-regulated During Septation
+PF15457	HopW1-1	Type III T3SS secreted effector HopW1-1/HopPmaA
+PF15458	NTR2	Nineteen complex-related protein 2
+PF15459	RRP14	60S ribosome biogenesis protein Rrp14
+PF15460	SAS4	Something about silencing, SAS, complex subunit 4
+PF15461	BCD	Beta-carotene 15,15'-dioxygenase
+PF15462	Barttin	Bartter syndrome, infantile, with sensorineural deafness (Barttin)
+PF15463	ECM11	Extracellular mutant protein 11
+PF15464	DUF4633	Domain of unknown function (DUF4633)
+PF15465	DUF4634	Domain of unknown function (DUF4634)
+PF15466	DUF4635	Domain of unknown function (DUF4635)
+PF15467	SGIII	Secretogranin-3
+PF15468	DUF4636	Domain of unknown function (DUF4636)
+PF15469	Sec5	Exocyst complex component Sec5
+PF15470	DUF4637	Domain of unknown function (DUF4637)
+PF15471	TMEM171	Transmembrane protein family 171
+PF15472	DUF4638	Domain of unknown function (DUF4638)
+PF15473	PCNP	PEST, proteolytic signal-containing nuclear protein family
+PF15474	MU117	Meiotically up-regulated gene family
+PF15475	UPF0444	Transmembrane protein C12orf23, UPF0444
+PF15476	SAP25	Histone deacetylase complex subunit SAP25
+PF15477	SMAP	Small acidic protein family
+PF15478	LKAAEAR	Family of unknown function with LKAAEAR motif
+PF15479	DUF4639	Domain of unknown function (DUF4639)
+PF15480	DUF4640	Domain of unknown function (DUF4640)
+PF15481	CPG4	Chondroitin proteoglycan 4
+PF15482	CCER1	Coiled-coil domain-containing glutamate-rich protein family 1
+PF15483	DUF4641	Domain of unknown function (DUF4641)
+PF15484	DUF4642	Domain of unknown function (DUF4642)
+PF15485	DUF4643	Domain of unknown function (DUF4643)
+PF15486	DUF4644	Domain of unknown function (DUF4644)
+PF15487	FAM220	FAM220 family
+PF15488	DUF4645	Domain of unknown function (DUF4645)
+PF15489	CTC1	CST, telomere maintenance, complex subunit CTC1
+PF15490	Ten1_2	Telomere-capping, CST complex subunit
+PF15491	CTC1_2	CST, telomere maintenance, complex subunit CTC1
+PF15492	Nbas_N	Neuroblastoma-amplified sequence, N terminal
+PF15493	YrpD	Domain of unknown function, YrpD
+PF15494	SRCR_2	Scavenger receptor cysteine-rich domain
+PF15495	Fimbrillin_C	Major fimbrial subunit protein type IV, Fimbrillin, C-terminal
+PF15496	DUF4646	Domain of unknown function (DUF4646)
+PF15497	SNAPc19	snRNA-activating protein complex subunit 19, SNAPc subunit 19
+PF15498	Dendrin	Nephrin and CD2AP-binding protein, Dendrin
+PF15499	Peptidase_C98	Ubiquitin-specific peptidase-like, SUMO isopeptidase
+PF15500	Ntox1	Putative RNase-like toxin, toxin_1
+PF15501	MDM1	Nuclear protein MDM1
+PF15502	MPLKIP	M-phase-specific PLK1-interacting protein
+PF15503	PPP1R35_C	Protein phosphatase 1 regulatory subunit 35 C-terminus
+PF15504	DUF4647	Domain of unknown function (DUF4647)
+PF15505	DUF4648	Domain of unknown function (DUF4648)
+PF15506	OCC1	OCC1 family
+PF15507	DUF4649	Domain of unknown function (DUF4649)
+PF15508	NAAA-beta	beta subunit of N-acylethanolamine-hydrolyzing acid amidase
+PF15509	DUF4650	Domain of unknown function (DUF4650)
+PF15510	CENP-W	CENP-W protein
+PF15511	CENP-T_C	Centromere kinetochore component CENP-T histone fold
+PF15512	CAF-1_p60_C	Chromatin assembly factor complex 1 subunit p60, C-terminal
+PF15513	DUF4651	Domain of unknown function (DUF4651)
+PF15514	ThaI	Restriction endonuclease ThaI
+PF15515	MvaI_BcnI	MvaI/BcnI restriction endonuclease family
+PF15516	BpuSI_N	BpuSI N-terminal domain
+PF15517	TBPIP_N	TBP-interacting protein N-terminus
+PF15518	L_protein_N	L protein N-terminus
+PF15519	RBM39linker	linker between RRM2 and RRM3 domains in RBM39 protein
+PF15520	Ntox10	Novel toxin 10
+PF15521	Ntox11	Novel toxin 11
+PF15522	Ntox14	Novel toxin 14
+PF15523	Ntox16	Novel toxin 16
+PF15524	Ntox17	Novel toxin 17
+PF15525	DUF4652	Domain of unknown function (DUF4652)
+PF15526	Ntox21	Novel toxin 21
+PF15527	Ntox22	Bacterial toxin 22
+PF15528	Ntox23	Bacterial toxin 23
+PF15529	Ntox24	Bacterial toxin 24
+PF15530	Ntox25	Bacterial toxin 25
+PF15531	Ntox27	Bacterial toxin 27
+PF15532	Ntox30	Bacterial toxin 30
+PF15533	Ntox33	Bacterial toxin 33
+PF15534	Ntox35	Bacterial toxin 35
+PF15535	Ntox37	Bacterial toxin 37
+PF15536	Ntox3	Bacterial toxin 3
+PF15537	Ntox43	Bacterial toxin 43
+PF15538	Ntox46	Bacterial toxin 46
+PF15539	CAF1-p150_C2	CAF1 complex subunit p150, region binding to CAF1-p60 at C-term
+PF15540	Ntox47	Bacterial toxin 47
+PF15541	Ntox4	Bacterial toxin 4
+PF15542	Ntox50	Bacterial toxin 50
+PF15543	Ntox5	Bacterial toxin 5
+PF15544	Ntox6	Bacterial toxin 6
+PF15545	Ntox8	Bacterial toxin 8
+PF15546	DUF4653	Domain of unknown function (DUF4653)
+PF15547	DUF4654	Domain of unknown function (DUF4654)
+PF15548	DUF4655	Domain of unknown function (DUF4655)
+PF15549	PGC7_Stella	PGC7/Stella/Dppa3 domain 
+PF15550	Draxin	Draxin
+PF15551	DUF4656	Domain of unknown function (DUF4656)
+PF15552	DUF4657	Domain of unknown function (DUF4657)
+PF15553	TEX19	Testis-expressed protein 19
+PF15554	FSIP1	FSIP1 family
+PF15555	DUF4658	Domain of unknown function (DUF4658)
+PF15556	Zwint	ZW10 interactor
+PF15557	CAF1-p150_N	CAF1 complex subunit p150, region binding to PCNA
+PF15558	DUF4659	Domain of unknown function (DUF4659)
+PF15559	DUF4660	Domain of unknown function (DUF4660)
+PF15560	Imm12	Immunity protein 12
+PF15561	Imm15	Immunity protein 15
+PF15562	Imm17	Immunity protein 17
+PF15563	Imm19	Immunity protein 19
+PF15564	Imm25	Immunity protein 25
+PF15565	Imm30	Immunity protein 30
+PF15566	Imm32	Immunity protein 32
+PF15567	Imm35	Immunity protein 35
+PF15568	Imm39	Immunity protein 39
+PF15569	Imm40	Immunity protein 40
+PF15570	Imm43	Immunity protein 43
+PF15571	Imm44	Immunity protein 44
+PF15572	Imm45	Immunity protein 45
+PF15573	Imm47	Immunity protein 47
+PF15574	Imm48	Immunity protein 48
+PF15575	Imm49	Immunity protein 49
+PF15576	DUF4661	Domain of unknown function (DUF4661)
+PF15577	Spc7_C2	Spc7_C2
+PF15578	DUF4662	Domain of unknown function (DUF4662)
+PF15579	Imm52	Immunity protein 52
+PF15580	Imm53	Immunity protein 53
+PF15581	Imm58	Immunity protein 58
+PF15582	Imm65	Immunity protein 65
+PF15583	Imm68	Immunity protein 68
+PF15584	Imm72	Immunity protein 72
+PF15585	Imm7	Immunity protein 7
+PF15586	Imm8	Immunity protein 8
+PF15587	Imm9	Immunity protein 9
+PF15588	Imm10	Immunity protein 10
+PF15589	Imm21	Immunity protein 21
+PF15590	Imm27	Immunity protein 27
+PF15591	Imm31	Immunity protein 31
+PF15592	Imm41	Immunity protein 41
+PF15593	Imm42	Immunity protein 42
+PF15594	Imm50	Immunity protein 50
+PF15595	Imm51	Immunity protein 51
+PF15596	Imm57	Immunity protein 57
+PF15597	Imm59	Immunity protein 59
+PF15598	Imm61	Immunity protein 61
+PF15599	Imm63	Immunity protein 63
+PF15600	Imm64	Immunity protein 64
+PF15601	Imm70	Immunity protein 70
+PF15602	Imm71	Immunity protein 71
+PF15603	Imm74	Immunity protein 74
+PF15604	Ntox15	Novel toxin 15
+PF15605	Ntox28	Bacterial toxin 28
+PF15606	Ntox34	Bacterial toxin 34
+PF15607	Ntox44	Bacterial toxin 44
+PF15608	PELOTA_1	PELOTA RNA binding domain
+PF15609	PRTase_2	Phosphoribosyl transferase
+PF15610	PRTase_3	PRTase ComF-like
+PF15611	EH_Signature	EH_Signature domain
+PF15612	WHIM1	WSTF, HB1, Itc1p, MBD9 motif 1
+PF15613	WSD	Williams-Beuren syndrome DDT (WSD), D-TOX E motif
+PF15615	TerB_C	TerB-C domain
+PF15616	TerY_C	TerY-C metal binding domain
+PF15617	C-C_Bond_Lyase	C-C_Bond_Lyase of the TIM-Barrel fold
+PF15619	Lebercilin	Ciliary protein causing Leber congenital amaurosis disease
+PF15620	CENP-C_mid	Centromere assembly component CENP-C middle DNMT3B-binding region
+PF15621	PROL5-SMR	Proline-rich submaxillary gland androgen-regulated family
+PF15622	CENP_C_N	Kinetochore assembly subunit CENP-C N-terminal
+PF15623	CT47	Cancer/testis gene family 47
+PF15624	Mif2_N	Kinetochore CENP-C fungal homologue, Mif2, N-terminal
+PF15625	CC2D2AN-C2	CC2D2A N-terminal C2 domain
+PF15626	mono-CXXC	single CXXC unit
+PF15627	CEP76-C2	CEP76 C2 domain
+PF15628	RRM_DME	RRM in Demeter
+PF15629	Perm-CXXC	Permuted single zf-CXXC unit 
+PF15630	CENP-S	CENP-S protein
+PF15631	Imm-NTF2-2	NTF2 fold immunity protein
+PF15632	ATPgrasp_Ter	ATP-grasp in the biosynthetic pathway with Ter operon
+PF15633	Tox-ART-HYD1	HYD1 signature containing ADP-ribosyltransferase
+PF15634	Tox-ART-HYE1	HYE1 signature containing ADP-ribosyltransferase
+PF15635	Tox-GHH2	GHH signature containing HNH/Endo VII superfamily nuclease toxin  2
+PF15636	Tox-GHH	GHH signature containing HNH/Endo VII superfamily nuclease toxin
+PF15637	Tox-HNH-HHH	HNH/Endo VII superfamily nuclease toxin with a HHH motif
+PF15638	Tox-MPTase2	Metallopeptidase toxin 2
+PF15639	Tox-MPTase3	Metallopeptidase toxin 3
+PF15640	Tox-MPTase4	Metallopeptidase toxin 4
+PF15641	Tox-MPTase5	Metallopeptidase toxin 5
+PF15642	Tox-ODYAM1	Toxin in Odyssella and Amoebophilus
+PF15643	Tox-PL-2	Papain fold toxin 2
+PF15644	Gln_amidase	Papain fold toxin 1, glutamine deamidase
+PF15645	Tox-PLDMTX	Dermonecrotoxin of the Papain-like fold
+PF15646	Tox-REase-2	Restriction endonuclease fold toxin 2
+PF15647	Tox-REase-3	Restriction endonuclease fold toxin 3
+PF15648	Tox-REase-5	Restriction endonuclease fold toxin 5
+PF15649	Tox-REase-7	Restriction endonuclease fold toxin 7
+PF15650	Tox-REase-9	Restriction endonuclease fold toxin 9
+PF15651	Tox-SGS	Salivary glad secreted protein domain toxin
+PF15652	Tox-SHH	HNH/Endo VII superfamily toxin with a SHH signature
+PF15653	Tox-URI2	URI fold toxin 2
+PF15654	Tox-WTIP	Toxin with a conserved tryptophan and TIP tripeptide motif
+PF15655	Imm-NTF2	NTF2 fold immunity protein
+PF15656	Tox-HDC	Toxin with a H, D/N and C signature
+PF15657	Tox-HNH-EHHH	HNH/Endo VII superfamily nuclease toxins
+PF15658	Latrotoxin_C	Latrotoxin C-terminal domain
+PF15659	Toxin-JAB1	JAB-like toxin  1
+PF15660	Imm75	Putative Immunity protein 75
+PF15661	CF222	C6orf222, uncharacterised family
+PF15662	SPATA3	Spermatogenesis-associated protein 3 family
+PF15663	zf-CCCH_3	Zinc-finger containing family
+PF15664	TMEM252	Transmembrane protein 252 family
+PF15665	FAM184	Family with sequence similarity 184, A and B
+PF15666	HGAL	Germinal center-associated lymphoma
+PF15667	GDWWSH	Protein of unknown function with motif GDWWSH
+PF15668	DUF4663	Domain of unknown function (DUF4663)
+PF15669	CCDC24	Coiled-coil domain-containing protein 24 family
+PF15670	Spem1	Spermatid maturation protein 1
+PF15671	PRR18	Proline-rich protein family 18
+PF15672	Mucin15	Cell-membrane associated Mucin15
+PF15673	Ciart	Circadian-associated transcriptional repressor 
+PF15674	CCDC23	Coiled-coil domain-containing protein 23
+PF15675	CLLAC	CLLAC-motif containing domain
+PF15676	S6OS1	Six6 opposite strand transcript 1 family
+PF15677	CEND1	Cell cycle exit and neuronal differentiation protein 1
+PF15678	SPICE	Centriole duplication and mitotic chromosome congression
+PF15679	DUF4665	Domain of unknown function (DUF4665)
+PF15680	OFCC1	Orofacial cleft 1 candidate gene 1 protein
+PF15681	LAX	Lymphocyte activation family X
+PF15682	Mustang	Musculoskeletal, temporally activated-embryonic nuclear protein 1
+PF15683	TDRP	Testis development-related protein
+PF15684	AROS	Active regulator of SIRT1, or 40S ribosomal protein S19-binding 1
+PF15685	GGN	Gametogenetin
+PF15686	LYRIC	Lysine-rich CEACAM1 co-isolated protein family
+PF15687	NRIP1_repr_1	Nuclear receptor-interacting protein 1 repression 1
+PF15688	NRIP1_repr_2	Nuclear receptor-interacting protein 1 repression 2
+PF15689	NRIP1_repr_3	Nuclear receptor-interacting protein 1 repression 3
+PF15690	NRIP1_repr_4	Nuclear receptor-interacting protein 1 repression 4
+PF15691	PPP1R32	Protein phosphatase 1 regulatory subunit 32
+PF15692	NKAP	NF-kappa-B-activating protein
+PF15693	Med26_C	Mediator complex subunit 26 C-terminal
+PF15694	Med26_M	Mediator complex subunit 26 middle domain
+PF15695	HERV-K_REC	Rec (regulator of expression encoded by corf) of HERV-K-113
+PF15696	RAD51_interact	RAD51 interacting motif
+PF15697	DUF4666	Domain of unknown function (DUF4666)
+PF15698	Phosphatase	Phosphatase
+PF15699	NPR1_interact	NPR1 interacting
+PF15700	DUF4667	Domain of unknown function (DUF4667)
+PF15701	DUF4668	Domain of unknown function (DUF4668)
+PF15702	HPS6	Hermansky-Pudlak syndrome 6 protein
+PF15703	LAT2	Linker for activation of T-cells family member 2
+PF15704	Mt_ATP_synt	Mitochondrial ATP synthase subunit
+PF15705	TMEM132D_N	Mature oligodendrocyte transmembrane protein, TMEM132D, N-term
+PF15706	TMEM132D_C	Mature oligodendrocyte transmembrane protein, TMEM132D, C-term
+PF15707	MCCD1	Mitochondrial coiled-coil domain protein 1
+PF15708	PRR20	Proline-rich protein family 20
+PF15709	DUF4670	Domain of unknown function (DUF4670)
+PF15710	DUF4671	Domain of unknown function (DUF4671)
+PF15711	ILEI	Interleukin-like EMT inducer
+PF15712	NPAT_C	NPAT C terminus
+PF15713	PTPRCAP	Protein tyrosine phosphatase receptor type C-associated
+PF15714	SpoVT_C	Stage V sporulation protein T C-terminal, transcription factor
+PF15715	PAF	PCNA-associated factor
+PF15716	DUF4672	Domain of unknown function (DUF4672)
+PF15717	PCM1_C	Pericentriolar material 1 C terminus
+PF15718	MNR	Protein moonraker
+PF15719	DUF4674	Domain of unknown function (DUF4674)
+PF15720	DUF4675	Domain of unknown function (DUF4675)
+PF15721	ANXA2R	Annexin-2 receptor
+PF15722	FAM153	FAM153 family
+PF15723	MqsR_toxin	Motility quorum-sensing regulator, toxin of MqsA
+PF15724	TMEM119	TMEM119 family
+PF15725	RCDG1	Renal cancer differentiation gene 1 protein
+PF15726	DUF4677	Domain of unknown function (DUF4677)
+PF15727	DUF4678	Domain of unknown function (DUF4678)
+PF15728	DUF4679	Domain of unknown function (DUF4679)
+PF15729	ALS2CR11	Amyotrophic lateral sclerosis 2 candidate 11
+PF15730	DUF4680	Domain of unknown function (DUF4680)
+PF15731	MqsA_antitoxin	Antitoxin component of bacterial toxin-antitoxin system, MqsA
+PF15732	DUF4681	Domain of unknown function (DUF4681)
+PF15733	DUF4682	Domain of unknown function (DUF4682)
+PF15734	MIIP	Migration and invasion-inhibitory
+PF15735	DUF4683	Domain of unknown function (DUF4683)
+PF15736	DUF4684	Domain of unknown function (DUF4684)
+PF15737	DUF4685	Domain of unknown function (DUF4685)
+PF15738	YafQ_toxin	Bacterial toxin of type II toxin-antitoxin system, YafQ 
+PF15739	TSNAXIP1_N	Translin-associated factor X-interacting N-terminus
+PF15740	PPP1R26_N	Protein phosphatase 1 regulatory subunit 26 N-terminus
+PF15741	LRIF1	Ligand-dependent nuclear receptor-interacting factor 1
+PF15742	DUF4686	Domain of unknown function (DUF4686)
+PF15743	SPATA1_C	Spermatogenesis-associated C-terminus
+PF15744	UPF0492	Uncharacterized protein family UPF0492
+PF15745	AP1AR	AP-1 complex-associated regulatory protein
+PF15746	TMEM215	TMEM215 family
+PF15747	DUF4687	Domain of unknown function (DUF4687)
+PF15748	CCSAP	Centriole, cilia and spindle-associated
+PF15749	MRNIP	MRN-interacting protein
+PF15750	UBZ_FAAP20	Ubiquitin-binding zinc-finger
+PF15751	FANCA_interact	FAAP20 FANCA interaction domain
+PF15752	DUF4688	Domain of unknown function (DUF4688)
+PF15753	BLOC1S3	Biogenesis of lysosome-related organelles complex 1 subunit 3
+PF15754	SPESP1	Sperm equatorial segment protein 1
+PF15755	DUF4689	Domain of unknown function (DUF4689)
+PF15756	DUF4690	Domain of unknown function (DUF4690)
+PF15757	Amelotin	Amelotin
+PF15758	HRCT1	Histidine-rich carboxyl terminus protein 1
+PF15759	TMEM108	TMEM108 family
+PF15760	DLEU7	Leukemia-associated protein 7
+PF15761	IMUP	Immortalisation up-regulated protein
+PF15762	DUF4691	Domain of unknown function (DUF4691)
+PF15763	DUF4692	Domain of unknown function (DUF4692)
+PF15764	DUF4693	Domain of unknown function (DUF4693)
+PF15765	DUF4694	Domain of unknown function (DUF4694)
+PF15766	DUF4695	Domain of unknown function (DUF4695)
+PF15767	DUF4696	Domain of unknown function (DUF4696)
+PF15768	CC190	Coiled-coil domain-containing protein 190
+PF15769	DUF4698	Domain of unknown function (DUF4698)
+PF15770	DUF4699	Domain of unknown function (DUF4699)
+PF15771	IHO1	Interactor of HORMAD1 protein 1
+PF15772	UPF0688	UPF0688 family
+PF15773	DUF4701	Domain of unknown function (DUF4701)
+PF15774	DUF4702	Domain of unknown function (DUF4702)
+PF15775	DUF4703	Domain of unknown function (DUF4703)
+PF15776	PRR22	Proline-rich protein family 22
+PF15777	Anti-TRAP	Tryptophan RNA-binding attenuator protein inhibitory protein
+PF15778	UNC80	Cation channel complex component UNC80
+PF15779	LRRC37	Leucine-rich repeat-containing protein 37 family
+PF15780	ASH	Abnormal spindle-like microcephaly-assoc'd, ASPM-SPD-2-Hydin
+PF15781	ParE-like_toxin	ParE-like toxin of type II bacterial toxin-antitoxin system
+PF15782	GREB1	Gene regulated by oestrogen in breast cancer
+PF15783	FSIP2	Fibrous sheath-interacting protein 2
+PF15784	GPS2_interact	G-protein pathway suppressor 2-interacting domain
+PF15785	SMG1	Serine/threonine-protein kinase smg-1
+PF15786	PET117	PET assembly of cytochrome c oxidase, mitochondrial
+PF15787	DUF4704	Domain of unknown function (DUF4704)
+PF15788	DUF4705	Domain of unknown function (DUF4705)
+PF15789	Hyr1	Hyphally regulated cell wall GPI-anchored protein 1
+PF15790	EP400_N	E1A-binding protein p400, N-terminal
+PF15791	DMRT-like	Doublesex-and mab-3-related transcription factor C1 and C2
+PF15792	LAS2	Lung adenoma susceptibility protein 2
+PF15793	FAM35_C	Protein family FAM35, C-terminal
+PF15794	CCDC106	Coiled-coil domain-containing protein 106
+PF15795	Spec3	Ectodermal ciliogenesis protein
+PF15796	KELK	KELK-motif containing domain of MRCK Ser/Thr protein kinase
+PF15797	DUF4706	Domain of unknown function (DUF4706)
+PF15798	PRAS	Proline-rich AKT1 substrate 1
+PF15799	CCD48	Coiled-coil domain-containing protein 48
+PF15800	CiPC	Clock interacting protein circadian
+PF15801	zf-C6H2	zf-MYND-like zinc finger, mRNA-binding
+PF15802	DCAF17	DDB1- and CUL4-associated factor 17
+PF15803	zf-SCNM1	Zinc-finger of sodium channel modifier 1
+PF15804	CCDC168_N	Coiled-coil domain-containing protein 168
+PF15805	SCNM1_acidic	Acidic C-terminal region of sodium channel modifier 1 SCNM1
+PF15806	DUF4707	Domain of unknown function (DUF4707)
+PF15807	MAP17	Membrane-associated protein 117 kDa, PDZK1-interacting protein 1 
+PF15808	BCOR	BCL-6 co-repressor, non-ankyrin-repeat region
+PF15809	STG	Simian taste bud-specific gene product family
+PF15810	CCDC117	Coiled-coil domain-containing protein 117
+PF15811	SVIP	Small VCP/p97-interacting protein
+PF15812	MREG	Melanoregulin
+PF15813	DUF4708	Domain of unknown function (DUF4708)
+PF15814	FAM199X	Protein family FAM199X
+PF15815	MKRN1_C	E3 ubiquitin-protein ligase makorin-1, C-terminal
+PF15816	TMEM82	Transmembrane protein 82
+PF15817	TMEM40	Transmembrane protein 40 family
+PF15818	CCDC73	Coiled-coil domain-containing protein 73 family
+PF15819	Fibin	Fin bud initiation factor homologue
+PF15820	ECSCR	Endothelial cell-specific chemotaxis regulator
+PF15821	DUF4709	Domain of unknown function (DUF4709)
+PF15822	MISS	MAPK-interacting and spindle-stabilising protein-like
+PF15823	UPF0524	UPF0524 of C3orf70
+PF15824	SPATA9	Spermatogenesis-associated protein 9
+PF15825	FAM25	FAM25 family
+PF15826	PUMA	Bcl-2-binding component 3, p53 upregulated modulator of apoptosis
+PF15827	UPF0730	UPF0730 unknown protein family
+PF15828	DUF4710	Domain of unknown function (DUF4710)
+PF15829	DUF4711	Domain of unknown function (DUF4711)
+PF15830	DUF4712	Domain of unknown function (DUF4712)
+PF15831	DUF4713	Domain of unknown function (DUF4713)
+PF15832	FAM27	FAM27 D and E protein family
+PF15833	DUF4714	Domain of unknown function (DUF4714)
+PF15834	THEG4	Testis highly expressed protein 4
+PF15835	DUF4715	Domain of unknown function (DUF4715)
+PF15836	SSTK-IP	SSTK-interacting protein, TSSK6-activating co-chaperone protein
+PF15837	DUF4716	Domain of unknown function (DUF4716)
+PF15838	DUF4717	Domain of unknown function (DUF4717)
+PF15839	TEX29	Testis-expressed sequence 29 protein
+PF15840	ARL17	ADP-ribosylation factor-like protein 17
+PF15841	TMEM239	Transmembrane protein 239 family
+PF15842	DUF4718	Domain of unknown function (DUF4718)
+PF15843	DUF4719	Domain of unknown function (DUF4719)
+PF15844	TMCCDC2	Transmembrane and coiled-coil domain-containing protein 2
+PF15845	NICE-1	Cysteine-rich C-terminal 1 family
+PF15846	DUF4720	Domain of unknown function (DUF4720)
+PF15847	Loricrin	Major keratinocyte cell envelope protein
+PF15848	DUF4721	Domain of unknown function (DUF4721)
+PF15849	DUF4722	Domain of unknown function (DUF4722)
+PF15851	DUF4723	Domain of unknown function (DUF4723)
+PF15852	DUF4724	Domain of unknown function (DUF4724)
+PF15854	DUF4725	Domain of unknown function (DUF4725)
+PF15855	DUF4726	Domain of unknown function (DUF4726)
+PF15856	DUF4727	Domain of unknown function (DUF4727)
+PF15858	LCE6A	Late cornified envelope protein 6A family
+PF15859	DEC1	Deleted in esophageal cancer 1 family
+PF15860	DUF4728	Domain of unknown function (DUF4728)
+PF15861	partial_CstF	Partial cleavage stimulation factor domain
+PF15862	Coilin_N	Coilin N-terminus
+PF15863	EELM2	Extended EGL-27 and MTA1 homology domain
+PF15864	PglL_A	Protein glycosylation ligase
+PF15865	Fanconi_A_N	Fanconi anaemia group A protein N terminus
+PF15866	DUF4729	Domain of unknown function (DUF4729)
+PF15867	Dynein_attach_N	Dynein attachment factor N-terminus
+PF15868	MBF2	Transcription activator MBF2
+PF15869	TolB_like	TolB-like 6-blade propeller-like
+PF15870	EloA-BP1	ElonginA binding-protein 1
+PF15871	JMY	Junction-mediating and -regulatory protein
+PF15872	SRTM1	Serine-rich and transmembrane domain-containing protein 1
+PF15873	DUF4730	Domain of unknown function (DUF4730)
+PF15874	Il2rg	Putative Interleukin 2 receptor, gamma chain
+PF15875	DUF4731	Domain of unknown function (DUF4731)
+PF15876	DUF4732	Domain of unknown function (DUF4732)
+PF15877	TMEM232	Transmembrane protein family 232
+PF15878	DUF4733	Domain of unknown function (DUF4733)
+PF15879	MWFE	NADH-ubiquinone oxidoreductase MWFE subunit
+PF15880	NDUFV3	NADH dehydrogenase [ubiquinone] flavoprotein 3, mitochondrial
+PF15881	DUF4734	Domain of unknown function (DUF4734)
+PF15882	DUF4735	Domain of unknown function (DUF4735)
+PF15883	DUF4736	Domain of unknown function (DUF4736)
+PF15884	QIL1	Protein QIL1
+PF15886	CBM39	Carbohydrate binding domain (family 32)
+PF15887	Peptidase_Mx	Putative zinc-binding metallo-peptidase
+PF15888	FOG_N	Folded gastrulation N-terminus
+PF15889	DUF4738	Domain of unknown function (DUF4738)
+PF15890	Peptidase_Mx1	Putative zinc-binding metallo-peptidase
+PF15891	Nuc_deoxyri_tr2	Nucleoside 2-deoxyribosyltransferase like
+PF15892	BNR_4	BNR repeat-containing family member
+PF15893	DUF4739	Domain of unknown function (DUF4739)
+PF15894	SgrT	Inhibitor of glucose uptake transporter SgrT
+PF15895	CAAX_1	CAAX box cerebral protein 1
+PF15897	DUF4741	Domain of unknown function (DUF4741)
+PF15898	PRKG1_interact	cGMP-dependent protein kinase interacting domain
+PF15899	BNR_6	BNR-Asp box repeat
+PF15901	Sortilin_C	Sortilin, neurotensin receptor 3, C-terminal
+PF15902	Sortilin-Vps10	Sortilin, neurotensin receptor 3,
+PF15903	PL48	Filopodia upregulated, FAM65
+PF15904	LIP1	LKB1 serine/threonine kinase interacting protein 1
+PF15905	HMMR_N	Hyaluronan mediated motility receptor N-terminal
+PF15906	zf-NOSIP	Zinc-finger of nitric oxide synthase-interacting protein
+PF15907	Itfg2	Integrin-alpha FG-GAP repeat-containing protein 2
+PF15908	HMMR_C	Hyaluronan mediated motility receptor C-terminal
+PF15909	zf-C2H2_8	C2H2-type zinc ribbon
+PF15910	V-set_2	ICOS V-set domain
+PF15911	WD40_3	WD domain, G-beta repeat
+PF15912	VIR_N	Virilizer, N-terminal
+PF15913	Furin-like_2	Furin-like repeat, cysteine-rich
+PF15914	FAM193_C	FAM193 family C-terminal
+PF15915	BAT	GAF and HTH_10 associated domain
+PF15916	DUF4743	Domain of unknown function (DUF4743)
+PF15917	PIEZO	Piezo
+PF15918	DUF4744	Domain of unknown function (DUF4744)
+PF15919	HicB_lk_antitox	HicB_like antitoxin of bacterial toxin-antitoxin system
+PF15920	WHAMM-JMY_N	N-terminal of Junction-mediating and WASP homolog-associated
+PF15921	CCDC158	Coiled-coil domain-containing protein 158
+PF15922	YjeJ	YjeJ-like
+PF15923	DUF4745	Domain of unknown function (DUF4745)
+PF15924	ALG11_N	ALG11 mannosyltransferase N-terminus
+PF15925	SOSSC	SOSS complex subunit C
+PF15926	RNF220	E3 ubiquitin-protein ligase RNF220
+PF15927	Casc1_N	Cancer susceptibility candidate 1 N-terminus
+PF15928	DUF4746	Domain of unknown function (DUF4746)
+PF15929	Myofilin	Myofilin
+PF15930	YdiH	Domain of unknown function
+PF15931	DUF4747	Domain of unknown function (DUF4747)
+PF15932	DUF4748	Domain of unknown function (DUF4748)
+PF15933	RnlB_antitoxin	Antitoxin to bacterial toxin RNase LS or RnlA
+PF15934	Yuri_gagarin	Yuri gagarin
+PF15935	RnlA_toxin	RNase LS, bacterial toxin
+PF15936	DUF4749	Domain of unknown function (DUF4749)
+PF15937	PrlF_antitoxin	prlF antitoxin for toxin YhaV_toxin
+PF15938	DUF4750	Domain of unknown function (DUF4750)
+PF15939	YmcE_antitoxin	Putative antitoxin of bacterial toxin-antitoxin system
+PF15940	YjcB	Family of unknown function
+PF15941	FidL_like	FidL-like putative membrane protein
+PF15942	DUF4751	Domain of unknown function (DUF4751)
+PF15943	YdaS_antitoxin	Putative antitoxin of bacterial toxin-antitoxin system, YdaS/YdaT
+PF15944	DUF4752	Domain of unknown function (DUF4752)
+PF15945	DUF4753	Domain of unknown function (DUF4753)
+PF15946	DUF4754	Domain of unknown function (DUF4754)
+PF15947	DUF4755	Domain of unknown function (DUF4755)
+PF15948	DUF4756	Domain of unknown function (DUF4756)
+PF15949	DUF4757	Domain of unknown function (DUF4757)
+PF15950	DUF4758	Putative sperm flagellar membrane protein
+PF15951	MITF_TFEB_C_3_N	MITF/TFEB/TFEC/TFE3 N-terminus
+PF15952	ESM4	Enhancer of split M4 family
+PF15953	PDU_like	Putative propanediol utilisation
+PF15955	Cuticle_4	Cuticle protein
+PF15956	DUF4760	Domain of unknown function (DUF4760)
+PF15957	Comm	Commissureless
+PF15958	DUF4761	Domain of unknown function (DUF4761)
+PF15959	DUF4762	Domain of unknown function (DUF4762)
+PF15960	DUF4763	Domain of unknown function (DUF4763)
+PF15961	DUF4764	Domain of unknown function (DUF4764)
+PF15962	DUF4765	Domain of unknown function (DUF4765)
+PF15963	Myb_DNA-bind_7	Myb DNA-binding like
+PF15964	CCCAP	Centrosomal colon cancer autoantigen protein family
+PF15965	zf-TRAF_2	TRAF-like zinc-finger
+PF15966	F-box_4	F-box
+PF15967	Nucleoporin_FG2	Nucleoporin FG repeated region
+PF15968	RexB	Membrane-anchored ion channel, Abi component
+PF15969	RexA	Intracellular sensor of Lambda phage, Abi component
+PF15970	HicB-like_2	HicB_like antitoxin of bacterial toxin-antitoxin system
+PF15971	Mannosyl_trans4	DolP-mannose mannosyltransferase
+PF15972	Unpaired	Unpaired protein
+PF15973	DUF4766	Domain of unknown function (DUF4766)
+PF15974	Cadherin_tail	Cadherin C-terminal cytoplasmic tail, catenin-binding region
+PF15975	Flot	Flotillin
+PF15976	CooC_C	CS1-pili formation C-terminal
+PF15977	HTH_46	Winged helix-turn-helix DNA binding
+PF15978	TnsD	Tn7-like transposition protein D
+PF15979	Glyco_hydro_115	Glycosyl hydrolase family 115
+PF15980	ComGF	Putative Competence protein ComGF
+PF15981	EAV_GP5	Envelope glycoprotein GP 5 of equine arteritis virus
+PF15982	TMEM135_C_rich	N-terminal cysteine-rich region of Transmembrane protein 135
+PF15983	DUF4767	Domain of unknown function (DUF4767)
+PF15984	Collagen_mid	Bacterial collagen, middle region
+PF15985	KH_6	KH domain
+PF15989	DUF4768	Domain of unknown function (DUF4768)
+PF15990	UPF0767	UPF0767 family
+PF15991	G_path_suppress	G-protein pathway suppressor
+PF15992	DUF4769	Domain of unknown function (DUF4769)
+PF15993	Fuseless	Fuseless
+PF15994	DUF4770	Domain of unknown function (DUF4770)
+PF15995	DUF4771	Domain of unknown function (DUF4771)
+PF15996	PNISR	Arginine/serine-rich protein PNISR
+PF15997	DUF4772	Domain of unknown function (DUF4772)
+PF15998	DUF4773	Domain of unknown function (DUF4773)
+PF15999	DUF4774	Domain of unknown function (DUF4774)
+PF16000	CARMIL_C	CARMIL C-terminus
+PF16001	DUF4775	Domain of unknown function (DUF4775)
+PF16002	Headcase	Headcase protein
+PF16003	DUF4776	Domain of unknown function (DUF4776)
+PF16004	EFTUD2	116 kDa U5 small nuclear ribonucleoprotein component N-terminus
+PF16005	MOEP19	KH-like RNA-binding domain
+PF16006	NUSAP	Nucleolar and spindle-associated protein
+PF16007	DUF4777	Domain of unknown function (DUF4777)
+PF16008	DUF4778	Domain of unknown function (DUF4778)
+PF16009	DUF4779	Domain of unknown function (DUF4779)
+PF16010	CDH-cyt	Cytochrome domain of cellobiose dehydrogenase
+PF16011	CBM9_2	Carbohydrate-binding family 9
+PF16012	DUF4780	Domain of unknown function (DUF4780)
+PF16013	DUF4781	Domain of unknown function (DUF4781)
+PF16014	SAP130_C	Histone deacetylase complex subunit SAP130 C-terminus
+PF16015	Promethin	Promethin
+PF16016	DUF4782	Domain of unknown function (DUF4782)
+PF16017	BTB_3	BTB/POZ domain
+PF16018	Anillin_N	Anillin N-terminus
+PF16019	CSRNP_N	Cysteine/serine-rich nuclear protein N-terminus
+PF16020	Deltameth_res	Deltamethrin resistance
+PF16021	PDCD7	Programmed cell death protein 7
+PF16022	DUF4783	Domain of unknown function (DUF4783)
+PF16023	DUF4784	Domain of unknown function (DUF4784)
+PF16024	DUF4785	Domain of unknown function (DUF4785)
+PF16025	CALM_bind	Calcium-dependent calmodulin binding
+PF16026	MIEAP	Mitochondria-eating protein
+PF16027	DUF4786	Domain of unknown function (DUF4786)
+PF16028	SLC3A2_N	Solute carrier family 3 member 2 N-terminus
+PF16029	DUF4787	Domain of unknown function (DUF4787)
+PF16030	GD_N	Serine protease gd N-terminus
+PF16031	TonB_N	TonB N-terminal region
+PF16032	DUF4788	Domain of unknown function (DUF4788)
+PF16033	DUF4789	Domain of unknown function (DUF4789)
+PF16034	JAKMIP_CC3	JAKMIP CC3 domain
+PF16035	Chalcone_2	Chalcone isomerase like
+PF16036	Chalcone_3	Chalcone isomerase-like
+PF16037	DUF4790	Domain of unknown function (DUF4790)
+PF16038	TMIE	TMIE protein
+PF16039	DUF4791	Domain of unknown function (DUF4791)
+PF16040	DUF4792	Domain of unknown function (DUF4792)
+PF16041	DUF4793	Domain of unknown function (DUF4793)
+PF16042	DUF4794	Domain of unknown function (DUF4794)
+PF16043	DUF4795	Domain of unknown function (DUF4795)
+PF16044	DUF4796	Domain of unknown function (DUF4796)
+PF16045	LisH_2	LisH
+PF16046	FAM76	FAM76 protein
+PF16047	Antimicrobial22	Frog antimicrobial peptide
+PF16048	Antimicrobial23	Frog antimicrobial peptide
+PF16049	Antimicrobial24	Frog antimicrobial peptide
+PF16050	CDC73_N	Paf1 complex subunit CDC73 N-terminal
+PF16051	DUF4797	Domain of unknown function (DUF4797)
+PF16053	MRP-S34	Mitochondrial 28S ribosomal protein S34
+PF16054	TMEM72	Transmembrane protein family 72
+PF16055	DUF4798	Domain of unknown function (DUF4798)
+PF16056	DUF4799	Domain of unknown function (DUF4799)
+PF16057	DUF4800	Domain of unknown function (DUF4800)
+PF16058	Mucin-like	Mucin-like
+PF16059	DUF4801	Domain of unknown function (DUF4801)
+PF16060	DUF4802	Domain of unknown function (DUF4802)
+PF16061	DUF4803	Domain of unknown function (DUF4803)
+PF16062	DUF4804	Domain of unknown function (DUF4804)
+PF16063	DUF4805	Domain of unknown function (DUF4805)
+PF16064	DUF4806	Domain of unknown function (DUF4806)
+PF16065	DUF4807	Domain of unknown function (DUF4807)
+PF16066	DUF4808	Domain of unknown function (DUF4808)
+PF16067	DUF4809	Domain of unknown function (DUF4809)
+PF16068	DUF4810	Domain of unknown function (DUF4810)
+PF16069	DUF4811	Domain of unknown function (DUF4811)
+PF16070	TMEM132	Transmembrane protein family 132
+PF16071	DUF4812	Domain of unknown function (DUF4812)
+PF16072	DUF4813	Domain of unknown function (DUF4813)
+PF16073	SAT	Starter unit:ACP transacylase in aflatoxin biosynthesis
+PF16074	PilW	Type IV Pilus-assembly protein W
+PF16075	DUF4815	Domain of unknown function (DUF4815)
+PF16076	Acyltransf_C	Acyltransferase C-terminus
+PF16077	Spaetzle	Spaetzle
+PF16078	2-oxogl_dehyd_N	2-oxoglutarate dehydrogenase N-terminus
+PF16079	Phage_holin_5_2	Phage holin family Hol44, in holin superfamily V
+PF16080	Phage_holin_2_3	Bacteriophage holin family HP1
+PF16081	Phage_holin_7_1	Mycobacterial 2 TMS Phage Holin (M2 Hol) Family
+PF16082	Phage_holin_2_4	Bacteriophage holin family, superfamily II-like
+PF16083	Phage_holin_3_3	LydA holin phage, holin superfamily III
+PF16084	LydB	LydA-holin antagonist
+PF16085	Phage_holin_3_5	Bacteriophage holin Hol, superfamily III
+PF16086	DUF4816	Domain of unknown function (DUF4816)
+PF16087	DUF4817	Domain of unknown function (DUF4817)
+PF16088	BORCS7	BLOC-1-related complex sub-unit 7
+PF16089	DUF4818	Domain of unknown function (DUF4818)
+PF16090	DUF4819	Domain of unknown function (DUF4819)
+PF16091	DUF4820	Domain of unknown function (DUF4820)
+PF16092	DUF4821	Domain of unknown function (DUF4821)
+PF16093	PAC4	Proteasome assembly chaperone 4
+PF16094	PAC1	Proteasome assembly chaperone 4
+PF16095	COR	C-terminal of Roc, COR, domain
+PF16096	FXR_C1	Fragile X-related 1 protein C-terminal region 2 
+PF16097	FXR_C3	Fragile X-related 1 protein C-terminal region 3 
+PF16098	FXMR_C2	Fragile X-related mental retardation protein C-terminal region 2
+PF16099	RMI1_C	Recq-mediated genome instability protein 1, C-terminal OB-fold
+PF16100	RMI2	RecQ-mediated genome instability protein 2
+PF16101	PRIMA1	Proline-rich membrane anchor 1
+PF16102	ACTH_assoc	ACTH-associated domain
+PF16103	DUF4822	Domain of unknown function (DUF4822)
+PF16104	FPRL1_inhibitor	Formyl peptide receptor-like 1 inhibitory protein
+PF16105	DUF4823	Domain of unknown function (DUF4823)
+PF16106	DUF4824	Domain of unknown function (DUF4824)
+PF16107	DUF4825	Domain of unknown function (DUF4825)
+PF16108	DUF4826	Domain of unknown function (DUF4826)
+PF16109	DUF4827	Domain of unknown function (DUF4827)
+PF16110	DUF4828	Domain of unknown function (DUF4828)
+PF16111	DUF4829	Domain of unknown function (DUF4829)
+PF16112	DUF4830	Domain of unknown function (DUF4830)
+PF16113	ECH_2	Enoyl-CoA hydratase/isomerase
+PF16114	Citrate_bind	ATP citrate lyase citrate-binding
+PF16115	DUF4831	Domain of unknown function (DUF4831)
+PF16116	DUF4832	Domain of unknown function (DUF4832)
+PF16117	DUF4833	Domain of unknown function (DUF4833)
+PF16118	DUF4834	Domain of unknown function (DUF4834)
+PF16119	DUF4835	Domain of unknown function (DUF4835)
+PF16120	DUF4836	Domain of unknown function (DUF4836)
+PF16121	40S_S4_C	40S ribosomal protein S4 C-terminus
+PF16122	40S_SA_C	40S ribosomal protein SA C-terminus
+PF16123	HAGH_C	Hydroxyacylglutathione hydrolase C-terminus
+PF16124	RecQ_Zn_bind	RecQ zinc-binding
+PF16125	DUF4837	Domain of unknown function (DUF4837)
+PF16126	DUF4838	Domain of unknown function (DUF4838)
+PF16127	DUF4839	Domain of unknown function (DUF4839)
+PF16128	DUF4840	Domain of unknown function (DUF4840)
+PF16129	DUF4841	Domain of unknown function (DUF4841)
+PF16130	DUF4842	Domain of unknown function (DUF4842)
+PF16131	Torus	Torus domain
+PF16132	DUF4843	Domain of unknown function (DUF4843)
+PF16133	DUF4844	Domain of unknown function (DUF4844)
+PF16134	THOC2_N	THO complex subunit 2 N-terminus
+PF16135	Jas	TPL-binding domain in jasmonate signalling
+PF16136	NINJA_B	Putative nuclear localisation signal
+PF16137	DUF4845	Domain of unknown function (DUF4845)
+PF16138	DUF4846	Domain of unknown function (4846)
+PF16139	DUF4847	Domain of unknown function (DUF4847)
+PF16140	DUF4848	Domain of unknown function (DUF4848)
+PF16141	DUF4849	Putative glycoside hydrolase Family 18, chitinase_18
+PF16142	DUF4850	Domain of unknown function (DUF4850)
+PF16143	DUF4851	Domain of unknown function (DUF4851)
+PF16144	DUF4852	Domain of unknown function (DUF4852)
+PF16145	DUF4853	Domain of unknown function (DUF4853)
+PF16146	DUF4854	Domain of unknown function (DUF4854)
+PF16147	DUF4855	Domain of unknown function (DUF4855)
+PF16148	DUF4856	Domain of unknown function (DUF4856)
+PF16149	DUF4857	Domain of unknown function (DUF4857)
+PF16150	DUF4858	Domain of unknown function (DUF4858)
+PF16151	DUF4859	Domain of unknown function (DUF4859)
+PF16152	DUF4860	Domain of unknown function (DUF4860)
+PF16153	DUF4861	Domain of unknown function (DUF4861)
+PF16154	DUF4862	Domain of unknown function (DUF4862)
+PF16155	DUF4863	Domain of unknown function (DUF4863)
+PF16156	DUF4864	Domain of unknown function (DUF4864)
+PF16157	DUF4865	Domain of unknown function (DUF4865)
+PF16158	N_BRCA1_IG	Ig-like domain from next to BRCA1 gene
+PF16159	FOXP-CC	FOXP coiled-coil domain
+PF16160	DUF4866	Domain of unknown function (DUF4866)
+PF16161	DUF4867	Domain of unknown function (DUF4867)
+PF16162	DUF4868	Domain of unknown function (DUF4868)
+PF16163	DUF4869	Domain of unknown function (DUF4869)
+PF16164	VWA_N2	VWA N-terminal
+PF16165	Ferlin_C	Ferlin C-terminus
+PF16166	TIC20	Chloroplast import apparatus Tic20-like
+PF16167	DUF4871	Domain of unknown function (DUF4871)
+PF16168	AIDA	Adhesin of bacterial autotransporter system, probable stalk 
+PF16169	DUF4872	Domain of unknown function (DUF4872)
+PF16170	DUF4873	Domain of unknown function (DUF4873)
+PF16171	CENP-T_N	Centromere kinetochore component CENP-T N-terminus
+PF16172	DOCK_N	DOCK N-terminus
+PF16173	DUF4874	Domain of unknown function (DUF4874)
+PF16174	IHABP4_N	Intracellular hyaluronan-binding protein 4 N-terminal
+PF16175	DUF4875	Domain of unknown function (DUF4875)
+PF16176	T-box_assoc	T-box transcription factor-associated
+PF16177	ACAS_N	Acetyl-coenzyme A synthetase N-terminus
+PF16178	Anoct_dimer	Dimerisation domain of Ca+-activated chloride-channel, anoctamin
+PF16179	RHD_dimer	Rel homology dimerisation domain
+PF16180	RelB_leu_zip	RelB leucine zipper
+PF16181	RelB_transactiv	RelB transactivation domain
+PF16182	AbLIM_anchor	Putative adherens-junction anchoring region of AbLIM
+PF16183	Kinesin_assoc	Kinesin-associated
+PF16184	Cadherin_3	Cadherin-like
+PF16185	MTABC_N	Mitochondrial ABC-transporter N-terminal five TM region
+PF16186	Arm_3	Atypical Arm repeat 
+PF16187	Peptidase_M16_M	Middle or third domain of peptidase_M16
+PF16188	Peptidase_M24_C	C-terminal region of peptidase_M24
+PF16189	Creatinase_N_2	Creatinase/Prolidase N-terminal domain
+PF16190	E1_FCCH	Ubiquitin-activating enzyme E1 FCCH domain
+PF16191	E1_4HB	Ubiquitin-activating enzyme E1 four-helix bundle
+PF16192	PMT_4TMC	C-terminal four TMM region of protein-O-mannosyltransferase 
+PF16193	AAA_assoc_2	AAA C-terminal domain
+PF16195	UBA2_C	SUMO-activating enzyme subunit 2 C-terminus
+PF16197	KAsynt_C_assoc	Ketoacyl-synthetase C-terminal extension
+PF16198	TruB_C_2	tRNA pseudouridylate synthase B C-terminal domain
+PF16199	Radical_SAM_C	Radical_SAM C-terminal domain
+PF16200	Band_7_C	C-terminal region of band_7
+PF16201	NopRA1	Nucleolar pre-ribosomal-associated protein 1
+PF16202	BLM_N	N-terminal region of Bloom syndrome protein
+PF16203	ERCC3_RAD25_C	ERCC3/RAD25/XPB C-terminal helicase
+PF16204	BDHCT_assoc	BDHCT-box associated domain on Bloom syndrome protein
+PF16205	Ribosomal_S17_N	Ribosomal_S17 N-terminal
+PF16206	Mon2_C	C-terminal region of Mon2 protein
+PF16207	RAWUL	RAWUL domain RING finger- and  WD40-associated ubiquitin-like
+PF16208	Keratin_2_head	Keratin type II head
+PF16209	PhoLip_ATPase_N	Phospholipid-translocating ATPase N-terminal
+PF16210	Keratin_2_tail	Keratin type II cytoskeletal 1 tail
+PF16211	Histone_H2A_C	C-terminus of histone H2A
+PF16212	PhoLip_ATPase_C	Phospholipid-translocating P-type ATPase C-terminal
+PF16213	DCB	Dimerisation and cyclophilin-binding domain of Mon2
+PF16214	AC_N	Adenylyl cyclase N-terminal extracellular and transmembrane region
+PF16215	DUF4876	Protein of unknown function (DUF4876)
+PF16216	GxGYxYP_N	GxGYxY sequence motif in domain of unknown function N-terminal
+PF16217	M64_N	Peptidase M64 N-terminus
+PF16218	Peptidase_C101	Peptidase family C101
+PF16219	DUF4879	Domain of unknown function (DUF4879)
+PF16220	DUF4880	Domain of unknown function (DUF4880)
+PF16221	HTH_47	winged helix-turn-helix
+PF16222	DUF4881	Domain of unknown function (DUF4881)
+PF16223	DUF4882	Domain of unknown function (DUF4882)
+PF16224	DUF4883	DOmain of unknown function (DUF4883)
+PF16225	DUF4884	Domain of unknown function (DUF4884)
+PF16226	DUF4885	Domain of unknown function (DUF4885)
+PF16227	DUF4886	Domain of unknown function (DUF4886)
+PF16228	DUF4887	Domain of unknown function (DUF4887)
+PF16229	DUF4888	Domain of unknown function (DUF4888)
+PF16230	DUF4889	Domain of unknown function (DUF4889)
+PF16231	DUF4890	Domain of unknown function (DUF4890)
+PF16232	DUF4891	Domain of unknown function (DUF4891)
+PF16233	DUF4893	Domain of unknown function (DUF4893)
+PF16234	DUF4892	Domain of unknown function (DUF4892)
+PF16235	DUF4894	Domain of unknown function (DUF4894)
+PF16236	DUF4895	Domain of unknown function (DUF4895)
+PF16237	DUF4896	Domain of unknown function (DUF4896)
+PF16238	DUF4897	Domain of unknown function (DUF4897)
+PF16239	DUF4898	Domain of unknown function (DUF4898)
+PF16240	DUF4899	Domain of unknown function (DUF4899)
+PF16241	DUF4900	Domain of unknown function (DUF4900)
+PF16242	Pyrid_ox_like	Pyridoxamine 5'-phosphate oxidase like
+PF16243	Sm_like	Sm_like domain
+PF16244	DUF4901	Domain of unknown function (DUF4901)
+PF16245	DUF4902	Domain of unknown function (DUF4902)
+PF16246	DUF4903	Domain of unknown function (DUF4903)
+PF16247	DUF4904	Domain of unknown function (DUF4904)
+PF16248	DUF4905	Domain of unknown function (DUF4905)
+PF16249	DUF4906	Domain of unknown function (DUF4906)
+PF16250	DUF4907	Domain of unknown function (DUF4907)
+PF16251	NAR	Nucleic acid-binding domain (NAR)
+PF16252	DUF4908	Domain of unknown function (DUF4908)
+PF16253	DUF4909	Domain of unknown function (DUF4909)
+PF16254	DUF4910	Domain of unknown function (DUF4910)
+PF16255	Lipase_GDSL_lke	GDSL-like Lipase/Acylhydrolase
+PF16256	DUF4911	Domain of unknown function (DUF4911)
+PF16257	UxaE	tagaturonate epimerase
+PF16258	DUF4912	Domain of unknown function (DUF4912)
+PF16259	DUF4913	Domain of unknown function (DUF4913)
+PF16260	DUF4914	Domain of unknown function (DUF4914)
+PF16261	DUF4915	Domain of unknown function (DUF4915)
+PF16262	DUF4916	Domain of unknown function (DUF4916)
+PF16263	DUF4917	Domain of unknown function (DUF4917)
+PF16264	SatD	SatD family (SatD)
+PF16265	DUF4918	Domain of unknown function (DUF4918)
+PF16266	DUF4919	Domain of unknown function (DUF4919)
+PF16267	DUF4920	Domain of unknown function (DUF4920)
+PF16268	DUF4921	Domain of unknown function (DUF4921)
+PF16269	DUF4922	Domain of unknown function (DUF4922)
+PF16270	DUF4923	Domain of unknown function (DUF4923)
+PF16271	DUF4924	Domain of unknown function (DUF4924)
+PF16272	DUF4925	Domain of unknown function (DUF4925)
+PF16273	NuDC	Nuclear distribution C domain
+PF16274	Qua1	Qua1 domain
+PF16275	SF1-HH	Splicing factor 1 helix-hairpin domain
+PF16276	NPM1-C	Nucleophosmin C-terminal domain
+PF16277	DUF4926	Domain of unknown function (DUF4926)
+PF16278	zf-C2HE	C2HE / C2H2 / C2HC zinc-binding finger
+PF16279	DUF4927	Domain of unknown function (DUF4927)
+PF16280	DUF4928	Domain of unknown function (DUF4928)
+PF16282	SANT_DAMP1_like	SANT/Myb-like domain of DAMP1
+PF16283	DUF4929	Domain of unknown function (DUF4929)
+PF16284	DUF4930	Domain of unknown function (DUF4930)
+PF16285	DUF4931	Domain of unknown function (DUF4931)
+PF16286	DUF4932	Domain of unknown function (DUF4932)
+PF16287	DUF4933	Domain of unknown function (DUF4933)
+PF16288	DUF4934	Domain of unknown function (DUF4934)
+PF16289	DUF4935	Domain of unknown function (DUF4935)
+PF16290	DUF4936	Domain of unknown function (DUF4936)
+PF16291	DUF4937	Domain of unknown function (DUF4937
+PF16292	DUF4938	Domain of unknown function (DUF4938)
+PF16293	zf-C2H2_9	C2H2 type zinc-finger (1 copy)
+PF16294	RSB_motif	RNSP1-SAP18 binding (RSB) motif
+PF16295	TetR_C_10	Tetracycline repressor, C-terminal all-alpha domain
+PF16296	TM_PBP2_N	N-terminal of TM subunit in PBP-dependent ABC transporters
+PF16297	DUF4939	Domain of unknown function (DUF4939)
+PF16298	DUF4940	Domain of unknown function (DUF4940)
+PF16299	DUF4941	Domain of unknown function (DUF4941)
+PF16300	WD40_4	Type of WD40 repeat
+PF16301	DUF4943	Domain of unknown function (DUF4943)
+PF16302	DUF4944	Domain of unknown function (DUF4944)
+PF16303	DUF4945	Domain of unknown function (DUF4945)
+PF16304	DUF4946	Domain of unknown function (DUF4946)
+PF16305	DUF4947	Domain of unknown function (DUF4947)
+PF16306	DUF4948	Domain of unknown function (DUF4948)
+PF16307	DUF4949	Domain of unknown function (DUF4949)
+PF16308	DUF4950	Domain of unknown function (DUF4950)
+PF16309	DUF4951	Domian of unknown function (DUF4951)
+PF16310	DUF4952	Domian of unknown function (DUF4952)
+PF16311	TMEM100	Transmembrane protein 100
+PF16312	Oberon_cc	Coiled-coil region of Oberon
+PF16313	DUF4953	Met-zincin
+PF16314	DUF4954	Domain of unknown function (DUF4954)
+PF16315	DUF4955	Domain of unknown function (DUF4955)
+PF16316	DUF4956	Domain of unknown function (DUF4956)
+PF16317	Glyco_hydro_99	Glycosyl hydrolase family 99
+PF16318	DUF4957	Domain of unknown function (DUF4957)
+PF16319	DUF4958	Domain of unknown function (DUF4958)
+PF16320	Ribosomal_L12_N	Ribosomal protein L7/L12 dimerisation domain
+PF16321	Ribosom_S30AE_C	Sigma 54 modulation/S30EA ribosomal protein C terminus
+PF16322	Tub_N	Tubby N-terminal
+PF16323	DUF4959	Domain of unknown function (DUF4959)
+PF16324	DUF4960	Domain of unknown function (DUF4960)
+PF16325	Peptidase_U32_C	Peptidase family U32 C-terminal domain
+PF16326	ABC_tran_CTD	ABC transporter C-terminal domain
+PF16327	CcmF_C	Cytochrome c-type biogenesis protein CcmF C-terminal
+PF16328	DUF4961	Domain of unknown function (DUF4961)
+PF16329	Pestivirus_E2	Pestivirus envelope glycoprotein E2
+PF16330	MukB_hinge	MukB hinge domain
+PF16331	TolA_bind_tri	TolA binding protein trimerisation
+PF16332	DUF4962	Domain of unknown function (DUF4962)
+PF16334	DUF4964	Domain of unknown function (DUF4964)
+PF16335	DUF4965	Domain of unknown function (DUF4965)
+PF16338	DUF4968	Domain of unknown function (DUF4968)
+PF16339	DUF4969	Domain of unknown function (DUF4969)
+PF16341	DUF4971	Domain of unknown function (DUF4971)
+PF16342	DUF4972	Domain of unknown function (DUF4972)
+PF16343	DUF4973	Domain of unknown function (DUF4973)
+PF16344	DUF4974	Domain of unknown function (DUF4974)
+PF16346	DUF4975	Domain of unknown function (DUF4975)
+PF16347	DUF4976	Domain of unknown function (DUF4976)
+PF16348	Corona_NSP4_C	Coronavirus nonstructural protein 4 C-terminus
+PF16349	DUF4978	Domain of unknown function (DUF4978)
+PF16350	FAO_M	FAD dependent oxidoreductase central domain
+PF16351	DUF4979	Domain of unknown function (DUF4979)
+PF16352	DUF4980	Domain of unknown function (DUF4980)
+PF16353	DUF4981	Domain of unknown function(DUF4981)
+PF16355	DUF4982	Domain of unknown function (DUF4982)
+PF16356	DUF4983	Domain of unknown function (DUF4983)
+PF16357	PepSY_TM_like_2	Putative PepSY_TM-like
+PF16358	RcsF	RcsF lipoprotein
+PF16359	RcsD_ABL	RcsD-ABL domain
+PF16360	GTP-bdg_M	GTP-binding GTPase Middle Region
+PF16361	Peptidase_S8_N	N-terminal of Subtilase family
+PF16362	YaiA	YaiA protein
+PF16363	GDP_Man_Dehyd	GDP-mannose 4,6 dehydratase
+PF16364	Antigen_C	Cell surface antigen C-terminus
+PF16365	EutK_C	Ethanolamine utilization protein EutK C-terminus
+PF16366	CEBP_ZZ	Cytoplasmic polyadenylation element-binding protein ZZ domain
+PF16367	RRM_7	RNA recognition motif
+PF16368	CEBP1_N	Cytoplasmic polyadenylation element-binding protein 1 N-terminus
+PF16369	GH43_C	C-terminal of Glycosyl hydrolases family 43
+PF16370	MetallophosC	C terminal of Calcineurin-like phosphoesterase
+PF16371	MetallophosN	N terminal of Calcineurin-like phosphoesterase
+PF16372	DUF4984	Domain of unknown function (DUF4984)
+PF16373	DUF4985	Domain of unknown function 
+PF16374	CIF	Cycle inhibiting factor (CIF)
+PF16375	DUF4986	Domain of unknown function
+PF16376	fragilysinNterm	N-terminal domain of fragilysin
+PF16377	DUF4987	Domain of unknown function
+PF16378	DUF4988	Domain of unknown function
+PF16379	DUF4989	Domain of unknown function (DUF4989)
+PF16380	DUF4990	Domain of unknown function
+PF16381	Coatomer_g_Cpla	Coatomer subunit gamma-1 C-terminal appendage platform
+PF16383	DUF4992	Domain of unknown function
+PF16384	DUF4993	Domain of unknown function
+PF16385	DUF4994	Domain of unknown function
+PF16386	DUF4995	Domain of unknown function
+PF16387	DUF4996	Domain of unknown function
+PF16389	DUF4998	Domain of unknown function
+PF16390	DUF4999	Domain of unknown function
+PF16391	DUF5000	Domain of unknown function
+PF16392	DUF5001	Domain of unknown function
+PF16394	DUF5003	Domain of unknown function (DUF5003)
+PF16395	DUF5004	Domain of unknown function (DUF5004)
+PF16396	DUF5005	Domain of unknown function (DUF5005)
+PF16397	DUF5006	Domain of unknown function (DUF5006)
+PF16398	DUF5007	Domain of unknown function (DUF5007)
+PF16399	Aquarius_N	Intron-binding protein aquarius N-terminus
+PF16400	DUF5008	Domain of unknown function (DUF5008)
+PF16401	DUF5009	Domain of unknown function (DUF5009)
+PF16402	DUF5010	Domain of unknown function (DUF5010)
+PF16403	DUF5011	Domain of unknown function (DUF5011)
+PF16404	DUF5012	Domain of unknown function (DUF5012)
+PF16405	DUF5013	Domain of unknown function (DUF5013)
+PF16406	DUF5014	Domain of unknown function (DUF5014)
+PF16407	PKD_2	PKD-like family
+PF16408	DUF5016	Domain of unknown function (DUF5016)
+PF16409	DUF5017	Domain of unknown function (DUF5017)
+PF16410	DUF5018	Domain of unknown function (DUF5018)
+PF16411	SusF_SusE	Outer membrane protein SusF_SusE
+PF16412	DUF5020	Domain of unknown function (DUF5020)
+PF16413	Mlh1_C	DNA mismatch repair protein Mlh1 C-terminus
+PF16414	NPC1_N	Niemann-Pick C1 N terminus
+PF16415	CNOT1_CAF1_bind	CCR4-NOT transcription complex subunit 1 CAF1-binding domain
+PF16416	GUN4_N	ARM-like repeat domain, GUN4-N terminal
+PF16417	CNOT1_TTP_bind	CCR4-NOT transcription complex subunit 1 TTP binding domain
+PF16418	CNOT1_HEAT	CCR4-NOT transcription complex subunit 1 HEAT repeat
+PF16419	CNOT1_HEAT_N	CCR4-NOT transcription complex subunit 1 HEAT repeat
+PF16420	ATG7_N	Ubiquitin-like modifier-activating enzyme ATG7 N-terminus
+PF16421	E2F_CC-MB	E2F transcription factor CC-MB domain
+PF16422	COE1_DBD	Transcription factor COE1 DNA-binding domain
+PF16423	COE1_HLH	Transcription factor COE1 helix-loop-helix domain
+PF16424	DUF5021	Domain of unknown function (DUF5021)
+PF16425	DUF5022	Domain of unknown function (DUF5022)
+PF16426	DUF5023	Domain of unknown function (DUF5023)
+PF16427	DUF5024	Domain of unknown function (DUF5024)
+PF16428	DUF5025	Domain of unknown function (DUF5025)
+PF16429	DUF5026	Domain of unknown function (DUF5026)
+PF16430	DUF5027	Domain of unknown function (DUF5027)
+PF16431	DUF5028	Domain of unknown function (DUF5028)
+PF16432	DUF5029	Domain of unknown function (DUF5029)
+PF16433	DUF5030	Domain of unknown function (DUF5030)
+PF16434	DUF5031	Domain of unknown function (DUF5031)
+PF16435	DUF5032	Domain of unknown function (DUF5032)
+PF16436	DUF5033	Domain of unknown function (DUF5033)
+PF16437	DUF5034	Domain of unknown function (DUF5034)
+PF16438	DUF5035	Domain of unknown function (DUF5035)
+PF16439	DUF5036	Domain of unknown function (DUF5036)
+PF16440	DUF5037	Domain of unknown function (DUF5037)
+PF16441	DUF5038	Domain of unknown function (DUF5038)
+PF16442	DUF5039	Domain of unknown function (DUF5039)
+PF16443	DUF5040	Domain of unknown function (DUF5040)
+PF16444	DUF5041	Domain of unknown function (DUF5041)
+PF16445	DUF5042	Domain of unknown function (DUF5042)
+PF16446	DUF5043	Domain of unknown function (DUF5043)
+PF16447	DUF5044	Domain of unknown function (DUF5044)
+PF16448	LapD_MoxY_N	LapD/MoxY periplasmic domain
+PF16449	MatB	Fimbrillin MatB
+PF16450	Prot_ATP_ID_OB	Proteasomal ATPase OB/ID domain
+PF16451	Spike_NTD	Spike glycoprotein N-terminal domain
+PF16452	Phage_CI_C	Bacteriophage CI repressor C-terminal domain
+PF16453	IQ_SEC7_PH	PH domain
+PF16454	PI3K_P85_iSH2	Phosphatidylinositol 3-kinase regulatory subunit P85 inter-SH2 domain
+PF16455	UBD	Ubiquitin-binding domain
+PF16456	YmgD	YmgD protein
+PF16457	PH_12	Pleckstrin homology domain
+PF16458	Beta-prism_lec	Beta-prism lectin
+PF16459	Phage_TAC_13	Phage tail assembly chaperone, TAC
+PF16460	Phage_TTP_11	Phage tail tube, TTP, lambda-like
+PF16461	Phage_TTP_12	Lambda phage tail tube protein, TTP
+PF16462	Phage_TAC_14	Phage tail assembly chaperone protein, TAC
+PF16463	Phage_TTP_13	Phage tail tube protein family
+PF16464	DUF5045	Domain of unknown function (DUF5045)
+PF16465	DUF5046	Domain of unknown function (DUF5046)
+PF16466	DUF5047	Domain of unknown function (DUF5047)
+PF16467	DUF5048	Domain of unknown function (DUF5048)
+PF16468	DUF5049	Domain of unknown function (DUF5049)
+PF16469	NPA	Nematode polyprotein allergen ABA-1
+PF16470	S8_pro-domain	Peptidase S8 pro-domain
+PF16471	JIP_LZII	JNK-interacting protein  leucine zipper II
+PF16472	DUF5050	Domain of unknown function (DUF5050)
+PF16473	DUF5051	3' exoribonuclease, RNase T-like
+PF16474	KIND	Kinase non-catalytic C-lobe domain
+PF16475	DUF5052	Domain of unknown function (DUF5052)
+PF16476	DUF5053	Domain of unknown function (DUF5053)
+PF16477	DUF5054	Domain of unknown function (DUF5054)
+PF16478	DUF5055	Domain of unknown function (DUF5055)
+PF16479	DUF5056	Domain of unknown function (DUF5056)
+PF16480	DUF5057	Domain of unknown function (DUF5057)
+PF16481	DUF5058	Domain of unknown function (DUF5058)
+PF16482	Staufen_C	Staufen C-terminal domain
+PF16483	Glyco_hydro_64	Beta-1,3-glucanase
+PF16484	CPT_N	Carnitine O-palmitoyltransferase N-terminus
+PF16485	PLN_propep	Protealysin propeptide
+PF16486	ArgoN	N-terminal domain of argonaute
+PF16487	ArgoMid	Mid domain of argonaute
+PF16488	ArgoL2	Argonaute linker 2 domain 
+PF16489	GAIN	GPCR-Autoproteolysis INducing (GAIN) domain
+PF16490	Oxidoreduct_C	Putative oxidoreductase C terminal domain
+PF16491	Peptidase_M48_N	CAAX prenyl protease N-terminal, five membrane helices
+PF16492	Cadherin_C_2	Cadherin cytoplasmic C-terminal
+PF16493	Meis_PKNOX_N	N-terminal of Homeobox Meis and PKNOX1
+PF16494	Na_Ca_ex_C	C-terminal extension of sodium/calcium exchanger domain
+PF16495	SWIRM-assoc_1	SWIRM-associated region 1
+PF16496	SWIRM-assoc_2	SWIRM-associated domain at the N-terminal
+PF16497	MHC_I_3	MHC-I family domain
+PF16498	SWIRM-assoc_3	SWIRM-associated domain at the C-terminal
+PF16499	Melibiase_2	Alpha galactosidase A
+PF16500	Cyclin_N2	N-terminal region of cyclin_N
+PF16501	SCAPER_N	S phase cyclin A-associated protein in the endoplasmic reticulum
+PF16502	DUF5059	Domain of unknown function (DUF5059)
+PF16503	zn-ribbon_14	Zinc-ribbon
+PF16504	SP24	Putative virion membrane protein of plant and insect virus
+PF16505	Emaravirus_P4	P4 movement protein of Emaravirus, and the 30K superfamily
+PF16506	DiSB-ORF2_chro	Putative virion glycoprotein of insect viruses
+PF16507	BLM10_mid	Proteasome-substrate-size regulator, mid region
+PF16508	NIBRIN_BRCT_II	Second BRCT domain on Nijmegen syndrome breakage protein
+PF16509	KORA	TrfB plasmid transcriptional repressor
+PF16510	P22_portal	Phage P22-like portal protein
+PF16511	FERM_f0	N-terminal or F0 domain of Talin-head FERM
+PF16512	RhoGAP-FF1	p190-A and -B Rho GAPs FF domain
+PF16514	NADH-UOR_E	putative NADH-ubiquinone oxidoreductase chain E
+PF16515	HIP1_clath_bdg	Clathrin-binding domain of Huntingtin-interacting protein 1
+PF16516	CC2-LZ	Leucine zipper of domain CC2 of NEMO, NF-kappa-B essential modulator
+PF16517	Nore1-SARAH	Novel Ras effector 1 C-terminal SARAH (Sav/Rassf/Hpo) domain
+PF16518	GrlR	T3SS negative regulator,GrlR
+PF16519	TRPM_tetra	Tetramerisation domain of TRPM
+PF16520	BDV_M	ssRNA-binding matrix protein of Bornaviridae
+PF16521	Myosin-VI_CBD	Myosin VI cargo binding domain
+PF16522	FliS_cochap	Flagellar FLiS export co-chaperone, HP1076
+PF16523	betaPIX_CC	betaPIX coiled coil
+PF16524	RisS_PPD	Periplasmic domain of Sensor histidine kinase RisS
+PF16525	MHB	Haemophore, haem-binding
+PF16526	CLZ	C-terminal leucine zipper domain of cyclic nucleotide-gated channels 
+PF16527	CpxA_peri	Two-component sensor protein CpxA, periplasmic domain
+PF16528	Exo84_C	Exocyst component 84 C-terminal
+PF16529	Ge1_WD40	WD40 region of Ge1, enhancer of mRNA-decapping protein
+PF16530	IHHNV_capsid	Infectious hypodermal and haematopoietic necrosis virus, capsid
+PF16531	SAS-6_N	Centriolar protein SAS N-terminal
+PF16532	Phage_tail_NK	Sf6-type phage tail needle knob or tip of some Caudovirales
+PF16533	SOAR	STIM1 Orai1-activating region
+PF16534	ULD	Ubiquitin-like oligomerisation domain of SATB
+PF16535	T3SSipB	Type III cell invasion protein SipB
+PF16536	PNKP-ligase_C	PNKP adenylyltransferase domain, C-terminal region
+PF16537	T2SSB	Type II secretion system protein B 
+PF16538	FlgT_C	Flagellar assembly protein T, C-terminal domain
+PF16539	FlgT_M	Flagellar assembly protein T, middle domain
+PF16540	MKLP1_Arf_bdg	Arf6-interacting domain of mitotic kinesin-like protein 1
+PF16541	AltA1	Alternaria alternata allergen 1
+PF16542	PNKP_ligase	PNKP adenylyltransferase domain, ligase domain
+PF16543	DFRP_C	DRG Family Regulatory Proteins, Tma46
+PF16544	STAR_dimer	Homodimerisation region of STAR domain protein
+PF16545	CCM2_C	Cerebral cavernous malformation protein, harmonin-homology 
+PF16546	SGTA_dimer	Homodimerisation domain of SGTA
+PF16547	BLM10_N	Proteasome-substrate-size regulator, N-terminal
+PF16548	FlgT_N	Flagellar assembly protein T, N-terminal domain
+PF16549	T2SSS_2	Type II secretion system (T2SS) pilotin, S protein
+PF16550	RPN13_C	UCH-binding domain
+PF16551	Quaking_NLS	Putative nuclear localisation signal of quaking
+PF16552	OAM_alpha	D-ornithine 4,5-aminomutase alpha-subunit
+PF16553	PUFD	BCORL-PCGF1-binding domain
+PF16554	OAM_dimer	Dimerisation domain of d-ornithine 4,5-aminomutase
+PF16555	GramPos_pilinD1	Gram-positive pilin subunit D1, N-terminal
+PF16556	IL17R_fnIII_D1	Interleukin-17 receptor, fibronectin-III-like domain 1
+PF16557	CUTL	CUT1-like DNA-binding domain of SATB
+PF16558	AZUL	Amino-terminal Zinc-binding domain of ubiquitin ligase E3A
+PF16559	GIT_CC	GIT coiled-coil Rho guanine nucleotide exchange factor
+PF16560	SAPI	Putative mobile pathogenicity island
+PF16561	AMPK1_CBM	Glycogen recognition site of AMP-activated protein kinase
+PF16562	HECW_N	N-terminal domain of E3 ubiquitin-protein ligase HECW1 and 2
+PF16563	P66_CC	Coiled-coil and interaction region of P66A and P66B with MBD2
+PF16564	MBDa	p55-binding region of Methyl-CpG-binding domain proteins MBD
+PF16565	MIT_C	Phospholipase D-like domain at C-terminus of MIT
+PF16566	CREPT	Cell-cycle alteration and expression-elevated protein in tumour
+PF16567	CagD	Pathogenicity island component CagD
+PF16568	Sam68-YY	Tyrosine-rich domain of Sam68
+PF16569	GramPos_pilinBB	Gram-positive pilin backbone subunit 2, Cna-B-like domain
+PF16570	GramPos_pilinD3	Gram-positive pilin backbone subunit 3, Cna-B-like domain
+PF16571	FBP_C	FBP C-terminal treble-clef zinc-finger
+PF16572	HlyD_D4	Long alpha hairpin domain of cation efflux system protein, CusB
+PF16573	CLP1_N	N-terminal beta-sandwich domain of polyadenylation factor
+PF16574	CEP209_CC5	Coiled-coil region of centrosome protein CE290
+PF16575	CLP1_P	mRNA cleavage and polyadenylation factor CLP1 P-loop
+PF16576	HlyD_D23	Barrel-sandwich domain of CusB or HlyD membrane-fusion
+PF16577	UBA_5	UBA domain
+PF16578	IL17R_fnIII_D2	Interleukin 17 receptor D
+PF16579	AdenylateSensor	Adenylate sensor of SNF1-like protein kinase
+PF16580	Astro_capsid_p2	C-terminal tail of astrovirus capsid projection or spike
+PF16581	HIGH_NTase1_ass	Cytidyltransferase-related C-terminal region
+PF16582	TPP_enzyme_M_2	Middle domain of thiamine pyrophosphate
+PF16583	ZirS_C	Zinc-regulated secreted antivirulence protein C-terminal domain
+PF16584	LolA_2	Outer membrane lipoprotein carrier protein LolA
+PF16585	Lipocalin_8	Lipocalin-like domain
+PF16586	DUF5060	Domain of unknown function (DUF5060)
+PF16587	DUF5061	17 kDa common-antigen outer membrane protein
+PF16588	zf-C2H2_10	C2H2 zinc-finger
+PF16589	BRCT_2	BRCT domain, a BRCA1 C-terminus domain
+PF16590	ESP	Exocrine gland-secreting peptide
+PF16591	HBM	Helical bimodular sensor domain
+PF16592	Cas9_REC	REC lobe of CRISPR-associated endonuclease Cas9
+PF16593	Cas9-BH	Bridge helix of CRISPR-associated endonuclease Cas9
+PF16594	ATP-synt_Z	Putative AtpZ or ATP-synthase-associated
+PF16595	Cas9_PI	PAM-interacting domain of CRISPR-associated endonuclease Cas9
+PF16596	MFMR_assoc	Disordered region downstream of MFMR
+PF16597	Thyroglob_assoc	Thyroglobulin_1 repeat associated disordered domain
+PF16598	Edc3_linker	Linker region of enhancer of mRNA-decapping protein 3
+PF16599	PTN13_u3	Unstructured linker region on PTN13 protein between PDZ
+PF16600	Caskin1-CID	Caskin1 CASK-interaction domain
+PF16601	NPF	Rabosyn-5 repeating NPF sequence-motif
+PF16602	USP19_linker	Linker region of USP19 deubiquitinase
+PF16605	LSM_int_assoc	LSM-interacting associated unstructured 
+PF16606	zf-C2H2_assoc	Unstructured conserved, between two C2H2-type zinc-fingers
+PF16607	CYLD_phos_site	Phosphorylation region of CYLD, unstructured
+PF16608	TNRC6-PABC_bdg	TNRC6-PABC binding domain
+PF16609	SH3-RhoG_link	SH3-RhoGEF linking unstructured region
+PF16610	dbPDZ_assoc	Unstructured region between two PDZ domains on Dlg5
+PF16611	RGS12_us2	Unstructured region between RBD and GoLoco
+PF16612	RGS12_usC	C-terminal unstructured region of RGS12
+PF16613	RGS12_us1	Unstructured region of RGS12
+PF16614	RhoGEF67_u2	Unstructured region two on RhoGEF 6 and 7
+PF16615	RhoGEF67_u1	Unstructured region one on RhoGEF 6 and 7
+PF16616	PHC2_SAM_assoc	Unstructured region on Polyhomeotic-like protein 1 and 2
+PF16617	INTAP	Intersectin and clathrin adaptor AP2 binding region
+PF16618	SH3-WW_linker	Linker region between SH3 and WW domains on ARHGAP12
+PF16619	SUIM_assoc	Unstructured region C-term to UIM in Ataxin3
+PF16620	23ISL	Unstructured linker between I-set domains 2 and 3 on MYLCK
+PF16621	NECFESHC	SH3 terminal domain of 2nd SH3 on Neutrophil cytosol factor 1
+PF16622	zf-C2H2_11	zinc-finger C2H2-type
+PF16623	WW_FCH_linker	Unstructured linker region between on GAS7 protein
+PF16624	zf-C2H2_assoc2	Unstructured region upstream of a zinc-finger
+PF16625	ISET-FN3_linker	Unstructured linking region I-set and fnIII on Brother of CDO
+PF16626	Papilin_u7	Linking region between Kunitz_BPTI and I-set on papilin
+PF16627	BRX_assoc	Unstructured region between BRX_N and BRX domain
+PF16628	Mac_assoc	Unstructured region on maltose acetyltransferase
+PF16629	Arm_APC_u3	Armadillo-associated region on APC
+PF16630	APC_u5	Unstructured region on APC between 1st and 2nd catenin-bdg motifs
+PF16631	TUTF7_u4	Unstructured region 4 on terminal uridylyltransferase 7
+PF16632	Caskin-tail	C-terminal region of Caskin
+PF16633	APC_u9	Unstructured region on APC between 1st two creatine-rich regions
+PF16634	APC_u13	Unstructured region on APC between APC_crr and SAMP
+PF16635	APC_u14	Unstructured region on APC between SAMP and APC_crr
+PF16636	APC_u15	Unstructured region on APC between APC_crr regions 5 and 6
+PF16637	zf-C2H2_assoc3	Putative zinc-finger between two C2H2 zinc-fingers on Patz
+PF16638	Tristanin_u2	Unstructured region on methyltransferase between zinc-fingers
+PF16639	Apocytochr_F_N	Apocytochrome F, N-terminal
+PF16640	Big_3_5	Bacterial Ig-like domain (group 3)
+PF16641	CLIP1_ZNF	CLIP1 zinc knuckle
+PF16642	KCNQ2_u3	Unstructured region on Potassium channel subunit alpha KvLQT2
+PF16643	cNMPbd_u2	Unstructured region on cNMP-binding protein
+PF16644	NEXCaM_BD	Regulatory region of Na+/H+ exchanger NHE binds to calmodulin
+PF16645	PHtD_u1	Unstructured region on Pneumococcal histidine triad protein
+PF16646	AXIN1_TNKS_BD	Axin-1 tankyrase binding domain
+PF16647	GCSF	Granulocyte colony-stimulating factor
+PF16648	Calpain_u2	Unstructured region on Calpain-3
+PF16649	IL23	Interleukin 23 subunit alpha
+PF16650	SPEG_u2	Unstructured region on SPEG complex protein
+PF16652	PH_13	Pleckstrin homology domain
+PF16653	Sacchrp_dh_C	Saccharopine dehydrogenase C-terminal domain
+PF16654	DAPDH_C	Diaminopimelic acid dehydrogenase C-terminal domain
+PF16655	PhoD_N	PhoD-like phosphatase, N-terminal domain
+PF16656	Pur_ac_phosph_N	Purple acid Phosphatase, N-terminal domain
+PF16657	Malt_amylase_C	Maltogenic Amylase, C-terminal domain
+PF16658	RF3_C	Class II release factor RF3, C-terminal domain
+PF16660	PHD20L1_u1	PHD finger protein 20-like protein 1
+PF16661	Lactamase_B_6	Metallo-beta-lactamase superfamily domain
+PF16662	FLYWCH_u	FLYWCH-type zinc finger-containing protein 1
+PF16663	MAGI_u1	Unstructured region on MAGI 
+PF16664	STAC2_u1	Unstructured on SH3 and cysteine-rich domain-containing protein 2
+PF16665	NCOA_u2	Unstructured region on nuclear receptor coactivator protein
+PF16666	MAGI_u5	Unstructured region on MAGI
+PF16667	MPDZ_u10	Unstructured region 10 on multiple PDZ protein
+PF16668	JLPA	Adhesin from Campylobacter
+PF16669	TTC5_OB	Tetratricopeptide repeat protein 5 OB fold domain
+PF16670	PI-PLC-C1	Phosphoinositide phospholipase C, Ca2+-dependent
+PF16671	ACD	Actin cross-linking domain
+PF16672	LAMTOR5	Ragulator complex protein LAMTOR5
+PF16673	TRAF_BIRC3_bd	TNF receptor-associated factor BIRC3 binding domain
+PF16674	UCH_N	N-terminal of ubiquitin carboxyl-terminal hydrolase 37
+PF16675	FOXO_KIX_bdg	KIX-binding domain of forkhead box O, CR2
+PF16676	FOXO-TAD	Transactivation domain of FOXO protein family
+PF16677	GP3_package	DNA-packaging protein gp3
+PF16678	HOIP-UBA	HOIP UBA domain pair
+PF16679	CDT1_C	DNA replication factor Cdt1 C-terminal domain
+PF16680	Ig_4	T-cell surface glycoprotein CD3 delta chain 
+PF16681	Ig_5	Ig-like domain on T-cell surface glycoprotein CD3 epsilon chain
+PF16682	MSL2-CXC	CXC domain of E3 ubiquitin-protein ligase MSL2
+PF16683	TGase_elicitor	Transglutaminase elicitor
+PF16684	Telomere_res	Telomere resolvase
+PF16685	zf-RING_10	zinc RING finger of MSL2
+PF16686	POT1PC	ssDNA-binding domain of telomere protection protein
+PF16687	ELYS-bb	beta-propeller of ELYS nucleoporin
+PF16688	CNV-Replicase_N	Replicase polyprotein N-term from Coronavirus nsp1
+PF16689	APC_N_CC	Coiled-coil N-terminus of APC, dimerisation domain
+PF16690	MMACHC	Methylmalonic aciduria and homocystinuria type C family
+PF16691	DUF5062	Domain of unknown function (DUF5062)
+PF16692	Folliculin_C	Folliculin C-terminal domain
+PF16693	Yop-YscD_ppl	Inner membrane component of T3SS, periplasmic domain
+PF16694	Cytochrome_P460	Cytochrome P460
+PF16695	Tai4	Type VI secretion system (T6SS), amidase immunity protein
+PF16696	ZFYVE21_C	Zinc finger FYVE domain-containing protein 21 C-terminus
+PF16697	Yop-YscD_cpl	Inner membrane component of T3SS, cytoplasmic domain
+PF16698	ADAM17_MPD	Membrane-proximal domain, switch, for ADAM17
+PF16699	CSTF1_dimer	Cleavage stimulation factor subunit 1, dimerisation domain
+PF16700	SNCAIP_SNCA_bd	Synphilin-1 alpha-Synuclein-binding domain
+PF16701	Ad_Cy_reg	Adenylate cyclase regulatory domain
+PF16702	DUF5063	Domain of unknown function (DUF5063)
+PF16703	DUF5064	Domain of unknown function (DUF5064)
+PF16704	Rab_bind	Rab binding domain
+PF16705	NUDIX_5	NUDIX, or N-terminal NPxY motif-rich,  region of KRIT
+PF16706	Izumo-Ig	Izumo-like Immunoglobulin domain
+PF16707	CagS	Cag pathogenicity island protein S of Helicobacter pylori
+PF16708	LppA	Lipoprotein confined to pathogenic Mycobacterium
+PF16709	SCAB-IgPH	Fused Ig-PH domain of plant-specific actin-binding protein
+PF16710	CTXphi_pIII-N1	N-terminal N1 domain of Vibrio phage CTXphi pIII
+PF16711	SCAB-ABD	Actin-binding domain of plant-specific actin-binding protein
+PF16712	SCAB_CC	Coiled-coil regions of plant-specific actin-binding protein
+PF16713	EAGR_box	Enriched in aromatic and glycine Residues box
+PF16714	TyrRSs_C	Tyrosyl-tRNA synthetase C-terminal domain
+PF16715	CDPS	Cyclodipeptide synthase
+PF16716	BST2	Bone marrow stromal antigen 2
+PF16717	RAC_head	Ribosome-associated complex head domain
+PF16718	IFS	Immunity factor for SPN
+PF16719	SAWADEE	SAWADEE domain
+PF16720	Albumin_I_a	Albumin I chain a
+PF16721	zf-H3C2	Zinc-finger like, probable DNA-binding 
+PF16722	SAPIS-gp6	Pathogenicity island protein gp6 in Staphylococcus
+PF16723	DUF5065	Domain of unknown function (DUF5065)
+PF16724	T4-gp15_tss	T4-like virus Myoviridae tail sheath stabiliser
+PF16725	Nucleolin_bd	Nucleolin binding domain
+PF16726	OCRL_clath_bd	Inositol polyphosphate 5-phosphatase clathrin binding domain
+PF16727	REV1_C	DNA repair protein REV1 C-terminal domain
+PF16728	DUF5066	Domain of unknown function (DUF5066)
+PF16729	DUF5067	Domain of unknown function (DUF5067)
+PF16730	DnaGprimase_HBD	DnaG-primase C-terminal, helicase-binding domain
+PF16731	GARP	Glutamic acid/alanine-rich protein of Trypanosoma
+PF16732	ComP_DUS	Type IV minor pilin ComP, DNA uptake sequence receptor
+PF16733	NRho	Rhomboid N-terminal domain
+PF16734	Pilin_GH	Type IV pilin-like G and H, putative
+PF16735	MYO10_CC	Unconventional myosin-X coiled coil domain
+PF16736	sCache_like	Single Cache-like 
+PF16737	PHF12_MRG_bd	PHD finger protein 12 MRG binding domain
+PF16738	CBM26	Starch-binding module 26
+PF16739	CARD_2	Caspase recruitment domain
+PF16740	SKA2	Spindle and kinetochore-associated protein 2
+PF16741	mRNA_decap_C	mRNA-decapping enzyme C-terminus
+PF16742	IL17R_D_N	N-terminus of interleukin 17 receptor D
+PF16743	PliI	Periplasmic lysozyme inhibitor of I-type lysozyme
+PF16744	Zf_RING	KIAA1045 RING finger
+PF16745	RsgA_N	RsgA N-terminal domain
+PF16746	BAR_3	BAR domain of APPL family
+PF16747	Adhesin_E	Surface-adhesin protein E
+PF16748	INSC_LBD	Inscuteable LGN-binding domain
+PF16749	Arteri_nsp7a	Arterivirus nonstructural protein 7 alpha 
+PF16750	HK_sensor	Sensor domain of 2-component histidine kinase
+PF16751	RsdA_SigD_bd	Anti-sigma-D factor RsdA to sigma factor binding region
+PF16752	TBCC_N	Tubulin-specific chaperone C N-terminal domain
+PF16753	Tipalpha	TNF-alpha-Inducing protein of Helicobacter
+PF16754	Pesticin	Bacterial toxin homologue of phage lysozyme, C-term
+PF16755	NUP214	Nucleoporin or Nuclear pore complex subunit NUP214=Nup159
+PF16756	PALB2_WD40	Partner and localizer of BRCA2 WD40 domain
+PF16757	Fucosidase_C	Alpha-L-fucosidase C-terminal domain
+PF16758	UL141	Herpes-like virus membrane glycoprotein UL141
+PF16759	LIG3_BRCT	DNA ligase 3 BRCT domain
+PF16760	CBM53	Starch/carbohydrate-binding module (family 53)
+PF16761	Clr2_transil	Transcription-silencing protein, cryptic loci regulator Clr2
+PF16762	RHH_6	Ribbon-helix-helix domain
+PF16763	Spidroin_N	Major ampullate spidroin 1, spider silk protein 1, N-term
+PF16764	Sharpin_PH	Sharpin PH domain
+PF16765	Pim	Pesticin immunity protein
+PF16766	CID_GANP	Binding region of GANP to ENY2
+PF16767	KinB_sensor	Sensor domain of alginate biosynthesis sensor protein KinB
+PF16768	NupH_GANP	Nucleoporin homology of Germinal-centre associated nuclear protein
+PF16769	MCM3AP_GANP	MCM3AP domain of GANP
+PF16770	RTT107_BRCT_5	Regulator of Ty1 transposition protein 107 BRCT domain
+PF16771	RTT107_BRCT_6	Regulator of Ty1 transposition protein 107 BRCT domain
+PF16772	TERF2_RBM	Telomeric repeat-binding factor 2 Rap1-binding motif
+PF16773	Phage_SSB	Lactococcus phage single-stranded DNA binding protein
+PF16774	Baseplate	Baseplate protein
+PF16775	ZoocinA_TRD	Target recognition domain of lytic exoenzyme
+PF16776	INPP5B_PH	Type II inositol 1,4,5-trisphosphate 5-phosphatase PH domain
+PF16777	RHH_7	Transcriptional regulator, RHH-like, CopG
+PF16778	Phage_tail_APC	Phage tail assembly chaperone protein
+PF16779	DMP12	DNA-mimic protein
+PF16780	AIMP2_LysRS_bd	AIMP2 lysyl-tRNA synthetase binding domain
+PF16781	DUF5068	Domain of unknown function (DUF5068)
+PF16782	SIL1	Nucleotide exchange factor SIL1
+PF16783	FANCM-MHF_bd	FANCM to MHF binding domain
+PF16784	HNHc_6	Putative HNHc nuclease
+PF16785	SMBP	Small metal-binding protein
+PF16786	RecA_dep_nuc	Recombination enhancement, RecA-dependent nuclease
+PF16787	NDC10_II	Centromere DNA-binding protein complex CBF3 subunit, domain 2
+PF16788	ATF7IP_BD	ATF-interacting protein binding domain
+PF16789	YscO-like	YscO-like protein
+PF16790	Phage_clamp_A	Bacteriophage clamp loader A subunit
+PF16791	Connexin40_C	Connexin 40 C-terminal domain
+PF16792	Caudo_bapla16	Phage tail base-plate attachment protein of Caudovirales ORF16
+PF16793	RepB_primase	RepB DNA-primase from phage plasmid
+PF16794	fn3_4	Fibronectin-III type domain
+PF16795	Phage_integr_3	Archaeal phage integrase
+PF16796	Microtub_bd	Microtubule binding
+PF16797	Fungal_KA1	Fungal kinase associated-1 domain
+PF16798	DUF5069	Domain of unknown function (DUF5069)
+PF16799	VGPC1_C	C-terminal membrane-localisation domain of ion-channel, VCN1
+PF16800	Endopep_inhib	IseA DL-endopeptidase inhibitor
+PF16801	MSL1_dimer	Dimerisation domain of Male-specific-Lethal 1
+PF16802	DUF5070	Domain of unknown function (DUF5070)
+PF16803	DRE2_N	Fe-S cluster assembly protein DRE2 N-terminus
+PF16804	DUF5071	Domain of unknown function (DUF5071)
+PF16805	Trans_coact	Phage late-transcription coactivator
+PF16806	ExsD	Antiactivator protein ExsD
+PF16807	DUF5072	Domain of unknown function (DUF5072)
+PF16808	PKcGMP_CC	Coiled-coil N-terminus of cGMP-dependent protein kinase
+PF16809	NleF_casp_inhib	NleF caspase inhibitor
+PF16810	RXLR	RXLR phytopathogen effector protein, Avirulence activity
+PF16811	TAtT	TRAP transporter T-component
+PF16812	AdHead_fibreRBD	C-terminal head domain of the fowl adenovirus type 1 long fibre
+PF16813	Cas_St_Csn2	CRISPR-associated protein Csn2 subfamily St
+PF16814	Read-through	Read-through domain
+PF16815	HRI1	Protein HRI1
+PF16816	DotD	DotD protein
+PF16817	DUF5073	Domain of unknown function (DUF5073)
+PF16818	SLM4	Protein SLM4
+PF16819	DUF5074	Domain of unknown function (DUF5074)
+PF16820	PKD_3	PKD-like domain
+PF16821	C_Hendra	C protein from hendra and measles viruses
+PF16822	ALGX	SGNH hydrolase-like domain, acetyltransferase AlgX
+PF16823	PilZ_2	Atypical PilZ domain, cyclic di-GMP receptor
+PF16824	CBM_26	C-terminal carbohydrate-binding module
+PF16825	DUF5075	IGP family C-type lectin domain
+PF16826	DUF5076	Domain of unknown function (DUF5076)
+PF16827	zf-HC3	zinc-finger
+PF16828	GAGBD	GAG-binding domain on surface antigen
+PF16829	ATR13	Avirulence protein ATR13, RxLR effector
+PF16830	NBD94	Nucleotide-Binding Domain 94 of RH
+PF16831	CssAB	CS6 fimbrial subunits A and B, Coli surface antigen 6
+PF16832	EKLF_TAD1	Erythroid krueppel-like transcription factor, transactivation 1
+PF16833	EKLF_TAD2	Erythroid krueppel-like transcription factor, transactivation 2
+PF16834	CSM2	Shu complex component Csm2, DNA-binding
+PF16835	SF3A2	Pre-mRNA-splicing factor SF3a complex subunit 2 (Prp11)
+PF16836	PSY3	Shu complex component Psy3, DNA-binding description
+PF16837	SF3A3	Pre-mRNA-splicing factor SF3A3, of SF3a complex, Prp9
+PF16838	Caud_tail_N	Caudoviral major tail protein N-terminus
+PF16839	Antimicrobial25	Nematode antimicrobial peptide
+PF16840	ACTL7A_N	Actin-like protein 7A N-terminus
+PF16841	CBM60	Ca-dependent carbohydrate-binding module xylan-binding
+PF16842	RRM_occluded	Occluded RNA-recognition motif
+PF16843	Get5_bdg	Binding domain to Get4 on Get5, Golgi to ER traffic protein 
+PF16844	DIMCO_N	Dinitrogenase iron-molybdenum cofactor, N-terminal      
+PF16845	SQAPI	Aspartic acid proteinase inhibitor
+PF16846	Cep3	Centromere DNA-binding protein complex CBF3 subunit B
+PF16847	AvrPtoB_bdg	Avirulence AvrPtoB, BAK1-binding domain
+PF16848	SoDot-IcmSS	Substrate of the Dot/Icm secretion system, putative
+PF16849	Glyco_transf_88	Glycosyltransferase family 88
+PF16850	Inhibitor_I66	Peptidase inhibitor I66
+PF16851	Stomagen	Stomagen
+PF16852	HHV-1_VABD	Herpes viral adaptor-to-host cellular mRNA binding domain
+PF16853	CDC13_N	Cell division control protein 13 N-terminus
+PF16854	VPS53_C	Vacuolar protein sorting-associated protein 53 C-terminus
+PF16855	Soc	Small outer capsid protein
+PF16856	CDC4_D	Cell division control protein 4 dimerisation domain
+PF16857	RNA_pol_inhib	RNA polymerase inhibitor
+PF16858	CNDH2_C	Condensin II complex subunit CAP-H2 or CNDH2, C-term
+PF16859	TetR_C_11	Bacterial transcriptional repressor C-terminal
+PF16860	CX9C	CHCH-CHCH-like Cx9C, IMS import disulfide relay-system,
+PF16861	Carbam_trans_C	Carbamoyltransferase C-terminus
+PF16862	Glyco_hydro_79C	Glycosyl hydrolase family 79 C-terminal beta domain
+PF16863	NtCtMGAM_N	N-terminal barrel of NtMGAM and CtMGAM, maltase-glucoamylase
+PF16864	Dimerisation2	Dimerisation domain
+PF16865	GST_C_5	Glutathione S-transferase, C-terminal domain
+PF16866	PHD_4	PHD-finger
+PF16867	DMSP_lyase	Dimethlysulfonioproprionate lyase
+PF16868	NMT1_3	NMT1-like family
+PF16869	CNDH2_M	PF16858
+PF16870	OxoGdeHyase_C	2-oxoglutarate dehydrogenase C-terminal
+PF16871	DUF5077	Domain of unknown function (DUF5077)
+PF16872	putAbiC	Putative phage abortive infection protein
+PF16873	AbiGii_2	Putative abortive phage resistance protein AbiGii toxin
+PF16874	Glyco_hydro_36C	Glycosyl hydrolase family 36 C-terminal domain
+PF16875	Glyco_hydro_36N	Glycosyl hydrolase family 36 N-terminal domain
+PF16876	Lipin_mid	Lipin/Ned1/Smp2 multi-domain protein middle domain
+PF16877	DUF5078	Domain of unknown function (DUF5078)
+PF16878	SIX1_SD	Transcriptional regulator, SIX1, N-terminal SD domain
+PF16879	Sin3a_C	C-terminal domain of Sin3a protein
+PF16880	EHD_N	N-terminal EH-domain containing protein
+PF16881	LIAS_N	N-terminal domain of lipoyl synthase of Radical_SAM family
+PF16882	DUF5079	Domain of unknown function (DUF5079)
+PF16883	DUF5080	Domain of unknown function (DUF5080)
+PF16884	ADH_N_2	N-terminal domain of oxidoreductase
+PF16885	CAC1F_C	Voltage-gated calcium channel subunit alpha, C-term
+PF16886	ATP-synt_ab_Xtn	ATPsynthase alpha/beta subunit N-term extension
+PF16887	DUF5081	Domain of unknown function (DUF5081)
+PF16888	DUF5082	Domain of unknown function (DUF5082)
+PF16889	Hepar_II_III_N	Heparinase II/III N-terminus
+PF16890	DUF5083	Domain of unknown function (DUF5083)
+PF16891	STPPase_N	Serine-threonine protein phosphatase N-terminal domain
+PF16892	CHS5_N	Chitin biosynthesis protein CHS5 N-terminus
+PF16893	fn3_2	Fibronectin type III domain
+PF16894	DUF5084	Domain of unknown function (DUF5084)
+PF16895	DUF5085	Domain of unknown function (DUF5085)
+PF16896	PGDH_C	Phosphogluconate dehydrogenase (decarboxylating) C-term
+PF16897	MMR_HSR1_Xtn	C-terminal region of MMR_HSR1 domain
+PF16898	TOPRIM_C	C-terminal associated domain of TOPRIM
+PF16899	Cyclin_C_2	Cyclin C-terminal domain
+PF16900	REPA_OB_2	Replication protein A OB domain
+PF16901	DAO_C	C-terminal domain of alpha-glycerophosphate oxidase
+PF16902	Type2_restr_D3	Type-2 restriction enzyme D3 domain
+PF16903	Capsid_N	Major capsid protein N-terminus
+PF16904	PurL_C	Phosphoribosylformylglycinamidine synthase II C-terminus
+PF16905	GPHH	Voltage-dependent L-type calcium channel, IQ-associated
+PF16906	Ribosomal_L26	Ribosomal proteins L26 eukaryotic, L24P archaeal
+PF16907	Caskin-Pro-rich	Proline rich region of Caskin proteins
+PF16908	VPS13	Vacuolar sorting-associated protein 13, N-terminal
+PF16909	VPS13_C	Vacuolar-sorting-associated 13 protein C-terminal
+PF16910	VPS13_mid_rpt	Repeating coiled region of VPS13
+PF16911	PapA_C	Phthiocerol/phthiodiolone dimycocerosyl transferase C-terminus
+PF16912	Glu_dehyd_C	Glucose dehydrogenase C-terminus
+PF16913	PUNUT	Purine nucleobase transmembrane transport
+PF16914	TetR_C_12	Bacterial transcriptional repressor C-terminal
+PF16915	Eryth_link_C	Annelid erythrocruorin linker subunit C-terminus
+PF16916	ZT_dimer	Dimerisation domain of Zinc Transporter
+PF16917	BPL_LplA_LipB_2	Biotin/lipoate A/B protein ligase family
+PF16918	PknG_TPR	Protein kinase G tetratricopeptide repeat
+PF16919	PknG_rubred	Protein kinase G rubredoxin domain
+PF16920	TPKR_C2	Tyrosine-protein kinase receptor C2 Ig-like domain
+PF16921	Tex_YqgF	Tex protein YqgF-like domain
+PF16922	SLD5_C	DNA replication complex GINS protein SLD5 C-terminus
+PF16923	Glyco_hydro_63N	Glycosyl hydrolase family 63 N-terminal domain
+PF16924	DpaA_N	Dipicolinate synthase subunit A N-terminal domain
+PF16925	TetR_C_13	Bacterial transcriptional repressor C-terminal
+PF16926	HisKA_4TM	Archaeal 4TM region of histidine kinase
+PF16927	HisKA_7TM	N-terminal 7TM region of histidine kinase
+PF16928	Inj_translocase	DNA/protein translocase of phage P22 injectosome
+PF16929	Asp2	Accessory Sec system GspB-transporter
+PF16930	Porin_5	Putative porin
+PF16931	Phage_holin_8	Putative phage holin
+PF16932	T4SS_TraI	Type IV secretory system, conjugal DNA-protein transfer
+PF16933	PelG	Putative exopolysaccharide Exporter (EPS-E)
+PF16934	Mersacidin	Two-component Enterococcus faecalis cytolysin (EFC)
+PF16935	Hol_Tox	Putative Holin-like Toxin (Hol-Tox)
+PF16936	Holin_9	Putative holin
+PF16937	T3SS_HrpK1	Type III secretion system translocator protein, HrpF
+PF16938	Phage_holin_Dp1	Putative phage holin Dp-1
+PF16939	Porin_6	Putative porin
+PF16940	Tic110	Chloroplast envelope transporter
+PF16941	CymA	Putative cyclodextrin porin
+PF16942	CclA_1	Putative cyclic bacteriocin
+PF16943	T4SS_CagC	Cag pathogenicity island, type IV secretory system
+PF16944	KCH	Fungal potassium channel
+PF16945	Phage_r1t_holin	Putative lactococcus lactis phage r1t holin
+PF16946	Porin_OmpG_1_2	OMPG-porin 1 family
+PF16947	Ferredoxin_N	N-terminal region of 4Fe-4S ferredoxin iron-sulfur binding
+PF16949	ABC_tran_2	Putative ATP-binding cassette
+PF16951	MaAIMP_sms	Putative methionine and alanine importer, small subunit
+PF16952	Gln-synt_N_2	Glutamine synthetase N-terminal domain
+PF16953	PRORP	Protein-only RNase P
+PF16954	HRG	Haem-transporter, endosomal/lysosomal, haem-responsive gene 
+PF16955	OFeT_1	Ferrous iron uptake permease, iron-lead transporter
+PF16956	Porin_7	Putative general bacterial porin
+PF16957	Mal_decarbox_Al	Malonate decarboxylase, alpha subunit, transporter
+PF16958	PRP9_N	Pre-mRNA-splicing factor PRP9 N-terminus
+PF16959	Collectrin	Renal amino acid transporter
+PF16960	HpuA	Haemoglobin-haptoglobin utilisation, porphyrin transporter
+PF16961	OmpA_like	Putative OmpA-OmpF-like porin family
+PF16962	ABC_export	Putative ABC exporter
+PF16963	PelD_GGDEF	PelD GGDEF domain
+PF16964	TadF	Putative tight adherence pilin protein F
+PF16965	CSG2	Ceramide synthase regulator
+PF16966	Porin_8	Porin-like glycoporin RafY
+PF16967	TcfC	E-set like domain
+PF16968	TadZ_N	Pilus assembly protein TadZ N-terminal
+PF16969	SRP68	RNA-binding signal recognition particle 68
+PF16970	FimA	Type-1 fimbrial protein, A
+PF16971	RcpB	Rough colony protein B, tight adherence - tad - subunit
+PF16972	TipE	Na+ channel auxiliary subunit TipE
+PF16973	FliN_N	Flagellar motor switch protein FliN N-terminal
+PF16974	NAR2	High-affinity nitrate transporter accessory
+PF16975	UPAR_LY6_2	Ly6/PLAUR domain-containing protein 6, Lypd6
+PF16976	RcpC	Flp pilus assembly protein RcpC/CpaB
+PF16977	ApeC	C-terminal domain of apextrin
+PF16978	CRIM	SAPK-interacting protein 1 (Sin1), middle CRIM domain
+PF16979	SIN1_PH	SAPK-interacting protein 1 (Sin1), Pleckstrin-homology
+PF16980	CitMHS_2	Putative citrate transport
+PF16981	Chi-conotoxin	chi-Conotoxin or t superfamily
+PF16982	Flp1_like	Putative Flagellin, Flp1-like, domain
+PF16983	MFS_MOT1	Molybdate transporter of MFS superfamily
+PF16984	Grp7_allergen	Group 7 allergen
+PF16985	DUF5086	Domain of unknown function (DUF5086)
+PF16986	CzcE	Heavy-metal resistance protein CzcE
+PF16987	KIX_2	KIX domain
+PF16988	Vps36-NZF-N	Vacuolar protein sorting 36 NZF-N zinc-finger domain
+PF16989	T6SS_VasJ	Type VI secretion, EvfE, EvfF, ImpA, BimE, VC_A0119, VasJ
+PF16990	CBM_35	Carbohydrate binding module (family 35)
+PF16991	SIR4_SID	Sir4 SID domain
+PF16992	RNA_pol_RpbG	DNA-directed RNA polymerase, subunit G
+PF16993	Asp1	Accessory Sec system protein Asp1
+PF16994	Glyco_trans_4_5	Glycosyl-transferase family 4
+PF16995	tRNA-synt_2_TM	Transmembrane region of lysyl-tRNA synthetase
+PF16996	Asp4	Accessory secretory protein Sec Asp4
+PF16997	Wap1	Wap1 domain
+PF16998	17kDa_Anti_2	17 kDa outer membrane surface antigen
+PF16999	V-ATPase_G_2	Vacuolar (H+)-ATPase G subunit
+PF17000	Asp5	Accessory secretory protein Sec, Asp5
+PF17001	T3SS_basalb_I	Type III secretion basal body protein I, YscI, HrpB, PscI
+PF17002	DUF5089	Domain of unknown function (DUF5089)
+PF17003	Actin_micro	Putative actin-like family
+PF17004	SRP_TPR_like	Putative TPR-like repeat
+PF17005	WD40_like	WD40-like domain
+PF17006	DUF5087	Domain of unknown function (DUF5087)
+PF17007	HTH_micro	HTH-like
+PF17008	DUF5088	Domain of unknown function (DUF5088)
+PF17009	DUF5090	Domain of unknown function (DUF5090)
+PF17010	DUF5092	Domain of unknown function (DUF5092)
+PF17011	DUF5093	Domain of unknown function (DUF5093)
+PF17012	DUF5091	Domain of unknown function (DUF5091)
+PF17013	Acetyltransf_15	Putative acetyl-transferase
+PF17014	Mad3_BUB1_I_2	Putative Mad3/BUB1 like region 1 protein
+PF17015	DUF5094	Domain of unknown function (DUF5094)
+PF17016	DUF5095	Domain of unknown function (DUF5095)
+PF17017	zf-C2H2_aberr	Aberrant zinc-finger
+PF17018	MICSWaP	Spore wall protein
+PF17019	DUF5096	Domain of unknown function (DUF5096)
+PF17020	DUF5097	Domain of unknown function (DUF5097)
+PF17021	Mei5_like	Putative double-strand recombination repair-like
+PF17022	PTP2	Polar tube protein 2 from Microsporidia
+PF17023	DUF5098	Domain of unknown function (DUF5098)
+PF17024	DMAP1_like	Putative DMAP1-like 
+PF17025	DUF5099	Domain of unknown function (DUF5099)
+PF17026	zf-RRPl_C4	Putative ribonucleoprotein zinc-finger pf C4 type
+PF17027	Bromo_TP_like	Histone-fold protein
+PF17028	8TM_micro	8TM Microsporidial transmembrane domain
+PF17029	DUF5100	Domain of unknown function (DUF5100)
+PF17030	Beta_lactamase3	Putative beta-lactamase-like family
+PF17031	DUF5101	Domain of unknown function (DUF5101)
+PF17032	zinc_ribbon_15	zinc-ribbon family
+PF17033	Peptidase_M99	Carboxypeptidase controlling helical cell shape catalytic
+PF17034	zinc_ribbon_16	Zinc-ribbon like family
+PF17035	BET	Bromodomain extra-terminal - transcription regulation
+PF17036	CBP_BcsS	Cellulose biosynthesis protein BcsS
+PF17037	CBP_BcsO	Cellulose biosynthesis protein BcsO
+PF17038	CBP_BcsN	Cellulose biosynthesis protein BcsN
+PF17039	Glyco_tran_10_N	Fucosyltransferase, N-terminal
+PF17040	CBP_CCPA	Cellulose-complementing protein A
+PF17041	SasG_E	E domain
+PF17042	DUF1357_C	Putative nucleotide-binding of sugar-metabolising enzyme
+PF17043	MAT1-1-2	Mating type protein 1-1-2 of unknown function
+PF17044	BPTA	Borrelial persistence in ticks protein A
+PF17045	CEP63	Centrosomal protein of 63 kDa  
+PF17046	Ses_B	SesB domain on fungal death-pathway protein
+PF17047	SMP_LBD	Synaptotagmin-like mitochondrial-lipid-binding domain
+PF17048	Ceramidse_alk_C	Neutral/alkaline non-lysosomal ceramidase, C-terminal
+PF17049	AEP1	ATPase expression protein 1
+PF17050	AIM5	Altered inheritance of mitochondria 5
+PF17051	COA2	Cytochrome C oxidase assembly factor 2
+PF17052	CAF20	Cap associated factor 
+PF17053	GEP5	Genetic interactor of prohibitin 5
+PF17054	JUPITER	Microtubule-Associated protein Jupiter
+PF17055	VMR2	Viral matrix protein M2
+PF17056	KRE1	Killer toxin-resistance protein 1
+PF17057	B3R	Poxviridae B3 protein
+PF17058	MBR1	Mitochondrial biogenesis regulation protein 1
+PF17059	MGTL	MgtA leader peptide
+PF17060	MPS2	Monopolar spindle protein 2
+PF17061	PARM	PARM
+PF17062	Osw5	Outer spore wall 5
+PF17063	Psm4	Phenol-soluble modulin alpha 4 peptide
+PF17064	QVR	Sleepless protein
+PF17065	UPF0669	Putative cytokine, C6ORF120
+PF17066	RITA	RBPJ-interacting and tubulin associated protein
+PF17067	RPS31	Ribosomal protein S31e
+PF17068	RRG8	Required for respiratory growth protein 8 mitochondrial
+PF17069	RSRP	Arginine/Serine-Rich protein 1
+PF17070	Thx	30S ribosomal protein Thx
+PF17071	Capsid_VP7	Outer capsid protein VP7
+PF17072	Spike_torovirin	Torovirinae spike glycoprotein
+PF17073	SafA	Two-component-system connector protein
+PF17074	Darcynin	Darcynin, domain of unknown function
+PF17075	RRT14	Regular of rDNA transcription protein 14
+PF17076	SBE2	SBE2, cell-wall formation
+PF17077	Msap1	Mitotic spindle associated protein SHE1
+PF17078	SHE3	SWI5-dependent HO expression protein 3
+PF17079	SOTI	Male-specific protein scotti
+PF17080	SepA	Multidrug Resistance efflux pump
+PF17081	SOP4	Suppressor of PMA 1-7 protein
+PF17082	Spc29	Spindle Pole Component 29
+PF17083	Swm2	Nucleolar protein Swm2
+PF17084	TDA11	Topoisomerase I damage affected protein 11
+PF17085	UCMA	Unique cartilage matrix associated protein
+PF17086	HV_small_capsid	Small capsid protein of Herpesviridae
+PF17087	HHV-5_US34A	Herpesvirus US34A protein family
+PF17088	YCF90	Uncharacterised protein family
+PF17089	YjbT	Uncharacterised protein family
+PF17090	Ytca	Uncharacterised protein family
+PF17091	Tail_VII	Inovirus G7P protein
+PF17092	PCB_OB	Penicillin-binding protein OB-like domain
+PF17093	PBP_N	Penicillin-binding protein N-terminus
+PF17094	UPF0715	Uncharacterised protein family (UPF0715)
+PF17095	CAMSAP_CC1	Spectrin-binding region of Ca2+-Calmodulin
+PF17096	AIM3	Altered inheritance of mitochondria protein 3
+PF17097	Kre28	Spindle pole body component
+PF17098	Wtap	WTAP/Mum2p family
+PF17099	TrpP	Tryptophan transporter TrpP
+PF17100	NACHT_N	N-terminal domain of NWD NACHT-NTPase
+PF17101	Stealth_CR1	Stealth protein CR1, conserved region 1
+PF17102	Stealth_CR3	Stealth protein CR3, conserved region 3
+PF17103	Stealth_CR4	Stealth protein CR4, conserved region 4
+PF17104	DUF5102	Domain of unknown function (DUF5102)
+PF17105	BRD4_CDT	C-terminal domain of bromodomain protein 4
+PF17106	NACHT_sigma	Sigma domain on NACHT-NTPases
+PF17107	SesA	N-terminal domain on NACHT_NTPase and P-loop NTPases
+PF17108	HET-S	N-terminal small S protein of HET, non-prionic
+PF17109	Goodbye	fungal STAND N-terminal Goodbye domain 
+PF17110	TFB6	Subunit 11 of the general transcription factor TFIIH
+PF17111	Helo_like_N	Fungal N-terminal domain of STAND proteins
+PF17112	Tom6	Mitochondrial import receptor subunit Tom6, fungal
+PF17113	AmpE	Regulatory signalling modulator protein AmpE
+PF17114	Nod1	Gef2-related medial cortical node protein Nod1
+PF17115	Toast_rack_N	N-terminal domain of toast_rack, DUF2154
+PF17116	DUF5103	Domain of unknown function (DUF5103)
+PF17117	DUF5104	Domain of unknown function (DUF5104)
+PF17118	DUF5105	Domain of unknown function (DUF5105)
+PF17119	MMU163	Mitochondrial protein up-regulated during meiosis
+PF17120	Zn_ribbon_17	Zinc-ribbon, C4HC2 type
+PF17121	zf-C3HC4_5	Zinc finger, C3HC4 type (RING finger)
+PF17122	zf-C3H2C3	Zinc-finger
+PF17123	zf-RING_11	RING-like zinc finger
+PF17124	ThiJ_like	ThiJ/PfpI family-like
+PF17125	Methyltr_RsmF_N	N-terminal domain of 16S rRNA methyltransferase RsmF
+PF17126	RsmF_methylt_CI	RsmF rRNA methyltransferase first C-terminal domain
+PF17127	DUF5106	Domain of unknown function (DUF5106)
+PF17128	DUF5107	Domain of unknown function (DUF5107)
+PF17129	Peptidase_M99_C	C-terminal domain of metallo-carboxypeptidase
+PF17130	Peptidase_M99_m	beta-barrel domain of carboxypeptidase M99
+PF17131	LolA_like	Outer membrane lipoprotein-sorting protein
+PF17132	Glyco_hydro_106	alpha-L-rhamnosidase
+PF17133	DUF5108	Domain of unknown function (DUF5108)
+PF17134	DUF5109	Domain of unknown function (DUF5109)
+PF17135	Ribosomal_L18	Ribosomal protein 60S L18 and 50S L18e
+PF17136	ribosomal_L24	Ribosomal proteins 50S L24/mitochondrial 39S L24
+PF17137	DUF5110	Domain of unknown function (DUF5110)
+PF17138	DUF5111	Domain of unknown function (DUF5111)
+PF17139	DUF5112	Domain of unknown function (DUF5112)
+PF17140	DUF5113	Domain of unknown function (DUF5113)
+PF17141	DUF5114	Domain of unknown function (DUF5114)
+PF17142	DUF5115	Domain of unknown function (DUF5115)
+PF17144	Ribosomal_L5e	Ribosomal large subunit proteins 60S L5, and 50S L18
+PF17145	DUF5119	Domain of unknown function (DUF5119)
+PF17146	PIN_6	PIN domain of ribonuclease
+PF17147	PFOR_II	Pyruvate:ferredoxin oxidoreductase core domain II
+PF17148	DUF5117	Domain of unknown function (DUF5117)
+PF17149	CHASE5	Periplasmic sensor domain found in signal transduction proteins
+PF17150	CHASE6_C	C-terminal domain of two-partite extracellular sensor domain
+PF17151	CHASE7	Periplasmic sensor domain
+PF17152	CHASE8	Periplasmic sensor domain
+PF17153	CHASE9	Periplasmic sensor domain, extracellular
+PF17154	GAPES3	Gammaproteobacterial periplasmic sensor domain
+PF17155	GAPES1	Gammaproteobacterial periplasmic sensor domain
+PF17156	GAPES2	Gammaproteobacterial periplasmic sensor domain
+PF17157	GAPES4	Gammaproteobacterial periplasmic sensor domain
+PF17158	MASE4	Membrane-associated sensor, integral membrane domain
+PF17159	MASE3	Membrane-associated sensor domain
+PF17160	DUF5124	Domain of unknown function (DUF5124)
+PF17161	DUF5123	Domain of unknown function (DUF5123)
+PF17162	DUF5118	Domain of unknown function (DUF5118)
+PF17163	DUF5125	Domain of unknown function (DUF5125)
+PF17164	DUF5122	Domain of unknown function (DUF5122) beta-propeller
+PF17165	DUF5121	Domain of unknown function (DUF5121)
+PF17166	DUF5126	Domain of unknown function (DUF5126)
+PF17167	Glyco_hydro_36	Glycosyl hydrolase 36 superfamily, catalytic domain
+PF17168	DUF5127	Domain of unknown function (DUF5127)
+PF17169	NRBF2_MIT	MIT domain of nuclear receptor-binding factor 2
+PF17170	DUF5128	6-bladed beta-propeller
+PF17171	GST_C_6	Glutathione S-transferase, C-terminal domain
+PF17172	GST_N_4	Glutathione S-transferase N-terminal domain 
+PF17173	DUF5129	Domain of unknown function (DUF5129)
+PF17174	DUF5130	Domain of unknown function (DUF5130)
+PF17175	MOLO1	Modulator of levamisole receptor-1
+PF17176	tRNA_bind_3	tRNA-binding domain
+PF17177	PPR_long	Pentacotripeptide-repeat region of PRORP
+PF17178	MASE5	Membrane-associated sensor
+PF17179	Fer4_22	4Fe-4S dicluster domain
+PF17180	zf-3CxxC_2	Zinc-binding domain
+PF17181	EPF	Epidermal patterning factor proteins
+PF17182	OSK	OSK domain
+PF17183	Blt1_C	Get5 carboxyl domain
+PF17184	Rit1_C	Rit1 N-terminal domain
+PF17185	NlpE_C	NlpE C-terminal OB domain
+PF17186	Lipocalin_9	Lipocalin-like domain
+PF17187	Svf1_C	Svf1-like C-terminal lipocalin-like domain
+PF17188	MucB_RseB_C	MucB/RseB C-terminal domain
+PF17189	Glyco_hydro_30C	Glycosyl hydrolase family 30 beta sandwich domain
+PF17190	RecG_N	RecG N-terminal helical domain
+PF17191	RecG_wedge	RecG wedge domain
+PF17192	MukF_M	MukF middle domain
+PF17193	MukF_C	MukF C-terminal domain
+PF17194	AbiEi_3_N	Transcriptional regulator, AbiEi antitoxin N-terminal domain
+PF17195	DUF5132	Protein of unknown function (DUF5132)
+PF17196	DUF5133	Protein of unknown function (DUF5133)
+PF17197	DUF5134	Domain of unknown function (DUF5134)
+PF17198	AveC_like	Spirocyclase AveC-like
+PF17199	DUF5136	Protein of unknown function (DUF5136)
+PF17200	sCache_2	Single Cache domain 2
+PF17201	Cache_3-Cache_2	Cache 3/Cache 2 fusion domain
+PF17202	sCache_3_3	Single cache domain 3
+PF17203	sCache_3_2	Single cache domain 3
+PF17204	Sid-5	Sid-5 family
+PF17205	PSI_integrin	Integrin plexin domain
+PF17206	SeqA_N	SeqA protein N-terminal domain
+PF17207	MCM_OB	MCM OB domain
+PF17208	RBR	RNA binding Region
+PF17209	Hfq	Hfq protein
+PF17210	SdrD_B	SdrD B-like domain
+PF17211	VHL_C	VHL box domain
+PF17212	Tube	Tail tubular protein
+PF17213	Hydin_ADK	Hydin Adenylate kinase-like domain
+PF17214	KH_7	KH domain
+PF17215	Rrp44_S1	S1 domain
+PF17216	Rrp44_CSD1	Rrp44-like cold shock domain
+PF17217	UPA	UPA domain
+PF17218	CBX7_C	CBX family C-terminal motif
+PF17219	YAF2_RYBP	Yaf2/RYBP C-terminal binding motif
+PF17220	DUF5137	Protein of unknown function (DUF5137)
+PF17221	COMMD1_N	COMMD1 N-terminal domain
+PF17222	Peptidase_C107	Viral cysteine endopeptidase C107
+PF17223	CPCFC	Cuticle protein CPCFC
+PF17224	DUF5300	Domain of unknown function (DUF5300)
+PF17225	DUF5301	Domain of unknown function (DUF5300)
+PF17226	MTA_R1	MTA R1 domain
+PF17227	DUF5302	Family of unknown function (DUF5302)
+PF17228	SGP	Sulphur globule protein
+PF17229	DUF5303	Region of unknown function (DUF5303)
+PF17230	DUF5304	Family of unknown function (DUF5304)
+PF17231	DUF5305	Family of unknown function (DUF5305)
+PF17232	DUF5306	Family of unknown function (DUF5306)
+PF17233	DUF5308	Family of unknown function (DUF5308)
+PF17234	MPM1	Mitochondrial peculiar membrane protein 1
+PF17235	STD1	STD1/MTH1
+PF17236	DUF5309	Family of unknown function (DUF5309)
+PF17237	DUF5310	Family of unknown function (DUF5310)
+PF17238	DUF5311	Family of unknown function (DUF5311)
+PF17239	DUF5312	Family of unknown function (DUF5312)
+PF17240	DUF5313	Family of unknown function (DUF5313)
+PF17241	DUF5314	Family of unknown function (DUF5314)
+PF17242	DUF5315	Disordered region of unknown function (DUF5315)
+PF17243	POTRA_TamA_1	POTRA domain TamA domain 1
+PF17244	CDC24_OB3	Cell division control protein 24, OB domain 3
+PF17245	CDC24_OB2	Cell division control protein 24, OB domain 2
+PF17246	CDC24_OB1	Cell division control protein 24, OB domain 1
+PF17247	DUF5316	Family of unknown function (DUF5316)
+PF17248	DUF5317	Family of unknown function (DUF5317)
+PF17249	DUF5318	Family of unknown function (DUF5318)
+PF17250	NDUFB11	NADH-ubiquinone oxidoreductase 11 kDa subunit
+PF17251	Pom	Protochlamydia outer membrane protein
+PF17252	DUF5319	Family of unknown function (DUF5319)
+PF17253	DUF5320	Family of unknown function (DUF5320)
+PF17254	DUF5321	Family of unknown function (DUF5321)
+PF17255	DUF5322	Family of unknown function (DUF5322)
+PF17256	ANAPC16	Anaphase Promoting Complex Subunit 16
+PF17257	DUF5323	Family of unknown function (DUF5323)
+PF17258	DUF5324	Family of unknown function (DUF5324)
+PF17259	DUF5325	Family of unknown function (DUF5325)
+PF17260	DUF5326	Family of unknown function (DUF5326)
+PF17261	DUF5327	Family of unknown function (DUF5327)
+PF17262	DUF5328	Family of unknown function (DUF5328)
+PF17263	DUF5329	Family of unknown function (DUF5329)
+PF17264	DUF5330	Family of unknown function (DUF5330)
+PF17265	DUF5331	Family of unknown function (DUF5331)
+PF17266	DUF5332	Family of unknown function (DUF5332)
+PF17267	DUF5333	Family of unknown function (DUF5333)
+PF17268	DUF5334	Family of unknown function (DUF5334)
+PF17269	DUF5335	Family of unknown function (DUF5335)
+PF17270	DUF5336	Family of unknown function (DUF5336)
+PF17271	Usher_TcfC	TcfC Usher-like barrel domain
+PF17272	DUF5337	Family of unknown function (DUF5337)
+PF17273	DUF5338	Family of unknown function (DUF5338)
+PF17274	DUF5339	Family of unknown function (DUF5339)
+PF17275	DUF5340	Family of unknown function (DUF5340)
+PF17276	DUF5341	Family of unknown function (DUF5341)
+PF17277	DUF5342	Family of unknown function (DUF5342)
+PF17278	DUF5343	Family of unknown function (DUF5343)
+PF17279	DUF5344	Family of unknown function (DUF5344)
+PF17280	DUF5345	Family of unknown function (DUF5345)
+PF17281	DUF5346	Family of unknown function (DUF5346)
+PF17282	DUF5347	Family of unknown function (DUF5347)
+PF17283	Zn_ribbon_SprT	SprT-like zinc ribbon domain
+PF17284	Spermine_synt_N	Spermidine synthase tetramerisation domain
+PF17285	PRMT5_TIM	PRMT5 TIM barrel domain
+PF17286	PRMT5_C	PRMT5 oligomerisation domain
+PF17287	POTRA_3	POTRA domain
+PF17288	Terminase_3C	Terminase RNAseH like domain
+PF17289	Terminase_6C	Terminase RNaseH-like domain
+PF17290	Arena_ncap_C	Arenavirus nucleocapsid C-terminal domain
+PF17291	M60-like_N	N-terminal domain of M60-like peptidases
+PF17292	POB3_N	POB3-like N-terminal PH domain
+PF17293	Arm-DNA-bind_5	Arm DNA-binding domain
+PF17294	Lipoprotein_22	Uncharacterised lipoprotein family
+PF17295	DUF5348	Domain of unknown function (DUF5348)
+PF17296	ArenaCapSnatch	Arenavirus cap snatching domain
+PF17297	PEPCK_N	Phosphoenolpyruvate carboxykinase N-terminal domain
+PF17298	DUF5349	Family of unknown function (DUF5349)
+PF17299	DUF5350	Family of unknown function (DUF5350)
+PF17300	FIN1	Filament protein FIN1
+PF17301	LpqV	Putative lipoprotein LpqV
+PF17302	DUF5351	Family of unknown function (DUF5351)
+PF17303	DUF5352	Family of unknown function (DUF5352)
+PF17304	DUF5353	Family of unknown function (DUF5353)
+PF17305	DUF5354	Family of unknown function (DUF5354)
+PF17306	DUF5355	Family of unknown function (DUF5355)
+PF17307	Smim3	Small integral membrane protein 3
+PF17308	Corazonin	Pro-corazonin
+PF17309	DUF5356	Family of unknown function (DUF5356)
+PF17310	DUF5357	Family of unknown function (DUF5357)
+PF17311	DUF5358	Family of unknown function (DUF5358)
+PF17312	Helveticin_J	Bacteriocin helveticin-J
+PF17313	DUF5359	Family of unknown function (DUF5359)
+PF17314	DUF5360	Family of unknown function (DUF5360)
+PF17315	FMP23	Found in Mitochondrial Proteome
+PF17316	PET10	Petite colonies protein 10
+PF17317	MFA1_2	Mating hormone A-factor 1&2
+PF17318	DUF5361	Family of unknown function (DUF5361)
+PF17319	DUF5362	Family of unknown function (DUF5362)
+PF17320	DUF5363	Family of unknown function (DUF5363)
+PF17321	Vac17	Vacuole-related protein 17
+PF17322	DUF5364	Family of unknown function (DUF5364)
+PF17323	ToxS	Trans-membrane regulatory protein ToxS
+PF17324	BLI1	BLOC-1 interactor 1
+PF17325	SPG4	Stationary phase protein 4
+PF17326	DUF5365	Family of unknown function (DUF5365)
+PF17327	AHL_synthase	Acyl homoserine lactone synthase
+PF17328	DUF5366	Family of unknown function (DUF5366)
+PF17329	DUF5367	Family of unknown function (DUF5367)
+PF17330	SWC7	SWR1 chromatin-remodelling complex, subunit Swc7
+PF17331	GFD1	GFD1 mRNA transport factor
+PF17332	pXO2-11	Uncharacterized protein pXO2-11
+PF17333	DEFB136	Beta-defensin 136
+PF17334	CsgA	Sigma-G-dependent sporulation-specific SASP protein
+PF17335	IES5	Ino80 complex subunit 5
+PF17336	DUF5368	Family of unknown function (DUF5368)
+PF17337	Gal_GalNac_35kD	Galactose-inhibitable lectin 35 kDa subunit
+PF17338	GP88	Gene 88 protein
+PF17339	DUF5369	Family of unknown function (DUF5369)
+PF17340	DUF5370	Family of unknown function (DUF5370)
+PF17341	DUF5371	Family of unknown function (DUF5371)
+PF17342	DUF5372	Family of unknown function (DUF5372)
+PF17343	DUF5373	Family of unknown function (DUF5373)
+PF17344	DUF5374	Family of unknown function (DUF5374)
+PF17345	DUF5375	Family of unknown function (DUF5375)
+PF17346	DUF5376	Family of unknown function (DUF5376)
+PF17347	DUF5377	Family of unknown function (DUF5377)
+PF17349	DUF5378	Family of unknown function (DUF5378)
+PF17350	DUF5379	Family of unknown function (DUF5379)
+PF17351	DUF5380	Family of unknown function (DUF5380)
+PF17352	MFS18	Male Flower Specific protein 18
+PF17353	DUF5381	Family of unknown function (DUF5381)
+PF17354	DUF5382	Family of unknown function (DUF5382)
+PF17355	DUF5383	Family of unknown function (DUF5383)
+PF17356	PBSX_XtrA	Phage-like element PBSX protein XtrA
+PF17357	FIT1_2	Facilitor Of Iron Transport 1 and 2
+PF17358	DUF5384	Family of unknown function (DUF5384)
+PF17359	DUF5385	Family of unknown function (DUF5385)
+PF17360	DUF5386	Family of unknown function (DUF5386)
+PF17361	DUF5387	Family of unknown function (DUF5387)
+PF17362	pXO2-34	Family of unknown function
+PF17363	DUF5388	Family of unknown function (DUF5388)
+PF17364	DUF5389	Family of unknown function (DUF5389)
+PF17365	DUF5390	Family of unknown function (DUF5390)
+PF17366	AGA2	A-agglutinin-binding subunit Aga2
+PF17367	NiFe_hyd_3_EhaA	NiFe-hydrogenase-type-3 Eha complex subunit A
+PF17368	YwcE	Spore morphogenesis and germination protein YwcE
+PF17369	DUF5391	Family of unknown function (DUF5391)
+PF17370	DUF5392	Family of unknown function (DUF5392)
+PF17371	DUF5393	Family of unknown function (DUF5393)
+PF17372	DUF5394	Family of unknown function (DUF5394)
+PF17373	DUF5395	Family of unknown function (DUF5395)
+PF17374	DUF5396	Family of unknown function (DUF5396)
+PF17375	DUF5397	Family of unknown function (DUF5397)
+PF17376	DUF5398	Family of unknown function (DUF5398)
+PF17377	DUF5399	Family of unknown function (DUF5399)
+PF17378	REC104	Meiotic recombination protein REC104
+PF17379	DUF5400	Family of unknown function (DUF5400)
+PF17380	DUF5401	Family of unknown function (DUF5401)
+PF17381	Svs_4_5_6	Seminal vesicle secretory protein 4/5/6
+PF17382	ycf70	Uncharacterized protein ycf70
+PF17383	kleA_kleC	Uncharacterized KorC regulated protein A
+PF17384	DUF150_C	RimP C-terminal SH3 domain
+PF17385	LBP_M	Lacto-N-biose phosphorylase central domain
+PF17386	LBP_C	Lacto-N-biose phosphorylase C-terminal domain
+PF17387	Glyco_hydro_59M	Glycosyl hydrolase family 59 central domain
+PF17388	GP24_25	Tail assembly protein Gp24 and Gp25
+PF17389	Bac_rhamnosid6H	Bacterial alpha-L-rhamnosidase 6 hairpin glycosidase domain
+PF17390	Bac_rhamnosid_C	Bacterial alpha-L-rhamnosidase C-terminal domain
+PF17391	Urocanase_N	Urocanase N-terminal domain
+PF17392	Urocanase_C	Urocanase C-terminal domain
+PF17393	DUF5402	Family of unknown function (DUF5402)
+PF17394	KleE	Uncharacterized KleE stable inheritance protein
+PF17395	DUF5403	Family of unknown function (DUF5403)
+PF17396	DUF1611_N	Domain of unknown function (DUF1611_N) Rossmann-like domain
+PF17397	DUF5404	Family of unknown function (DUF5404)
+PF17398	NolB	Nodulation protein NolB
+PF17399	DUF5405	Domain of unknown function (DUF5405)
+PF17400	DUF5406	Family of unknown function (DUF5406)
+PF17401	DUF5407	Family of unknown function (DUF5407)
+PF17402	DUF5408	Family of unknown function (DUF5408)
+PF17403	Nrap_D2	Nrap protein PAP/OAS-like domain
+PF17404	Nrap_D3	Nrap protein domain 3
+PF17405	Nrap_D4	Nrap protein nucleotidyltransferase domain 4
+PF17406	Nrap_D5	Nrap protein PAP/OAS1-like domain 5
+PF17407	Nrap_D6	Nrap protein domain 6
+PF17408	MCD_N	Malonyl-CoA decarboxylase N-terminal domain
+PF17409	MoaF_C	MoaF C-terminal domain
+PF17410	Stevor	Subtelomeric Variable Open Reading frame
+PF17411	SmaI	Type II site-specific deoxyribonuclease 
+PF17412	VraX	Family of unknown function
+PF17413	VirB7	Outer membrane lipoprotein virB7
+PF17414	MatP_C	MatP C-terminal ribbon-helix-helix domain
+PF17415	NigD_C	NigD-like C-terminal beta sandwich domain
+PF17416	Glycoprot_B_PH1	Herpesvirus Glycoprotein B
+PF17417	Glycoprot_B_PH2	Herpesvirus Glycoprotein B PH-like domain
+PF17418	SdpA	Sporulation delaying protein SdpA
+PF17419	MauJ	Methylamine utilization protein MauJ
+PF17420	Gp17	Superinfection exclusion protein, bacteriophage P22
+PF17421	DUF5409	Family of unknown function (DUF5409)
+PF17422	DUF5410	Family of unknown function (DUF5410)
+PF17423	SwrA	Swarming motility protein
+PF17424	DUF5411	Family of unknown function (DUF5411)
+PF17425	Arylsulfotran_N	Arylsulfotransferase Ig-like domain
+PF17426	Putative_G5P	Putative Gamma DNA binding protein G5P
+PF17427	Phi29_Phage_SSB	Phage Single-stranded DNA-binding protein
+PF17428	DUF5412	Family of unknown function (DUF5412)
+PF17429	GP70	Gene 70 protein
+PF17430	yqgC	Uncharacterized yqgC
+PF17431	ypmT	Uncharacterized ympT
+PF17432	DUF3458_C	Domain of unknown function (DUF3458_C) ARM repeats
+PF17433	Glyco_hydro_49N	Glycosyl hydrolase family 49 N-terminal Ig-like domain
+PF17434	DUF5413	Family of unknown function (DUF5413)
+PF17435	DUF5414	Family of unknown function (DUF5414)
+PF17436	DUF5415	Family of unknown function (DUF5415)
+PF17437	DUF5416	Family of unknown function (DUF5416)
+PF17438	DUF5417	Family of unknown function (DUF5417)
+PF17439	DUF5418	Family of unknown function (DUF5418)
+PF17440	Thiol_cytolys_C	Thiol-activated cytolysin beta sandwich domain
+PF17441	DUF5419	Family of unknown function (DUF5419)
+PF17442	U62_UL91	Functional domain of U62 and UL91 proteins  
+PF17443	pXO2-72	Uncharacterized protein pXO2-72
+PF17444	yhdX	Uncharacterized protein YhdX
+PF17445	Mfa1	Mating factor A1
+PF17446	ltuA	Late transcription unit A protein
+PF17447	ykpC	Uncharacterized protein YkpC
+PF17448	yqaH	Uncharacterized protein YqaH
+PF17449	yrzK	Uncharacterized protein YrzK
+PF17450	Melibiase_2_C	Alpha galactosidase A C-terminal beta sandwich domain
+PF17451	Glyco_hyd_101C	Glycosyl hydrolase 101 beta sandwich domain
+PF17452	YnfE	Uncharacterized protein YnfE
+PF17453	YhdK	Sigma-M inhibitor protein
+PF17454	Bee_toxin	Honey bee toxin
+PF17455	LtuB	Late transcription unit B protein
+PF17456	TcpS	Toxin-coregulated pilus protein S
+PF17457	DUF5420	Family of unknown function (DUF5420)
+PF17458	DUF5421	Family of unknown function (DUF5421)
+PF17459	DUF5422	Family of unknown function (DUF5422)
+PF17460	RP854	Uncharacterized protein RP854
+PF17461	DUF5423	Family of unknown function (DUF5423)
+PF17462	DUF5424	Family of unknown function (DUF5424)
+PF17463	Gp79	Gene Product 79
+PF17464	Pns11_12	Non-structural protein 11 and 12
+PF17465	Putative_CCL4	Chemokine-like protein, HHV-6 U83 gene product
+PF17466	NinD	Family of unknown function
+PF17467	E7R	Viral Protein E7
+PF17468	Gp52	Phage protein Gp52
+PF17469	Gp68	Phage protein Gp68
+PF17470	Gp45_2	Phage protein Gp45.2
+PF17471	Gp63	Hypothetical phage protein Gp63
+PF17472	DUF5425	Family of unknown function (DUF5425)
+PF17473	DUF5426	Family of unknown function (DUF5426)
+PF17474	U71	Tegument protein UL11 homolog
+PF17475	Binary_toxB_2	Clostridial binary toxin B/anthrax toxin PA domain 2
+PF17476	Binary_toxB_3	Clostridial binary toxin B/anthrax toxin PA domain 3
+PF17477	Rota_VP4_MID	Rotavirus VP4 membrane interaction domain
+PF17478	VP4_helical	Rotavirus VP4 helical domain
+PF17479	DUF3048_C	Protein of unknown function (DUF3048) C-terminal domain
+PF17480	AlphaC_C	Alpha C protein C terminal
+PF17481	Phage_sheath_1N	Phage tail sheath protein beta-sandwich domain
+PF17482	Phage_sheath_1C	Phage tail sheath C-terminal domain
+PF17483	TbpB_C	C-lobe handle domain of Tf-binding protein B
+PF17484	TbpB_A	N-Lobe handle Tf-binding protein B
+PF17485	SatRNA_48	Satellite RNA 48 kDa protein
+PF17486	Cys_Knot_tox	Cystine knot toxins
+PF17487	RPS12	Ribosomal protein S12
+PF17488	Herpes_glycoH_C	Herpesvirus glycoprotein H C-terminal domain
+PF17489	Tnp_22_trimer	L1 transposable element trimerization domain
+PF17490	Tnp_22_dsRBD	L1 transposable element dsRBD-like domain
+PF17491	m_DGTX_Dc1a_b_c	Spider Toxins mu-diguetoxin-1 a, b and c
+PF17492	D_CNTX	Delta Ctenitoxins
+PF17493	DUF5428	Family of unknown function (DUF5428)
+PF17494	DUF5429	Family of unknown function (DUF5429)
+PF17495	DUF5430	Family of unknown function (DUF5430)
+PF17496	DUF5431	Family of unknown function (DUF5431)
+PF17497	DUF5432	Family of unknown function (DUF5432)
+PF17498	DUF5433	Family of unknown function (DUF5433)
+PF17499	Pilosulin	Ant venom peptides
+PF17500	Colicin_K	Colicin-K immunity protein
+PF17501	Viral_RdRp_C	Viral RNA-directed RNA polymerase
+PF17502	DUF5434	Family of unknown function (DUF5434)
+PF17503	DUF5435	Family of unknown function (DUF5435)
+PF17504	DUF5436	Family of unknown function (DUF5436)
+PF17505	DUF5437	Family of unknown function (DUF5437)
+PF17506	DUF5438	Family of unknown function (DUF5438)
+PF17507	DUF5439	Family of unknown function (DUF5439)
+PF17508	MccV	Microcin V bacteriocin
+PF17509	DUF5440	Family of unknown function (DUF5440)
+PF17510	Gp44	Mycobacterium phage hypothetical protein Gp44.1
+PF17511	Mobilization_B	Mobilization protein B
+PF17512	Sh_2	Metapneumovirus Small hydrophobic protein
+PF17513	DUF5441	Family of unknown function (DUF5441)
+PF17514	DUF5442	Family of unknown function (DUF5442)
+PF17515	CPV_Polyhedrin	Cypovirus polyhedrin protein
+PF17516	ProQ_C	ProQ C-terminal domain
+PF17517	IgGFc_binding	IgGFc binding protein
+PF17518	DUF5443	Family of unknown function (DUF5443)
+PF17519	DUF5444	Family of unknown function (DUF5444)
+PF17520	DUF5445	Family of unknown function (DUF5445)
+PF17521	Secapin	Honey bee peptides
+PF17522	DUF5446	Family of unknown function (DUF5446)
+PF17523	MPS-4	MinK-related peptide, potassium channel accessory sub-unit protein 4
+PF17524	CnrY	anti-sigma factor CnrY
+PF17525	DUF5447	Family of unknown function (DUF5447)
+PF17526	DUF5448	Family of unknown function (DUF5448)
+PF17527	ALP	Phage ALP protein
+PF17528	DUF5449	Family of unknown function (DUF5449)
+PF17529	DUF5450	Family of unknown function (DUF5450)
+PF17530	NS3	Non-structural protein NS3
+PF17531	O_Spanin_T7	outer-membrane spanin sub-unit
+PF17532	DUF5451	Family of unknown function (DUF5451)
+PF17533	DUF5452	Family of unknown function (DUF5452)
+PF17534	DUF5453	Family of unknown function (DUF5453)
+PF17535	DUF5454	Family of unknown function (DUF5454)
+PF17536	Mx_ML	Matrix and Matrix long proteins N-terminal
+PF17537	DUF5455	Family of unknown function (DUF5455)
+PF17538	C_LFY_FLO	DNA Binding Domain (C-terminal) Leafy/Floricaula
+PF17539	DUF5456	Family of unknown function (DUF5456)
+PF17540	DUF5457	Family of unknown function (DUF5457)
+PF17541	DUF5458	Family of unknown function (DUF5458)
+PF17542	RP853	Uncharacterized RP853
+PF17543	DUF5459	Family of unknown function (DUF5459)
+PF17544	DUF5460	Family of unknown function (DUF5460)
+PF17545	DUF5461	Family of unknown function (DUF5461)
+PF17546	Defb50	Beta Defensin 50
+PF17547	DUF5462	Family of unknown function (DUF5462)
+PF17548	p6	Histone-like Protein p6
+PF17549	Phage_Gp17	Gene Product 17
+PF17550	PsaF	Family of unknown function
+PF17551	DUF5463	Family of unknown function (DUF5463)
+PF17552	DUF5464	Family of unknown function (DUF5464)
+PF17553	DUF5465	Family of unknown function (DUF5465)
+PF17554	DUF5466	Family of unknown function (DUF5466)
+PF17555	DUF5467	Family of unknown function (DUF5467)
+PF17556	MIT_LIKE_ACTX	MIT-like atracotoxin family
+PF17557	Conotoxin_I2	I2-superfamily conotoxins
+PF17558	AGH	Androgenic gland hormone
+PF17559	DUF5468	Family of unknown function (DUF5468)
+PF17560	Megourin	Aphid Megourins
+PF17561	DUF5469	Family of unknown function (DUF5469)
+PF17562	Styelin	Styelin A-E
+PF17563	Cu	Cupiennin
+PF17564	DUF5470	Family of unknown function (DUF5470)
+PF17565	DUF5471	Family of unknown function (DUF5471)
+PF17566	DUF5472	Family of unknown function (DUF5472)
+PF17567	DUF5473	Family of unknown function (DUF5473)
+PF17568	DUF5474	Family of unknown function (DUF5474)
+PF17569	DUF5475	Family of unknown function (DUF5475)
+PF17570	DUF5476	Family of unknown function (DUF5476)
+PF17571	DUF5477	Family of unknown function (DUF5477)
+PF17572	DUF5478	Family of unknown function (DUF5478)
+PF17573	GA-like	GA-like domain
+PF17574	TA_inhibitor	Inhibitor of toxin/antitoxin system (Gp4.5)  
+PF17575	DUF5479	Family of unknown function (DUF5479)
+PF17576	DUF5480	Family of unknown function (DUF5480)
+PF17577	ETM	ECORI-T site protein ETM
+PF17578	DUF5481	Family of unknown function (DUF5481)
+PF17579	DUF5482	Family of unknown function (DUF5482)
+PF17580	GBR_NSP5	Group B Rotavirus Non-structural protein 5
+PF17581	DUF5483	Family of unknown function (DUF5483)
+PF17582	UL20	Cytomegalovirus UL20
+PF17583	DUF5484	Family of unknown function (DUF5484)
+PF17584	comS	Bacillus Competence protein S
+PF17585	Phage_Arf	Accessory recombination function protein
+PF17586	DUF5485	Family of unknown function (DUF5485)
+PF17587	Dmd	Discriminator of mRNA degradation
+PF17588	DUF5486	Family of unknown function (DUF5486)
+PF17589	DUF5487	Family of unknown function (DUF5487)
+PF17590	DUF5488	Family of unknown function (DUF5488)
+PF17591	UL41A	Herpesvirus UL41A
+PF17592	DUF5489	Family of unknown function (DUF5489)
+PF17593	DUF5490	Family of unknown function (DUF5490)
+PF17594	GP57	Phage Tail fiber assembly helper protein
+PF17595	DUF5491	Family of unknown function (DUF5491)
+PF17596	DUF5492	Family of unknown function (DUF5492)
+PF17597	DUF5493	Family of unknown function (DUF5493)
+PF17598	DUF5494	Family of unknown function (DUF5494)
+PF17599	DUF5495	Family of unknown function (DUF5495)
+PF17600	DUF5496	Family of unknown function (DUF5496)
+PF17601	DUF5497	Family of unknown function (DUF5497)
+PF17602	DUF5498	Family of unknown function (DUF5498)
+PF17603	DUF5499	Family of unknown function (DUF5499)
+PF17604	DUF5500	Family of unknown function (DUF5500)
+PF17605	DUF5501	Family of unknown function (DUF5501)
+PF17606	DUF5502	Family of unknown function (DUF5502)
+PF17607	DUF5503	Family of unknown function (DUF5503)
+PF17608	DUF5504	Family of unknown function (DUF5504)
+PF17609	HCMV_UL124	Family of unknown function
+PF17610	DUF5505	Family of unknown function (DUF5505)
+PF17611	DUF5506	Family of unknown function (DUF5506)
+PF17612	DUF5507	Family of unknown function (DUF5507)
+PF17613	motB	Modifier of transcription
+PF17614	FPV060	Viral CC-type chemokine
+PF17615	C166	Family of unknown function
+PF17616	US6	Viral unique short region 6
+PF17617	US10	Viral unique short region 10
+PF17618	SL4P	Uncharacterized Strongylid L4 protein
+PF17619	SCVP	Secreted clade V proteins
+PF17620	ORF45	Family of unknown function
+PF17621	DUF5508	Family of unknown function (DUF5508)
+PF17622	UL16	Viral unique long protein 16
+PF17623	B277	Family of unknown function
+PF17624	US30	Family of unknown function
+PF17625	DUF5509	Family of unknown function (DUF5509)
+PF17626	IncF	Inclusion membrane protein F
+PF17627	IncE	Inclusion membrane protein E
+PF17628	IncD	Inclusion membrane protein D
+PF17629	DUF5510	Family of unknown function (DUF5510)
+PF17630	DUF5511	Family of unknown function (DUF5511)
+PF17631	DUF5512	Family of unknown function (DUF5512)
+PF17632	DUF5513	Family of unknown function (DUF5513)
+PF17633	DUF5514	Family of unknown function (DUF5514)
+PF17634	Gp67	Gene product 67
+PF17635	DUF5515	Family of unknown function (DUF5515)
+PF17636	UL21a	Viral Unique Long protein 21a
+PF17637	DUF5516	Family of unknown function (DUF5516)
+PF17638	UL42	HCMV UL42
+PF17639	DUF5517	Family of unknown function (DUF5517)
+PF17640	UL17	Uncharacterized UL17
+PF17641	ASPRs	Ancylostoma-associated secreted protein related genes


### PR DESCRIPTION
- Fixed #61
- Also updated PFAM endpoint URLs (see https://stackoverflow.com/q/20381976 for details)
- We decided to not include color mappings in genome-nexus, we will dynamically assign colors on the front end.