### PR TITLE
Add sentry for error logging

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -63,6 +63,11 @@
       <version>2.7.0</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>io.sentry</groupId>
+      <artifactId>sentry-spring</artifactId>
+      <version>1.6.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/web/src/main/java/org/cbioportal/genome_nexus/GenomeNexusAnnotation.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/GenomeNexusAnnotation.java
@@ -46,6 +46,7 @@ import springfox.documentation.service.ApiInfo;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -60,6 +61,11 @@ public class GenomeNexusAnnotation extends SpringBootServletInitializer
     public static void main(String[] args)
     {
         SpringApplication.run(GenomeNexusAnnotation.class, args);
+    }
+
+    @Bean
+    public HandlerExceptionResolver sentryExceptionResolver() {
+        return new io.sentry.spring.SentryExceptionResolver();
     }
 
     @Bean


### PR DESCRIPTION
This works when setting env variable `SENTRY_DSN` or `dsn=` property (see slack channel `sentry-genome-nexus`). We've been using sentry on frontend. There it was reporting way too many errors, but perhaps more useful on backend.

Was able to generate example exception here when mongodb isn't running:
https://sentry.io/memorial-sloan-kettering/genome-nexus/issues/393666626/

It's also possible to get HTTP request info on error, but I couldn't get that to work:
https://docs.sentry.io/clients/java/modules/spring/#spring-boot-http-data