### PR TITLE
Updated annotation model for certain numerical fields

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/Hotspot.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/Hotspot.java
@@ -45,8 +45,8 @@ public class Hotspot
     private String hugoSymbol;
     private String residue;
 
-    private String proteinStart;
-    private String proteinEnd;
+    private Integer proteinStart;
+    private Integer proteinEnd;
     private String geneId;
 
     public String getTranscriptId()
@@ -59,22 +59,22 @@ public class Hotspot
         this.transcriptId = transcriptId;
     }
 
-    public String getProteinStart()
+    public Integer getProteinStart()
     {
         return proteinStart;
     }
 
-    public void setProteinStart(String proteinStart)
+    public void setProteinStart(Integer proteinStart)
     {
         this.proteinStart = proteinStart;
     }
 
-    public String getProteinEnd()
+    public Integer getProteinEnd()
     {
         return proteinEnd;
     }
 
-    public void setProteinEnd(String proteinEnd)
+    public void setProteinEnd(Integer proteinEnd)
     {
         this.proteinEnd = proteinEnd;
     }

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/TranscriptConsequence.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/TranscriptConsequence.java
@@ -50,16 +50,16 @@ public class TranscriptConsequence
     private String variantAllele;
     private String codons;
     private String proteinId;
-    private String proteinStart;
-    private String proteinEnd;
+    private Integer proteinStart;
+    private Integer proteinEnd;
     private String geneSymbol;
     private String geneId;
     private String aminoAcids;
-    private String hgncId;
+    private Integer hgncId;
     private String canonical;
-    private String polyphenScore;
+    private Double polyphenScore;
     private String polyphenPrediction;
-    private String siftScore;
+    private Double siftScore;
     private String siftPrediction;
 
     private List<String> refseqTranscriptIds;
@@ -123,12 +123,12 @@ public class TranscriptConsequence
     }
 
     @Field(value="polyphen_score")
-    public String getPolyphenScore()
+    public Double getPolyphenScore()
     {
         return polyphenScore;
     }
 
-    public void setPolyphenScore(String polyphenScore) { this.polyphenScore = polyphenScore; }
+    public void setPolyphenScore(Double polyphenScore) { this.polyphenScore = polyphenScore; }
 
     @Field(value="polyphen_prediction")
     public String getPolyphenPrediction()
@@ -139,12 +139,12 @@ public class TranscriptConsequence
     public void setPolyphenPrediction(String polyphenPrediction) { this.polyphenPrediction = polyphenPrediction; }
 
     @Field(value="sift_score")
-    public String getSiftScore()
+    public Double getSiftScore()
     {
         return siftScore;
     }
 
-    public void setSiftScore(String siftScore) { this.siftScore = siftScore; }
+    public void setSiftScore(Double siftScore) { this.siftScore = siftScore; }
 
     @Field(value="sift_prediction")
     public String getSiftPrediction()
@@ -177,23 +177,23 @@ public class TranscriptConsequence
     }
 
     @Field(value="protein_start")
-    public String getProteinStart()
+    public Integer getProteinStart()
     {
         return proteinStart;
     }
 
-    public void setProteinStart(String proteinStart)
+    public void setProteinStart(Integer proteinStart)
     {
         this.proteinStart = proteinStart;
     }
 
     @Field(value="protein_end")
-    public String getProteinEnd()
+    public Integer getProteinEnd()
     {
         return proteinEnd;
     }
 
-    public void setProteinEnd(String proteinEnd)
+    public void setProteinEnd(Integer proteinEnd)
     {
         this.proteinEnd = proteinEnd;
     }
@@ -232,12 +232,12 @@ public class TranscriptConsequence
     }
 
     @Field(value="hgnc_id")
-    public String getHgncId()
+    public Integer getHgncId()
     {
         return hgncId;
     }
 
-    public void setHgncId(String hgncId)
+    public void setHgncId(Integer hgncId)
     {
         this.hgncId = hgncId;
     }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/TranscriptConsequenceMixin.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/TranscriptConsequenceMixin.java
@@ -27,10 +27,10 @@ public class TranscriptConsequenceMixin
     private String proteinId;
 
     @JsonProperty(value="protein_start", required = true)
-    private String proteinStart;
+    private Integer proteinStart;
 
     @JsonProperty(value="protein_end", required = true)
-    private String proteinEnd;
+    private Integer proteinEnd;
 
     @JsonProperty(value="gene_symbol", required = true)
     private String geneSymbol;
@@ -42,19 +42,19 @@ public class TranscriptConsequenceMixin
     private String aminoAcids;
 
     @JsonProperty(value="hgnc_id", required = true)
-    private String hgncId;
+    private Integer hgncId;
 
     @JsonProperty(value="canonical", required = true)
     private String canonical;
 
     @JsonProperty(value="polyphen_score", required = true)
-    private String polyphenScore;
+    private Double polyphenScore;
 
     @JsonProperty(value="polyphen_prediction", required = true)
     private String polyphenPrediction;
 
     @JsonProperty(value="sift_score", required = true)
-    private String siftScore;
+    private Double siftScore;
 
     @JsonProperty(value="sift_prediction", required = true)
     private String siftPrediction;

