### PR TITLE
Add version controller and service

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/InfoServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/InfoServiceImpl.java
@@ -1,0 +1,36 @@
+package org.cbioportal.genome_nexus.service.internal;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+
+@Configuration
+@PropertySource("classpath:/maven.properties")
+@Service
+public class InfoServiceImpl {
+    @Autowired
+    private Version version;
+
+    public Version getVersion() {
+        return this.version;
+    }
+
+    @Component
+    public static class Version {
+        private String version;
+
+        @Autowired
+        Version(@Value("${project.version}") final String version) {
+            this.version = version;
+        }
+
+        public String getVersion() {
+            return this.version;
+        }
+    }
+
+}

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -85,6 +85,17 @@
           </execution>
         </executions>
       </plugin>
+      <!-- copy maven project properties to system variables -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.20.1</version>
+        <configuration>
+          <systemPropertyVariables>
+            <projectVersion>1.0</projectVersion>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
       <!-- copy application.properties.EXAMPLE if it doesn't exist -->
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
@@ -137,6 +148,7 @@
     <resources>
       <resource>
         <directory>src/main/resources</directory>
+        <filtering>true</filtering>
         <excludes>
           <exclude>*.EXAMPLE</exclude>
         </excludes>

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/InfoController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/InfoController.java
@@ -1,0 +1,35 @@
+package org.cbioportal.genome_nexus.web;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.cbioportal.genome_nexus.web.config.PublicApi;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.cbioportal.genome_nexus.service.internal.InfoServiceImpl;
+
+@RestController // shorthand for @Controller, @ResponseBody
+@CrossOrigin(origins="*") // allow all cross-domain requests
+@RequestMapping(value= "/")
+@Api(tags = "info-controller", description = "Info Controller")
+@PublicApi
+public class InfoController
+{
+    private InfoServiceImpl infoService;
+
+    @Autowired
+    public InfoController(InfoServiceImpl infoService) {
+        this.infoService = infoService;
+    }
+
+    @ApiOperation(value = "Retrieve Genome Nexus Version",
+        nickname = "fetchVersionGET")
+    @RequestMapping(value = "/version",
+        method = RequestMethod.GET,
+        produces = "application/json")
+    @ResponseBody
+    public InfoServiceImpl.Version fetchVersionGET()
+    {
+        return infoService.getVersion();
+    }
+
+}

--- a/web/src/main/resources/maven.properties
+++ b/web/src/main/resources/maven.properties
@@ -1,0 +1,2 @@
+# pass maven property to spring
+project.version=@project.version@


### PR DESCRIPTION
Uses @project.version@ in new `maven.properties `file to pass the maven prop to spring. Then return on `/version` endpoint

Might be worth looking at actuator at some point: https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html