### PR TITLE
Unit tests for MutationAssessorService

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/ExternalResourceFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/ExternalResourceFetcher.java
@@ -1,0 +1,16 @@
+package org.cbioportal.genome_nexus.service;
+
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public interface ExternalResourceFetcher<T>
+{
+    String fetchJsonString(Map<String, String> queryParams) throws HttpClientErrorException, ResourceAccessException;
+    String fetchJsonString(String param) throws HttpClientErrorException, ResourceAccessException;
+    List<T> fetchInstances(Map<String, String> queryParams) throws HttpClientErrorException, ResourceAccessException, IOException;
+    List<T> fetchInstances(String param) throws HttpClientErrorException, ResourceAccessException, IOException;
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/remote/MutationAssessorDataFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/remote/MutationAssessorDataFetcher.java
@@ -1,0 +1,81 @@
+package org.cbioportal.genome_nexus.service.remote;
+
+import org.cbioportal.genome_nexus.model.MutationAssessor;
+import org.cbioportal.genome_nexus.service.ExternalResourceFetcher;
+import org.cbioportal.genome_nexus.service.internal.ExternalResourceTransformer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class MutationAssessorDataFetcher implements ExternalResourceFetcher<MutationAssessor>
+{
+    @Value("${mutationAssessor.url}")
+    private String mutationAssessorUrl;
+
+    private final ExternalResourceTransformer externalResourceTransformer;
+
+    @Autowired
+    public MutationAssessorDataFetcher(ExternalResourceTransformer externalResourceTransformer)
+    {
+        this.externalResourceTransformer = externalResourceTransformer;
+    }
+
+    @Override
+    public String fetchJsonString(Map<String, String> queryParams)
+        throws HttpClientErrorException, ResourceAccessException
+    {
+        String variant = queryParams.get("variant");
+        String uri = this.mutationAssessorUrl;
+
+        if (variant != null && variant.length() > 0) {
+            uri = uri.replace("VARIANT", variant);
+        }
+
+        RestTemplate restTemplate = new RestTemplate();
+        return restTemplate.getForObject(uri, String.class);
+    }
+
+    @Override
+    public String fetchJsonString(String variant)
+        throws HttpClientErrorException, ResourceAccessException
+    {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("variant", variant);
+
+        return this.fetchJsonString(queryParams);
+    }
+
+    @Override
+    public List<MutationAssessor> fetchInstances(Map<String, String> queryParams)
+        throws IOException, HttpClientErrorException, ResourceAccessException
+    {
+        return this.externalResourceTransformer.transform(this.fetchJsonString(queryParams), MutationAssessor.class);
+    }
+
+    @Override
+    public List<MutationAssessor> fetchInstances(String variant)
+        throws IOException, HttpClientErrorException, ResourceAccessException
+    {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("variant", variant);
+
+        return this.fetchInstances(queryParams);
+    }
+
+    public String getMutationAssessorUrl() {
+        return mutationAssessorUrl;
+    }
+
+    public void setMutationAssessorUrl(String mutationAssessorUrl) {
+        this.mutationAssessorUrl = mutationAssessorUrl;
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/MutationAssessorTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/MutationAssessorTest.java
@@ -4,6 +4,7 @@ import org.cbioportal.genome_nexus.model.MutationAssessor;
 import org.cbioportal.genome_nexus.service.config.ExternalResourceObjectMapper;
 import org.cbioportal.genome_nexus.service.internal.ExternalResourceTransformer;
 import org.cbioportal.genome_nexus.service.internal.MutationAssessorService;
+import org.cbioportal.genome_nexus.service.remote.MutationAssessorDataFetcher;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -14,6 +15,7 @@ import java.net.URL;
 
 import static org.junit.Assert.*;
 
+// TODO these tests are not unit tests, disabled for now due to direct access to a real web API
 public class MutationAssessorTest
 {
     // for debugging
@@ -23,12 +25,13 @@ public class MutationAssessorTest
     private String url =
         "http://mutationassessor.org/r3/?cm=var&var=VARIANT&frm=json&fts=input,rgaa,rgvt,var,gene,F_impact,F_score,chr,rs_pos";
 
-    @Test
+    //@Test
     public void testStringInputs() throws IOException
     {
         ExternalResourceTransformer transformer = new ExternalResourceTransformer(new ExternalResourceObjectMapper());
-        MutationAssessorService service = new MutationAssessorService(transformer);
-        service.setMutationAssessorURL(url);
+        MutationAssessorDataFetcher fetcher = new MutationAssessorDataFetcher(transformer);
+        fetcher.setMutationAssessorUrl(url);
+        MutationAssessorService service = new MutationAssessorService(fetcher);
 
         String urlString1 = url.replace("VARIANT", "7,140453136,A,T");
         MutationAssessor mutationObj1 = service.getMutationAssessor("7,140453136,A,T", "7:g.140453136A>T");
@@ -52,12 +55,13 @@ public class MutationAssessorTest
 
     }
 
-    @Test
+    //@Test
     public void testJunk() throws IOException
     {
         ExternalResourceTransformer transformer = new ExternalResourceTransformer(new ExternalResourceObjectMapper());
-        MutationAssessorService service = new MutationAssessorService(transformer);
-        service.setMutationAssessorURL(url);
+        MutationAssessorDataFetcher fetcher = new MutationAssessorDataFetcher(transformer);
+        fetcher.setMutationAssessorUrl(url);
+        MutationAssessorService service = new MutationAssessorService(fetcher);
 
         String urlString = url.replace("VARIANT", "junkInput");
         MutationAssessor mutationObj1 = service.getMutationAssessor("junkInput", "junkInput");

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/internal/MutationAssessorServiceTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/internal/MutationAssessorServiceTest.java
@@ -1,0 +1,87 @@
+package org.cbioportal.genome_nexus.service.internal;
+
+import org.cbioportal.genome_nexus.model.MutationAssessor;
+import org.cbioportal.genome_nexus.service.remote.MutationAssessorDataFetcher;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MutationAssessorServiceTest
+{
+    @InjectMocks
+    private MutationAssessorService service;
+
+    @Mock
+    private MutationAssessorDataFetcher fetcher;
+
+    @Test
+    public void testStringInputs() throws IOException
+    {
+        Map<String, List<MutationAssessor>> mockData = this.generateMockData();
+
+        // mock methods in order to prevent hitting the live mutation assessor web API
+        Mockito.when(fetcher.fetchInstances("7,140453136,A,T")).thenReturn(mockData.get("7,140453136,A,T"));
+        Mockito.when(fetcher.fetchInstances("12,25398285,C,A")).thenReturn(mockData.get("12,25398285,C,A"));
+        Mockito.when(fetcher.fetchInstances("INVALID")).thenReturn(mockData.get("INVALID"));
+
+        // TODO add more assertions once the mock data is updated
+        MutationAssessor mutationAssessor1 = service.getMutationAssessor("7,140453136,A,T", "7:g.140453136A>T");
+        assertEquals(mutationAssessor1.getHugoSymbol(), mockData.get("7,140453136,A,T").get(0).getHugoSymbol());
+
+        MutationAssessor mutationAssessor2 = service.getMutationAssessor("12,25398285,C,A", "12:g.25398285C>A");
+        assertEquals(mutationAssessor2.getHugoSymbol(), mockData.get("12,25398285,C,A").get(0).getHugoSymbol());
+
+        MutationAssessor mutationAssessor3 = service.getMutationAssessor("INVALID", "INVALID");
+        assertEquals(mutationAssessor3.getHugoSymbol(), mockData.get("INVALID").get(0).getHugoSymbol());
+    }
+
+    // TODO define a better mock data if needed
+    private Map<String, List<MutationAssessor>> generateMockData()
+    {
+        Map<String, List<MutationAssessor>> mockData = new HashMap<>();
+
+        List<MutationAssessor> list;
+        MutationAssessor mutationAssessor;
+
+        // mock data for variant: 7,140453136,A,T
+        mutationAssessor = new MutationAssessor();
+        mutationAssessor.setHugoSymbol("GENE1");
+
+        list = new ArrayList<>();
+        list.add(mutationAssessor);
+
+        mockData.put("7,140453136,A,T", list);
+
+        // mock data for variant: 12,25398285,C,A
+        mutationAssessor = new MutationAssessor();
+        mutationAssessor.setHugoSymbol("GENE2");
+
+        list = new ArrayList<>();
+        list.add(mutationAssessor);
+
+        mockData.put("12,25398285,C,A", list);
+
+        // mock data for variant: INVALID
+        mutationAssessor = new MutationAssessor();
+        mutationAssessor.setHugoSymbol(null);
+
+        list = new ArrayList<>();
+        list.add(mutationAssessor);
+
+        mockData.put("INVALID", list);
+
+        return mockData;
+    }
+}


### PR DESCRIPTION
Fix #78

- added a new interface `ExternalResourceFetcher` to make data mocking easier for tests: Now, we should also update other services to use instances of `ExternalResourceFetcher`.
- added unit tests for `MutationAssessorService`: This is just a proof of concept, the mock data is not complete.