--- a/service/src/main/java/org/cbioportal/genome_nexus/util/Numerical.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/util/Numerical.java
@@ -82,10 +82,10 @@ public class Numerical
      * @param end   end value
      * @return      true if there is an overlap between values
      */
-    public static boolean overlaps(String input, String start, String end)
+    public static boolean overlaps(String input, Integer start, Integer end)
     {
-        Integer startValue = null;
-        Integer endValue = null;
+        Integer startValue = start;
+        Integer endValue = end;
         Integer minPos = null;
         Integer maxPos = null;
         boolean overlap = false;
@@ -95,14 +95,6 @@ public class Numerical
         {
             minPos = Collections.min(positions);
             maxPos = Collections.max(positions);
-        }
-
-        if (end != null && end.matches("\\d+")) {
-            endValue = Integer.parseInt(end);
-        }
-
-        if (start != null && start.matches("\\d+")) {
-            startValue = Integer.parseInt(start);
         }
 
         NumberRange range;

--- a/service/src/test/java/org/cbioportal/genome_nexus/util/NumericalTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/util/NumericalTest.java
@@ -79,17 +79,17 @@ public class NumericalTest
     @Test
     public void overlaps()
     {
-        assertTrue(Numerical.overlaps("667", "666", "668"));
-        assertTrue(Numerical.overlaps("667-700", "666", "668"));
-        assertTrue(Numerical.overlaps("660-667", "666", "668"));
-        assertTrue(Numerical.overlaps("668-680", "666", "668"));
-        assertTrue(Numerical.overlaps("600-666", "666", "668"));
+        assertTrue(Numerical.overlaps("667", 666, 668));
+        assertTrue(Numerical.overlaps("667-700", 666, 668));
+        assertTrue(Numerical.overlaps("660-667", 666, 668));
+        assertTrue(Numerical.overlaps("668-680", 666, 668));
+        assertTrue(Numerical.overlaps("600-666", 666, 668));
 
-        assertFalse(Numerical.overlaps("777", "666", "668"));
-        assertFalse(Numerical.overlaps("700-707", "666", "668"));
-        assertFalse(Numerical.overlaps("600", "666", "668"));
-        assertFalse(Numerical.overlaps("600-606", "666", "668"));
+        assertFalse(Numerical.overlaps("777", 666, 668));
+        assertFalse(Numerical.overlaps("700-707", 666, 668));
+        assertFalse(Numerical.overlaps("600", 666, 668));
+        assertFalse(Numerical.overlaps("600-606", 666, 668));
 
-        assertTrue(Numerical.overlaps("665-669", "666", "668"));
+        assertTrue(Numerical.overlaps("665-669", 666, 668));
     }
 }

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/HotspotMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/HotspotMixin.java
@@ -16,10 +16,10 @@ public class HotspotMixin
     private String residue;
 
     @ApiModelProperty(value = "Protein start position", required = false)
-    private String proteinStart;
+    private Integer proteinStart;
 
     @ApiModelProperty(value = "Protein end position", required = false)
-    private String proteinEnd;
+    private Integer proteinEnd;
 
     @ApiModelProperty(value = "Ensembl gene id", required = false)
     private String geneId;

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/TranscriptConsequenceMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/TranscriptConsequenceMixin.java
@@ -35,11 +35,11 @@ public class TranscriptConsequenceMixin
 
     @JsonProperty(value="protein_start", required = true)
     @ApiModelProperty(value = "Protein start position", required = false)
-    private String proteinStart;
+    private Integer proteinStart;
 
     @JsonProperty(value="protein_end", required = true)
     @ApiModelProperty(value = "Protein end position", required = false)
-    private String proteinEnd;
+    private Integer proteinEnd;
 
     @JsonProperty(value="gene_symbol", required = true)
     @ApiModelProperty(value = "Hugo gene symbol", required = false)
@@ -55,7 +55,7 @@ public class TranscriptConsequenceMixin
 
     @JsonProperty(value="hgnc_id", required = true)
     @ApiModelProperty(value = "HGNC id", required = false)
-    private String hgncId;
+    private Integer hgncId;
 
     @JsonProperty(value="canonical", required = true)
     @ApiModelProperty(value = "Canonical transcript indicator", required = false)
@@ -63,7 +63,7 @@ public class TranscriptConsequenceMixin
 
     @JsonProperty(value="polyphen_score", required = true)
     @ApiModelProperty(value = "Polyphen Score", required = false)
-    private String polyphenScore;
+    private Double polyphenScore;
 
     @JsonProperty(value="polyphen_prediction", required = true)
     @ApiModelProperty(value = "Polyphen Prediction", required = false)
@@ -71,7 +71,7 @@ public class TranscriptConsequenceMixin
 
     @JsonProperty(value="sift_score", required = true)
     @ApiModelProperty(value = "Sift Score", required = false)
-    private String siftScore;
+    private Double siftScore;
 
     @JsonProperty(value="sift_prediction", required = true)
     @ApiModelProperty(value = "Sift Prediction", required = false)


### PR DESCRIPTION
Fields like `proteinStart`, `proteinEnd`, `polyphenScore`, `siftScore`, etc. is modeled as numbers in the external APIs we use. We should also model them the same way.