### PR TITLE
Added PDB header service

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/PdbHeader.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/PdbHeader.java
@@ -1,0 +1,54 @@
+package org.cbioportal.genome_nexus.model;
+
+import java.util.Map;
+
+/**
+ * @author Selcuk Onur Sumer
+ */
+public class PdbHeader
+{
+    private String pdbId;
+    private String title;
+    private Map<String, Object> compound;
+    private Map<String, Object> source;
+
+    public String getPdbId()
+    {
+        return pdbId;
+    }
+
+    public void setPdbId(String pdbId)
+    {
+        this.pdbId = pdbId;
+    }
+
+    public String getTitle()
+    {
+        return title;
+    }
+
+    public void setTitle(String title)
+    {
+        this.title = title;
+    }
+
+    public Map<String, Object> getCompound()
+    {
+        return compound;
+    }
+
+    public void setCompound(Map<String, Object> compound)
+    {
+        this.compound = compound;
+    }
+
+    public Map<String, Object> getSource()
+    {
+        return source;
+    }
+
+    public void setSource(Map<String, Object> source)
+    {
+        this.source = source;
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/SimpleCacheEntity.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/SimpleCacheEntity.java
@@ -1,0 +1,41 @@
+package org.cbioportal.genome_nexus.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/**
+ * @author Selcuk Onur Sumer
+ */
+@Document(collection = "simple_cache")
+public class SimpleCacheEntity
+{
+    @Id
+    private String key;
+    private String value;
+
+    public SimpleCacheEntity(String key, String value)
+    {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey()
+    {
+        return key;
+    }
+
+    public void setKey(String key)
+    {
+        this.key = key;
+    }
+
+    public String getValue()
+    {
+        return value;
+    }
+
+    public void setValue(String value)
+    {
+        this.value = value;
+    }
+}

--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/SimpleCacheRepository.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/SimpleCacheRepository.java
@@ -1,0 +1,9 @@
+package org.cbioportal.genome_nexus.persistence;
+
+import org.cbioportal.genome_nexus.model.SimpleCacheEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+/**
+ * @author Selcuk Onur Sumer
+ */
+public interface SimpleCacheRepository extends MongoRepository<SimpleCacheEntity, String> {}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/PdbDataService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/PdbDataService.java
@@ -1,0 +1,11 @@
+package org.cbioportal.genome_nexus.service;
+
+import org.cbioportal.genome_nexus.model.PdbHeader;
+
+/**
+ * @author Selcuk Onur Sumer
+ */
+public interface PdbDataService
+{
+    PdbHeader getPdbHeader(String pdbId);
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/PdbDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/PdbDataServiceImpl.java
@@ -1,0 +1,89 @@
+package org.cbioportal.genome_nexus.service.internal;
+
+import org.cbioportal.genome_nexus.model.PdbHeader;
+import org.cbioportal.genome_nexus.model.SimpleCacheEntity;
+import org.cbioportal.genome_nexus.persistence.SimpleCacheRepository;
+import org.cbioportal.genome_nexus.service.PdbDataService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+/**
+ * @author Selcuk Onur Sumer
+ */
+@Service
+public class PdbDataServiceImpl implements PdbDataService
+{
+    private String headerServiceURL;
+    @Value("${pdb.header_service_url}")
+    public void setHeaderServiceURL(String headerServiceURL)
+    {
+        this.headerServiceURL = headerServiceURL;
+    }
+
+    @Autowired
+    private SimpleCacheRepository cacheRepository;
+
+    @Autowired
+    private PdbFileParser pdbParser;
+
+    @Override
+    public PdbHeader getPdbHeader(String pdbId)
+    {
+        PdbHeader info = null;
+
+        if (pdbId != null &&
+            pdbId.length() > 0)
+        {
+            String rawData = this.getRawInfo(pdbId);
+
+            if (rawData != null)
+            {
+                Map<String, String> content = this.pdbParser.parsePdbFile(rawData);
+
+                info = new PdbHeader();
+
+                info.setPdbId(pdbId);
+                info.setTitle(this.pdbParser.parseTitle(content.get("title")));
+                info.setCompound(this.pdbParser.parseCompound(content.get("compnd")));
+                info.setSource(this.pdbParser.parseCompound(content.get("source")));
+            }
+        }
+
+        return info;
+    }
+
+    private String getRawInfo(String pdbId)
+    {
+        // try to get the data from database first
+        SimpleCacheEntity entity = cacheRepository.findOne(pdbId);
+
+        // we have the information in the cache already!
+        if (entity != null)
+        {
+            return entity.getValue();
+        }
+
+        //http://www.rcsb.org/pdb/files/PDB_ID.pdb?headerOnly=YES
+        //http://files.rcsb.org/header/PDB_ID.pdb
+        String uri = headerServiceURL.replace("PDB_ID", pdbId.toUpperCase());
+        RestTemplate restTemplate = new RestTemplate();
+
+        try {
+            String value = restTemplate.getForObject(uri, String.class);
+            // cache the retrieved value
+            if (value != null && value.length() > 0)
+            {
+                // TODO sanitize value before caching?
+                cacheRepository.save(new SimpleCacheEntity(pdbId, value));
+            }
+            return value;
+        } catch (Exception e) {
+            //e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/PdbFileParser.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/PdbFileParser.java
@@ -1,0 +1,196 @@
+package org.cbioportal.genome_nexus.service.internal;
+
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+/**
+ * Class designed to parse raw text files returned from PDB data service,
+ * and to convert data into JSON objects.
+ *
+ * @author Selcuk Onur Sumer
+ */
+@Component
+public class PdbFileParser
+{
+    /**
+     * Parses the raw PDB file retrieved from the server and
+     * creates a mapping for each main identifier.
+     *
+     * @param rawInput  raw file contents as a String
+     * @return  data mapped on the main identifier names
+     */
+    public Map<String, String> parsePdbFile(String rawInput)
+    {
+        String[] lines = rawInput.toLowerCase().split("\n");
+
+        // count for distinct identifiers
+        Map<String, Integer> countMap = new HashMap<String, Integer>();
+
+        // map of builders to build content for each identifier
+        Map<String, StringBuilder> contentMap = new HashMap<String, StringBuilder>();
+
+        // actual content map to return
+        Map<String, String> content = new HashMap<String, String>();
+
+        for (String line: lines)
+        {
+            String[] tokens = line.split("[\\s]+");
+
+            // first token is the identifier
+            if (tokens.length == 0)
+            {
+                // empty line, just skip
+                continue;
+            }
+
+            String identifier = tokens[0];
+
+            // get the corresponding count
+            Integer count = countMap.get(identifier);
+
+            if (count == null)
+            {
+                count = 0;
+            }
+
+            // update count
+            countMap.put(identifier, ++count);
+
+            String str = line;
+
+            // if there is more than one identifier lines,
+            // than the line starts with the line number
+            // we should get rid of the line number as well
+            if (count > 1)
+            {
+                str = str.replaceFirst(count.toString(), "");
+            }
+
+            // get the corresponding string builder
+            StringBuilder sb = contentMap.get(identifier);
+
+            if (sb == null)
+            {
+                sb = new StringBuilder();
+                contentMap.put(identifier, sb);
+            }
+
+            // get rid of the identifier itself
+            str = str.replaceFirst(identifier, "").trim();
+
+            // append the parsed line
+            sb.append(str);
+            sb.append("\n");
+        }
+
+        for (String identifier: contentMap.keySet())
+        {
+            String value = contentMap.get(identifier).toString().trim();
+            content.put(identifier, value);
+        }
+
+        return content;
+    }
+
+    /**
+     * Parses the raw compound/source content returned by the service,
+     * and creates a nested map structure for each sub-field.
+     *
+     * @param rawInput  raw data from the service
+     * @return  nested map structure
+     */
+    public Map<String, Object> parseCompound(String rawInput)
+    {
+        String[] lines = rawInput.split("\n");
+        Map<String, Object> content = new HashMap<String, Object>();
+        Map<String, Object> mol = null;
+
+        // buffering lines (just in case if an entity consists of multiple lines)
+        StringBuilder buffer = new StringBuilder();
+
+        for (String line: lines)
+        {
+            buffer.append(line);
+
+            // process the buffer if line end with a semicolon
+            if (line.trim().endsWith(";"))
+            {
+                String[] tokens = buffer.toString().split(":");
+
+                if (tokens.length > 1)
+                {
+                    String field = tokens[0].trim();
+                    String value = tokens[1].trim();
+                    // remove the semicolon
+                    value = value.substring(0, value.length() - 1);
+                    List<String> list = null;
+
+                    // create a new mapping object for each mol_id
+                    if (field.equals("mol_id"))
+                    {
+                        mol = new HashMap<String, Object>();
+                        content.put(value, mol);
+                    }
+                    // convert comma separated chain and gene lists into an array
+                    else if (field.equals("chain") ||
+                        field.equals("gene"))
+                    {
+                        String[] values = value.split("[\\s,]+");
+                        list = new LinkedList<>();
+                        list.addAll(Arrays.asList(values));
+                    }
+
+                    // add the field for the current mol
+                    if (mol != null)
+                    {
+                        if (list != null)
+                        {
+                            mol.put(field, list);
+                        }
+                        else
+                        {
+                            mol.put(field, value);
+                        }
+                    }
+                }
+
+                // reset buffer for the next entity
+                buffer = new StringBuilder();
+            }
+            else
+            {
+                // add a whitespace before adding the next line
+                buffer.append(" ");
+            }
+        }
+
+        return content;
+    }
+
+    /**
+     * Parses the raw PDB title content returned by the service,
+     * and creates a human readable info string.
+     *
+     * @param rawTitle   data lines to process
+     * @return  a human readable info string
+     */
+    public String parseTitle(String rawTitle)
+    {
+        String[] lines = rawTitle.split("\n");
+        StringBuilder sb = new StringBuilder();
+
+        for (String line: lines)
+        {
+            sb.append(line);
+
+            // whether to add a space at the end or not
+            if (!line.endsWith("-"))
+            {
+                sb.append(" ");
+            }
+        }
+
+        return sb.toString().trim();
+    }
+}

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/PdbController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/PdbController.java
@@ -1,0 +1,77 @@
+package org.cbioportal.genome_nexus.web;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.cbioportal.genome_nexus.model.PdbHeader;
+import org.cbioportal.genome_nexus.service.PdbDataService;
+import org.cbioportal.genome_nexus.web.config.PublicApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Selcuk Onur Sumer
+ */
+@PublicApi
+@RestController // shorthand for @Controller, @ResponseBody
+@CrossOrigin(origins="*") // allow all cross-domain requests
+@RequestMapping(value= "/")
+@Api(tags = "pdb-controller", description = "PDB Controller")
+public class PdbController
+{
+    private final PdbDataService pdbDataService;
+
+    @Autowired
+    public PdbController(PdbDataService pdbDataService)
+    {
+        this.pdbDataService = pdbDataService;
+    }
+
+    @ApiOperation(value = "Retrieves PDB header info by a PDB id",
+        nickname = "fetchPdbHeaderGET")
+    @RequestMapping(value = "pdb/header/{pdbId}",
+        method = RequestMethod.GET,
+        produces = "application/json")
+    public PdbHeader fetchPdbHeaderGET(
+        @ApiParam(value = "PDB id, for example 1a37",
+            required = true,
+            allowMultiple = true)
+        @PathVariable String pdbId)
+    {
+        return pdbDataService.getPdbHeader(pdbId);
+    }
+
+    @ApiOperation(value = "Retrieves PDB header info by a PDB id",
+        nickname = "fetchPdbHeaderPOST")
+    @RequestMapping(value = "pdb/header",
+        method = RequestMethod.POST,
+        produces = "application/json")
+    public List<PdbHeader> fetchPdbHeaderPOST(
+        @ApiParam(value = "List of pdb ids, for example [\"1a37\",\"1a4o\"]",
+            required = true,
+            allowMultiple = true)
+        @RequestBody List<String> pdbIds)
+    {
+        List<PdbHeader> pdbHeaderList = new LinkedList<>();
+
+        // remove duplicates
+        Set<String> pdbIdSet = new LinkedHashSet<>(pdbIds);
+
+        for (String pdbId : pdbIdSet)
+        {
+            PdbHeader header = pdbDataService.getPdbHeader(pdbId);
+
+            if (header != null)
+            {
+                pdbHeaderList.add(header);
+            }
+        }
+
+        return pdbHeaderList;
+    }
+}

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
@@ -20,6 +20,7 @@ public class ApiObjectMapper extends ObjectMapper
         mixinMap.put(IsoformOverride.class, IsoformOverrideMixin.class);
         mixinMap.put(MutationAssessor.class, MutationAssessorMixin.class);
         mixinMap.put(PfamDomain.class, PfamDomainMixin.class);
+        mixinMap.put(PdbHeader.class, PdbHeaderMixin.class);
         mixinMap.put(TranscriptConsequence.class, TranscriptConsequenceMixin.class);
         mixinMap.put(VariantAnnotation.class, VariantAnnotationMixin.class);
         mixinMap.put(EnsemblTranscript.class, EnsemblTranscriptMixin.class);

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/PdbHeaderMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/PdbHeaderMixin.java
@@ -1,0 +1,19 @@
+package org.cbioportal.genome_nexus.web.mixin;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PdbHeaderMixin
+{
+    @ApiModelProperty(value = "PDB id", required = true)
+    private String pdbId;
+
+    @ApiModelProperty(value = "PDB description", required = true)
+    private String title;
+
+    private Map<String, Object> compound;
+    private Map<String, Object> source;
+}

--- a/web/src/main/resources/application.properties.EXAMPLE
+++ b/web/src/main/resources/application.properties.EXAMPLE
@@ -15,6 +15,9 @@ mutationAssessor.url=http://mutationassessor.org/r3/?cm=var&var=VARIANT&frm=json
 # Comma separated list of isoform_overrides_resource:overrides_filename pairs.
 vep.isoform.overrides=uniprot:isoform_overrides_uniprot.txt,mskcc:isoform_overrides_at_mskcc.txt
 
+# PDB header web service URL
+pdb.header_service_url=http://files.rcsb.org/header/PDB_ID.pdb
+
 # Ensembl biomart PFAM filename
 ensembl.biomart.pfam=ensembl_biomart_pfam.txt
 


### PR DESCRIPTION
Moved over the PDB info service implementation, with a simple key-value pair caching, from the https://github.com/genome-nexus/g2s/tree/master/pdb module, so that we can retire `pdb-annotation.war`.