### PR TITLE
Taking variant classification into account when filtering hotspots

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/AggregatedHotspots.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/AggregatedHotspots.java
@@ -1,0 +1,34 @@
+package org.cbioportal.genome_nexus.model;
+
+import java.util.List;
+
+public class AggregatedHotspots
+{
+    private GenomicLocation genomicLocation;
+    private String variant;
+    private List<Hotspot> hotspots;
+
+    public String getVariant() {
+        return variant;
+    }
+
+    public void setVariant(String variant) {
+        this.variant = variant;
+    }
+
+    public GenomicLocation getGenomicLocation() {
+        return genomicLocation;
+    }
+
+    public void setGenomicLocation(GenomicLocation genomicLocation) {
+        this.genomicLocation = genomicLocation;
+    }
+
+    public List<Hotspot> getHotspots() {
+        return hotspots;
+    }
+
+    public void setHotspots(List<Hotspot> hotspots) {
+        this.hotspots = hotspots;
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/GenomicLocation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/GenomicLocation.java
@@ -1,0 +1,50 @@
+package org.cbioportal.genome_nexus.model;
+
+public class GenomicLocation
+{
+    private String chromosome;
+    private Integer start;
+    private Integer end;
+    private String referenceAllele;
+    private String variantAllele;
+
+    public String getChromosome() {
+        return chromosome;
+    }
+
+    public void setChromosome(String chromosome) {
+        this.chromosome = chromosome;
+    }
+
+    public Integer getStart() {
+        return start;
+    }
+
+    public void setStart(Integer start) {
+        this.start = start;
+    }
+
+    public Integer getEnd() {
+        return end;
+    }
+
+    public void setEnd(Integer end) {
+        this.end = end;
+    }
+
+    public String getReferenceAllele() {
+        return referenceAllele;
+    }
+
+    public void setReferenceAllele(String referenceAllele) {
+        this.referenceAllele = referenceAllele;
+    }
+
+    public String getVariantAllele() {
+        return variantAllele;
+    }
+
+    public void setVariantAllele(String variantAllele) {
+        this.variantAllele = variantAllele;
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/Hotspot.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/Hotspot.java
@@ -44,68 +44,64 @@ public class Hotspot
 
     private String hugoSymbol;
     private String residue;
+    private Integer tumorTypeCount;
+    private Integer tumorCount;
+    private IntegerRange aminoAcidPosition;
+    private String type;
 
-    private Integer proteinStart;
-    private Integer proteinEnd;
-    private String geneId;
-
-    public String getTranscriptId()
-    {
+    public String getTranscriptId() {
         return transcriptId;
     }
 
-    public void setTranscriptId(String transcriptId)
-    {
+    public void setTranscriptId(String transcriptId) {
         this.transcriptId = transcriptId;
     }
 
-    public Integer getProteinStart()
-    {
-        return proteinStart;
-    }
-
-    public void setProteinStart(Integer proteinStart)
-    {
-        this.proteinStart = proteinStart;
-    }
-
-    public Integer getProteinEnd()
-    {
-        return proteinEnd;
-    }
-
-    public void setProteinEnd(Integer proteinEnd)
-    {
-        this.proteinEnd = proteinEnd;
-    }
-
-    public String getGeneId()
-    {
-        return geneId;
-    }
-
-    public void setGeneId(String geneId)
-    {
-        this.geneId = geneId;
-    }
-
-    public String getHugoSymbol()
-    {
+    public String getHugoSymbol() {
         return hugoSymbol;
     }
 
-    public void setHugoSymbol(String hugoSymbol)
-    {
+    public void setHugoSymbol(String hugoSymbol) {
         this.hugoSymbol = hugoSymbol;
     }
 
-    public String getResidue()
-    {
+    public String getResidue() {
         return residue;
     }
 
-    public void setResidue(String residue)
-    {
+    public void setResidue(String residue) {
         this.residue = residue;
+    }
+
+    public Integer getTumorTypeCount() {
+        return tumorTypeCount;
+    }
+
+    public void setTumorTypeCount(Integer tumorTypeCount) {
+        this.tumorTypeCount = tumorTypeCount;
+    }
+
+    public Integer getTumorCount() {
+        return tumorCount;
+    }
+
+    public void setTumorCount(Integer tumorCount) {
+        this.tumorCount = tumorCount;
+    }
+
+    public IntegerRange getAminoAcidPosition() {
+        return aminoAcidPosition;
+    }
+
+    public void setAminoAcidPosition(IntegerRange aminoAcidPosition) {
+        this.aminoAcidPosition = aminoAcidPosition;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
     }
 }

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/IntegerRange.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/IntegerRange.java
@@ -14,7 +14,7 @@
  */
 
 /*
- * This file is part of cBioPortal Genome Nexus.
+ * This file is part of cBioPortal Cancer Hotspots.
  *
  * cBioPortal is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -30,26 +30,49 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package org.cbioportal.genome_nexus.service;
-
-import org.cbioportal.genome_nexus.model.Hotspot;
-import org.cbioportal.genome_nexus.model.TranscriptConsequence;
-import org.cbioportal.genome_nexus.model.VariantAnnotation;
-import org.cbioportal.genome_nexus.service.exception.CancerHotspotsWebServiceException;
-import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
-import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
-
-import java.util.List;
+package org.cbioportal.genome_nexus.model;
 
 /**
  * @author Selcuk Onur Sumer
  */
-public interface CancerHotspotService
+public class IntegerRange
 {
-    List<Hotspot> getHotspots(String transcriptId) throws CancerHotspotsWebServiceException;
-    List<Hotspot> getHotspots(TranscriptConsequence transcript, VariantAnnotation annotation) throws CancerHotspotsWebServiceException;
-    List<Hotspot> getHotspots() throws CancerHotspotsWebServiceException;
-    List<Hotspot> getHotspotAnnotations(List<String> variants) throws CancerHotspotsWebServiceException;
-    List<Hotspot> getHotspotAnnotations(String variant)
-        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException, CancerHotspotsWebServiceException;
+    private Integer start;
+    private Integer end;
+
+    public IntegerRange()
+    {
+        this(null, null);
+    }
+
+    public IntegerRange(Integer start)
+    {
+        this(start, null);
+    }
+
+    public IntegerRange(Integer start, Integer end)
+    {
+        this.start = start;
+        this.end = end;
+    }
+
+    public Integer getStart()
+    {
+        return start;
+    }
+
+    public void setStart(Integer start)
+    {
+        this.start = start;
+    }
+
+    public Integer getEnd()
+    {
+        return end;
+    }
+
+    public void setEnd(Integer end)
+    {
+        this.end = end;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </parent>
 
     <properties>
-      <java.version>1.7</java.version>
+      <java.version>1.8</java.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-parent</artifactId>
-      <version>1.3.2.RELEASE</version>
+      <version>1.5.10.RELEASE</version>
     </parent>
 
     <properties>

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/CancerHotspotService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/CancerHotspotService.java
@@ -32,9 +32,7 @@
 
 package org.cbioportal.genome_nexus.service;
 
-import org.cbioportal.genome_nexus.model.Hotspot;
-import org.cbioportal.genome_nexus.model.TranscriptConsequence;
-import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.model.*;
 import org.cbioportal.genome_nexus.service.exception.CancerHotspotsWebServiceException;
 import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
 import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
@@ -49,7 +47,10 @@ public interface CancerHotspotService
     List<Hotspot> getHotspots(String transcriptId) throws CancerHotspotsWebServiceException;
     List<Hotspot> getHotspots(TranscriptConsequence transcript, VariantAnnotation annotation) throws CancerHotspotsWebServiceException;
     List<Hotspot> getHotspots() throws CancerHotspotsWebServiceException;
-    List<Hotspot> getHotspotAnnotations(List<String> variants) throws CancerHotspotsWebServiceException;
-    List<Hotspot> getHotspotAnnotations(String variant)
+    List<AggregatedHotspots> getHotspotAnnotationsByVariants(List<String> variants) throws CancerHotspotsWebServiceException;
+    List<AggregatedHotspots> getHotspotAnnotationsByGenomicLocations(List<GenomicLocation> genomicLocations) throws CancerHotspotsWebServiceException;
+    List<Hotspot> getHotspotAnnotationsByVariant(String variant)
+        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException, CancerHotspotsWebServiceException;
+    List<Hotspot> getHotspotAnnotationsByGenomicLocation(String genomicLocation)
         throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException, CancerHotspotsWebServiceException;
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/CanonicalTranscriptResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/CanonicalTranscriptResolver.java
@@ -1,0 +1,51 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.TranscriptConsequence;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class CanonicalTranscriptResolver
+{
+    private final TranscriptConsequencePrioritizer consequencePrioritizer;
+
+    @Autowired
+    public CanonicalTranscriptResolver(TranscriptConsequencePrioritizer consequencePrioritizer)
+    {
+        this.consequencePrioritizer = consequencePrioritizer;
+    }
+
+    public TranscriptConsequence resolve(VariantAnnotation variantAnnotation)
+    {
+        List<TranscriptConsequence> transcripts = new ArrayList<>();
+
+        for (TranscriptConsequence transcript : variantAnnotation.getTranscriptConsequences())
+        {
+            if (transcript.getTranscriptId() != null &&
+                transcript.getCanonical() != null &&
+                transcript.getCanonical().equals("1"))
+            {
+                transcripts.add(transcript);
+            }
+        }
+
+        // only one transcript marked as canonical
+        if (transcripts.size() == 1) {
+            return transcripts.iterator().next();
+        }
+        else if (transcripts.size() > 1) {
+            return this.consequencePrioritizer.transcriptWithMostSevereConsequence(
+                transcripts, variantAnnotation.getMostSevereConsequence());
+        }
+        // no transcript marked as canonical (list.size() == 0),
+        // use most severe consequence to decide which one to pick among all available
+        else {
+            return this.consequencePrioritizer.transcriptWithMostSevereConsequence(
+                variantAnnotation.getTranscriptConsequences(), variantAnnotation.getMostSevereConsequence());
+        }
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/NotationConverter.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/NotationConverter.java
@@ -1,0 +1,124 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.GenomicLocation;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotationConverter
+{
+    public GenomicLocation parseGenomicLocation(String genomicLocation, String delimiter)
+    {
+        String[] parts = genomicLocation.split(delimiter);
+        GenomicLocation location = null;
+
+        if (parts.length >= 5)
+        {
+            location = new GenomicLocation();
+
+            location.setChromosome(parts[0]);
+            location.setStart(Integer.parseInt(parts[1]));
+            location.setEnd(Integer.parseInt(parts[2]));
+            location.setReferenceAllele(parts[3]);
+            location.setVariantAllele(parts[4]);
+        }
+
+        return location;
+    }
+
+    public String genomicToHgvs(GenomicLocation genomicLocation)
+    {
+        String chr = genomicLocation.getChromosome();
+        Integer start = genomicLocation.getStart();
+        Integer end = genomicLocation.getEnd();
+        String ref = genomicLocation.getReferenceAllele();
+        String var = genomicLocation.getVariantAllele();
+
+        String prefix = "";
+
+        if(!ref.equals(var)) {
+            prefix = longestCommonPrefix(ref, var);
+        }
+//        else {
+//            log.warn("Warning: Reference allele extracted from " + chr + ":" + start + "-" + end + " matches alt allele.");
+//        }
+
+        // Remove common prefix and adjust variant position accordingly
+        if (prefix.length() > 0)
+        {
+            ref = ref.substring(prefix.length());
+            var = var.substring(prefix.length());
+
+            int nStart = start;
+            int nEnd = end;
+
+            nStart += prefix.length();
+
+            if (ref.length() == 0) {
+                nStart -= 1;
+            }
+
+            start = nStart;
+        }
+
+        String hgvs;
+
+        /*
+         Process Insertion
+         Example insertion: 17 36002277 36002278 - A
+         Example output: 17:g.36002277_36002278insA
+         */
+        if(ref.equals("-") || ref.length() == 0)
+        {
+            try {
+                hgvs = chr + ":g." + start + "_" + String.valueOf(start + 1) + "ins" + var;
+            }
+            catch (NumberFormatException e) {
+                return "";
+            }
+        }
+        /*
+         Process Deletion
+         Example deletion: 1 206811015 206811016  AC -
+         Example output:   1:g.206811015_206811016delAC
+         */
+        else if(var.equals("-") || var.length() == 0) {
+            hgvs = chr + ":g." + start + "_" + end + "del" + ref;
+        }
+        /*
+         Process ONP
+         Example SNP   : 2 216809708 216809709 CA T
+         Example output: 2:g.216809708_216809709delCAinsT
+         */
+        else if (ref.length() > 1) {
+            hgvs = chr + ":g." + start + "_" + end + "del" + ref + "ins" + var;
+        }
+        /*
+         Process SNV
+         Example SNP   : 2 216809708 216809708 C T
+         Example output: 2:g.216809708C>T
+         */
+        else {
+            hgvs = chr + ":g." + start + ref + ">" + var;
+        }
+
+        return hgvs;
+    }
+
+    // TODO factor out to a utility class as a static method if needed
+    public String longestCommonPrefix(String str1, String str2)
+    {
+        for (int prefixLen = 0; prefixLen < str1.length(); prefixLen++)
+        {
+            char c = str1.charAt(prefixLen);
+
+            if (prefixLen >= str2.length() ||
+                str2.charAt(prefixLen) != c)
+            {
+                // mismatch found
+                return str2.substring(0, prefixLen);
+            }
+        }
+
+        return str1;
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/TranscriptConsequencePrioritizer.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/TranscriptConsequencePrioritizer.java
@@ -1,0 +1,128 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.TranscriptConsequence;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class TranscriptConsequencePrioritizer
+{
+    public static final Map<String, Integer> EFFECT_PRIORITY = initEffectPriority();
+
+    public TranscriptConsequence transcriptWithMostSevereConsequence(List<TranscriptConsequence> transcripts,
+                                                                     String mostSevereConsequence)
+    {
+        Integer highestPriority = Integer.MAX_VALUE;
+        TranscriptConsequence highestPriorityTranscript = null;
+
+        for (TranscriptConsequence transcript : transcripts)
+        {
+            List<String> consequenceTerms = transcript.getConsequenceTerms();
+
+            for (String consequenceTerm : consequenceTerms)
+            {
+                if (EFFECT_PRIORITY.getOrDefault(consequenceTerm.toLowerCase(), Integer.MAX_VALUE) < highestPriority)
+                {
+                    highestPriorityTranscript = transcript;
+                    highestPriority = EFFECT_PRIORITY.getOrDefault(consequenceTerm.toLowerCase(), Integer.MAX_VALUE);
+                }
+
+                if (consequenceTerm.trim().equals(mostSevereConsequence)) {
+                    return transcript;
+                }
+            }
+        }
+
+        // no match, pick one with the highest priority
+        if (highestPriorityTranscript != null) {
+            return highestPriorityTranscript;
+        }
+
+        // if for whatever reason that is null, just return the first one.
+        if (transcripts.size() > 0) {
+            return transcripts.get(0);
+        }
+
+        return null;
+    }
+
+    public String pickHighestPriorityConsequence(List<String> consequences)
+    {
+        String highestPriorityConsequence = "";
+        Integer highestPriority = Integer.MAX_VALUE;
+
+        for (String consequence : consequences)
+        {
+            if (EFFECT_PRIORITY.getOrDefault(consequence.toLowerCase(), Integer.MAX_VALUE) < highestPriority)
+            {
+                highestPriorityConsequence = consequence;
+                highestPriority = EFFECT_PRIORITY.getOrDefault(consequence.toLowerCase(), Integer.MAX_VALUE);
+            }
+        }
+
+        return highestPriorityConsequence;
+    }
+
+    // Prioritize Sequence Ontology terms in order of severity, as estimated by Ensembl:
+    // http://useast.ensembl.org/info/genome/variation/predicted_data.html#consequences
+    private static Map<String, Integer> initEffectPriority()
+    {
+        Map<String, Integer> effectPriority = new HashMap<>();
+
+        effectPriority.put("transcript_ablation", 1); // A feature ablation whereby the deleted region includes a transcript feature
+        effectPriority.put("exon_loss_variant", 1); // A sequence variant whereby an exon is lost from the transcript
+        effectPriority.put("splice_donor_variant", 2); // A splice variant that changes the 2 base region at the 5' end of an intron
+        effectPriority.put("splice_acceptor_variant", 2); // A splice variant that changes the 2 base region at the 3' end of an intron
+        effectPriority.put("stop_gained", 3); // A sequence variant whereby at least one base of a codon is changed, resulting in a premature stop codon, leading to a shortened transcript
+        effectPriority.put("frameshift_variant", 3); // A sequence variant which causes a disruption of the translational reading frame, because the number of nucleotides inserted or deleted is not a multiple of three
+        effectPriority.put("stop_lost", 3); // A sequence variant where at least one base of the terminator codon (stop) is changed, resulting in an elongated transcript
+        effectPriority.put("start_lost", 4); // A codon variant that changes at least one base of the canonical start codon
+        effectPriority.put("initiator_codon_variant", 4); // A codon variant that changes at least one base of the first codon of a transcript
+        effectPriority.put("disruptive_inframe_insertion", 5); // An inframe increase in cds length that inserts one or more codons into the coding sequence within an existing codon
+        effectPriority.put("disruptive_inframe_deletion", 5); // An inframe decrease in cds length that deletes bases from the coding sequence starting within an existing codon
+        effectPriority.put("inframe_insertion", 5); // An inframe non synonymous variant that inserts bases into the coding sequence
+        effectPriority.put("inframe_deletion", 5); // An inframe non synonymous variant that deletes bases from the coding sequence
+        effectPriority.put("missense_variant", 6); // A sequence variant, that changes one or more bases, resulting in a different amino acid sequence but where the length is preserved
+        effectPriority.put("conservative_missense_variant", 6); // A sequence variant whereby at least one base of a codon is changed resulting in a codon that encodes for a different but similar amino acid. These variants may or may not be deleterious
+        effectPriority.put("rare_amino_acid_variant", 6); // A sequence variant whereby at least one base of a codon encoding a rare amino acid is changed, resulting in a different encoded amino acid
+        effectPriority.put("transcript_amplification", 7); // A feature amplification of a region containing a transcript
+        effectPriority.put("splice_region_variant", 8); // A sequence variant in which a change has occurred within the region of the splice site, either within 1-3 bases of the exon or 3-8 bases of the intron
+        effectPriority.put("stop_retained_variant", 9); // A sequence variant where at least one base in the terminator codon is changed, but the terminator remains
+        effectPriority.put("synonymous_variant", 9); // A sequence variant where there is no resulting change to the encoded amino acid
+        effectPriority.put("incomplete_terminal_codon_variant", 10); // A sequence variant where at least one base of the final codon of an incompletely annotated transcript is changed
+        effectPriority.put("protein_altering_variant", 11); // A sequence variant which is predicted to change the protein encoded in the coding sequence
+        effectPriority.put("coding_sequence_variant", 11); // A sequence variant that changes the coding sequence
+        effectPriority.put("mature_miRNA_variant", 11); // A transcript variant located with the sequence of the mature miRNA
+        effectPriority.put("exon_variant", 11); // A sequence variant that changes exon sequence
+        effectPriority.put("5_prime_utr_variant", 12); // A UTR variant of the 5' UTR
+        effectPriority.put("5_prime_utr_premature_start_codon_gain_variant", 12); // snpEff-specific effect, creating a start codon in 5' UTR
+        effectPriority.put("3_prime_utr_variant", 12); // A UTR variant of the 3' UTR
+        effectPriority.put("non_coding_exon_variant", 13); // A sequence variant that changes non-coding exon sequence
+        effectPriority.put("non_coding_transcript_exon_variant", 13); // snpEff-specific synonym for non_coding_exon_variant
+        effectPriority.put("non_coding_transcript_variant", 14); // A transcript variant of a non coding RNA gene
+        effectPriority.put("nc_transcript_variant", 14); // A transcript variant of a non coding RNA gene (older alias for non_coding_transcript_variant)
+        effectPriority.put("intron_variant", 14); // A transcript variant occurring within an intron
+        effectPriority.put("intragenic_variant", 14); // A variant that occurs within a gene but falls outside of all transcript features. This occurs when alternate transcripts of a gene do not share overlapping sequence
+        effectPriority.put("intragenic", 14); // snpEff-specific synonym of intragenic_variant
+        effectPriority.put("nmd_transcript_variant", 15); // A variant in a transcript that is the target of NMD
+        effectPriority.put("upstream_gene_variant", 16); // A sequence variant located 5' of a gene
+        effectPriority.put("downstream_gene_variant", 16); // A sequence variant located 3' of a gene
+        effectPriority.put("tfbs_ablation", 17); // A feature ablation whereby the deleted region includes a transcription factor binding site
+        effectPriority.put("tfbs_amplification", 17); // A feature amplification of a region containing a transcription factor binding site
+        effectPriority.put("tf_binding_site_variant", 17); // A sequence variant located within a transcription factor binding site
+        effectPriority.put("regulatory_region_ablation", 17); // A feature ablation whereby the deleted region includes a regulatory region
+        effectPriority.put("regulatory_region_amplification", 17); // A feature amplification of a region containing a regulatory region
+        effectPriority.put("regulatory_region_variant", 17); // A sequence variant located within a regulatory region
+        effectPriority.put("regulatory_region", 17); // snpEff-specific effect that should really be regulatory_region_variant
+        effectPriority.put("feature_elongation", 18); // A sequence variant that causes the extension of a genomic feature, with regard to the reference sequence
+        effectPriority.put("feature_truncation", 18); // A sequence variant that causes the reduction of a genomic feature, with regard to the reference sequence
+        effectPriority.put("intergenic_variant", 19); // A sequence variant located in the intergenic region, between genes
+        effectPriority.put("intergenic_region", 19); // snpEff-specific effect that should really be intergenic_variant
+        effectPriority.put("", 20);
+
+        return effectPriority;
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/VariantClassificationResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/VariantClassificationResolver.java
@@ -1,0 +1,200 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.TranscriptConsequence;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+public class VariantClassificationResolver
+{
+    public static Map<String, String> VARIANT_MAP = initVariantMap();
+
+    private final CanonicalTranscriptResolver canonicalTranscriptResolver;
+    private final TranscriptConsequencePrioritizer consequencePrioritizer;
+    private final VariantTypeResolver variantTypeResolver;
+
+    @Autowired
+    public VariantClassificationResolver(CanonicalTranscriptResolver canonicalTranscriptResolver,
+                                         VariantTypeResolver variantTypeResolver,
+                                         TranscriptConsequencePrioritizer consequencePrioritizer)
+    {
+        this.canonicalTranscriptResolver = canonicalTranscriptResolver;
+        this.consequencePrioritizer = consequencePrioritizer;
+        this.variantTypeResolver = variantTypeResolver;
+    }
+
+    /**
+     * Resolves to a single variant classification for the given variant annotation.
+     *
+     * @param variantAnnotation
+     * @return
+     */
+    public String resolve(VariantAnnotation variantAnnotation)
+    {
+        TranscriptConsequence canonicalTranscript = this.canonicalTranscriptResolver.resolve(variantAnnotation);
+
+        // resolve for the canonical transcript
+        // if canonical transcript resolver returns null, then most severe consequence will be used
+        return this.resolve(variantAnnotation, canonicalTranscript);
+    }
+
+    /**
+     * Resolves to a single variant classification for the given variant annotation and transcript consequence.
+     *
+     * @param variantAnnotation
+     * @param transcriptConsequence
+     * @return
+     */
+    public String resolve(VariantAnnotation variantAnnotation, TranscriptConsequence transcriptConsequence)
+    {
+        String variantClassification = null;
+        String variantType = this.variantTypeResolver.resolve(variantAnnotation);
+        Boolean isInframe = this.isInframe(variantAnnotation);
+
+        // if not null, try to resolve the variant classification for the provided transcript
+        if (transcriptConsequence != null)
+        {
+            variantClassification = this.resolveVariantClassification(
+                this.consequencePrioritizer.pickHighestPriorityConsequence(transcriptConsequence.getConsequenceTerms()),
+                    variantType, isInframe);
+        }
+        // use the most severe consequence to resolve the variant classification
+        else
+        {
+            if (variantAnnotation.getMostSevereConsequence() != null) {
+                variantClassification = resolveVariantClassification(
+                    variantAnnotation.getMostSevereConsequence(), variantType, isInframe);
+            }
+        }
+
+        return variantClassification;
+    }
+
+    /**
+     * Resolves all possible variant classification for the given transcript.
+     *
+     * @param variantAnnotation
+     * @param transcriptConsequence
+     * @return
+     */
+    public Set<String> resolveAll(VariantAnnotation variantAnnotation, TranscriptConsequence transcriptConsequence)
+    {
+        Set<String> variantClassifications = new HashSet<>();
+        String variantType = this.variantTypeResolver.resolve(variantAnnotation);
+        Boolean isInframe = this.isInframe(variantAnnotation);
+
+        // try to resolve all the variant classifications for the provided transcript
+        for (String consequenceTerm : transcriptConsequence.getConsequenceTerms())
+        {
+            variantClassifications.add(this.resolveVariantClassification(consequenceTerm, variantType, isInframe));
+        }
+
+        return variantClassifications;
+    }
+
+    public Boolean isInframe(VariantAnnotation variantAnnotation)
+    {
+        Boolean inframe = false;
+
+        if (variantAnnotation.getAlleleString() != null)
+        {
+            String[] alleles = variantAnnotation.getAlleleString().split("/", -1);
+
+            if (alleles.length == 2)
+            {
+                String referenceAllele = alleles[0];
+                String variantAllele = alleles[1];
+
+                inframe = Math.abs(referenceAllele.length() - variantAllele.length()) % 3 == 0;
+            }
+        }
+
+        return inframe;
+    }
+
+    private String resolveVariantClassification(String variant, String variantType, Boolean isInframe)
+    {
+        variant = variant.toLowerCase();
+
+        if ((variant.equals("frameshift_variant") || variant.equals("protein_altering_variant") ||
+            variant.equals("coding_sequence_variant")) &&
+            !isInframe)
+        {
+            if (variantType.equals("DEL")) {
+                return "Frame_Shift_Del";
+            }
+            else if (variantType.equals("INS")) {
+                return "Frame_Shift_Ins";
+            }
+        }
+        else if ((variant.equals("protein_altering_variant") || variant.equals("coding_sequence_variant")) &&
+            isInframe)
+        {
+            if (variantType.equals("DEL")) {
+                return "In_Frame_Del";
+            }
+            else if (variantType.equals("INS")) {
+                return "In_Frame_Ins";
+            }
+        }
+
+        return VARIANT_MAP.getOrDefault(variant, "Targeted_Region");
+    }
+
+    private static Map<String, String> initVariantMap()
+    {
+        Map<String, String> variantMap = new HashMap<>();
+
+        variantMap.put("splice_acceptor_variant",       "Splice_Site");
+        variantMap.put("splice_donor_variant",          "Splice_Site");
+        variantMap.put("transcript_ablation",           "Splice_Site");
+        variantMap.put("exon_loss_variant", "Splice_Site");
+        variantMap.put("stop_gained",                   "Nonsense_Mutation");
+        variantMap.put("frameshift_variant",            "Frame_Shift");
+        variantMap.put("stop_lost",                     "Nonstop_Mutation");
+        variantMap.put("initiator_codon_variant",       "Translation_Start_Site");
+        variantMap.put("start_lost",                    "Translation_Start_Site");
+        variantMap.put("inframe_insertion",             "In_Frame_Ins");
+        variantMap.put("inframe_deletion",              "In_Frame_Del");
+        variantMap.put("disruptive_inframe_insertion", "In_Frame_Ins");
+        variantMap.put("disrupting_inframe_deletion", "In_Frame_Del");
+        variantMap.put("missense_variant",              "Missense_Mutation");
+        variantMap.put("protein_altering_variant",      "Missense_Mutation"); // Not always correct, resolveVariantClassification handles the exceptions
+        variantMap.put("coding_sequence_variant",       "Missense_Mutation"); // Not always correct, resolveVariantClassification handles the exceptions
+        variantMap.put("conservative_missense_variant", "Missense_Mutation");
+        variantMap.put("rare_amino_acid_variant",       "Missense_Mutation");
+        variantMap.put("transcript_amplification",      "Intron");
+        variantMap.put("splice_region_variant",         "Splice_Region");
+        variantMap.put("intron_variant",                "Intron");
+        variantMap.put("intragenic",                    "Intron");
+        variantMap.put("intragenic_variant",            "Intron");
+        variantMap.put("incomplete_terminal_codon_variant", "Silent");
+        variantMap.put("synonymous_variant",            "Silent");
+        variantMap.put("stop_retained_variant",         "Silent");
+        variantMap.put("nmd_transcript_variant",        "Silent");
+        variantMap.put("mature_mirna_variant",          "RNA");
+        variantMap.put("non_coding_exon_variant",       "RNA");
+        variantMap.put("non_coding_transcript_exon_variant", "RNA");
+        variantMap.put("non_coding_transcript_variant", "RNA");
+        variantMap.put("nc_transcript_variant",         "RNA");
+        variantMap.put("exon_variant", "RNA");
+        variantMap.put("5_prime_utr_variant",           "5'UTR");
+        variantMap.put("5_prime_utr_premature_start_codon_gain_variant", "5'UTR");
+        variantMap.put("3_prime_utr_variant",           "3'UTR");
+        variantMap.put("TF_binding_site_variant",       "IGR");
+        variantMap.put("regulatory_region_variant",     "IGR");
+        variantMap.put("regulatory_region",             "IGR");
+        variantMap.put("intergenic_variant",            "IGR");
+        variantMap.put("intergenic_region",             "IGR");
+        variantMap.put("upstream_gene_variant",         "5'Flank");
+        variantMap.put("downstream_gene_variant",       "3'Flank");
+
+        return variantMap;
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/VariantTypeResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/VariantTypeResolver.java
@@ -1,0 +1,49 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.springframework.stereotype.Component;
+
+@Component
+public class VariantTypeResolver
+{
+    public String resolve(VariantAnnotation variantAnnotation)
+    {
+        String variantType = "";
+
+        if (variantAnnotation.getAlleleString() != null)
+        {
+            String[] alleles = variantAnnotation.getAlleleString().split("/", -1);
+
+            if (alleles.length == 2)
+            {
+                String referenceAllele = alleles[0];
+                String variantAllele = alleles[1];
+
+                variantType = resolveVariantType(referenceAllele, variantAllele);
+            }
+        }
+
+        return variantType;
+    }
+
+    private String resolveVariantType(String referenceAllele, String variantAllele)
+    {
+        String npType[] = {"SNP", "DNP", "TNP"};
+
+        Integer refLength = referenceAllele.equals("-") ? 0 : referenceAllele.length();
+        Integer varLength = variantAllele.equals("-") ? 0 : variantAllele.length();
+
+        if (refLength.equals(varLength))
+        {
+            if (refLength - 1 < 0) {
+                // TODO log.info("Check " + mRecord.getTUMOR_SAMPLE_BARCODE() + " " + mRecord.getHUGO_SYMBOL());??
+                return "";
+            }
+
+            return refLength < 3 ? npType[refLength - 1] : "ONP";
+        }
+        else {
+            return refLength < varLength ? "INS" : "DEL";
+        }
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/HotspotAnnotationEnricher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/HotspotAnnotationEnricher.java
@@ -44,7 +44,7 @@ public class HotspotAnnotationEnricher implements AnnotationEnricher
             for (TranscriptConsequence transcript : annotation.getTranscriptConsequences())
             {
                 try {
-                    hotspotsList.add(hotspotService.getHotspots(transcript));
+                    hotspotsList.add(hotspotService.getHotspots(transcript, annotation));
                 } catch (CancerHotspotsWebServiceException e) {
                     LOG.warn(e.getLocalizedMessage());
                 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HotspotFilter.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HotspotFilter.java
@@ -62,6 +62,9 @@ public class HotspotFilter
             typeMatches = variantClassification.toLowerCase().contains("inframe") ||
                 variantClassification.toLowerCase().contains("in_frame");
         }
+        else if (hotspotType.contains("3d"))  {
+            typeMatches = variantClassification.toLowerCase().contains("missense");
+        }
 
         return typeMatches;
     }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HotspotFilter.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HotspotFilter.java
@@ -1,0 +1,68 @@
+package org.cbioportal.genome_nexus.service.internal;
+
+import org.cbioportal.genome_nexus.model.Hotspot;
+import org.cbioportal.genome_nexus.model.TranscriptConsequence;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.annotation.VariantClassificationResolver;
+import org.cbioportal.genome_nexus.util.Numerical;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+public class HotspotFilter
+{
+    private final VariantClassificationResolver variantClassificationResolver;
+
+    @Autowired
+    public HotspotFilter(VariantClassificationResolver variantClassificationResolver)
+    {
+        this.variantClassificationResolver = variantClassificationResolver;
+    }
+
+    public Boolean filter(Hotspot hotspot, TranscriptConsequence transcript, VariantAnnotation annotation)
+    {
+        return (
+            // filter by protein position:
+            // only include the hotspot if the protein change position overlaps with the current transcript
+            Numerical.overlaps(hotspot.getResidue(), transcript.getProteinStart(), transcript.getProteinEnd()) &&
+            // filter by mutation type:
+            // only include the hotspot if the variant classification matches the hotspot type
+            this.typeMatches(hotspot.getType(), this.variantClassificationResolver.resolveAll(annotation, transcript))
+        );
+    }
+
+    public Boolean typeMatches(String hotspotType, Set<String> variantClassifications)
+    {
+        Boolean typeMatches = false;
+
+        for (String variantClassification : variantClassifications)
+        {
+            // just one match is enough
+            if (typeMatches(hotspotType, variantClassification)) {
+                typeMatches = true;
+                break;
+            }
+        }
+
+        return typeMatches;
+    }
+
+    public Boolean typeMatches(String hotspotType, String variantClassification)
+    {
+        Boolean typeMatches = true;
+
+        // for single residue hotspots, filter out anything but missense mutations
+        if (hotspotType.contains("single residue")) {
+            typeMatches = variantClassification.toLowerCase().contains("missense");
+        }
+        // for in-frame indel hotspots, filter out anything but in-frame mutations
+        else if (hotspotType.contains("in-frame"))  {
+            typeMatches = variantClassification.toLowerCase().contains("inframe") ||
+                variantClassification.toLowerCase().contains("in_frame");
+        }
+
+        return typeMatches;
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/remote/CancerHotspot3dDataFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/remote/CancerHotspot3dDataFetcher.java
@@ -1,0 +1,18 @@
+package org.cbioportal.genome_nexus.service.remote;
+
+import org.cbioportal.genome_nexus.model.Hotspot;
+import org.cbioportal.genome_nexus.service.transformer.ExternalResourceTransformer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CancerHotspot3dDataFetcher extends CancerHotspotDataFetcher
+{
+    @Autowired
+    public CancerHotspot3dDataFetcher(ExternalResourceTransformer<Hotspot> transformer,
+                                      @Value("${hotspots.3d.url}") String hotspotsUrl)
+    {
+        super(transformer, hotspotsUrl);
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/internal/HotspotFilterTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/internal/HotspotFilterTest.java
@@ -1,0 +1,74 @@
+package org.cbioportal.genome_nexus.service.internal;
+
+import org.cbioportal.genome_nexus.model.Hotspot;
+import org.cbioportal.genome_nexus.model.IntegerRange;
+import org.cbioportal.genome_nexus.model.TranscriptConsequence;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.annotation.VariantClassificationResolver;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HotspotFilterTest
+{
+    @InjectMocks
+    private HotspotFilter hotspotFilter;
+
+    @Mock
+    private VariantClassificationResolver variantClassificationResolver;
+
+    @Test
+    public void filterHotspotsByPositionAndMutationType()
+    {
+        VariantAnnotation annotation = new VariantAnnotation();
+        annotation.setVariantId("7:g.140453136A>T");
+
+        Hotspot singleResidueHotspot = new Hotspot();
+        singleResidueHotspot.setResidue("V600");
+        singleResidueHotspot.setAminoAcidPosition(new IntegerRange(600, 600));
+        singleResidueHotspot.setType("single residue");
+
+        Hotspot indelHotspot = new Hotspot();
+        indelHotspot.setResidue("594-602");
+        indelHotspot.setAminoAcidPosition(new IntegerRange(594, 602));
+        indelHotspot.setType("in-frame indel");
+
+        TranscriptConsequence singleResidueTranscript = new TranscriptConsequence();
+        singleResidueTranscript.setProteinStart(600);
+        singleResidueTranscript.setProteinEnd(600);
+
+        TranscriptConsequence indelTranscript = new TranscriptConsequence();
+        indelTranscript.setProteinStart(599);
+        indelTranscript.setProteinEnd(613);
+
+        this.mockVariantClassificationResolverMethod(annotation, singleResidueTranscript, "Missense_Mutation");
+        this.mockVariantClassificationResolverMethod(annotation, indelTranscript, "In_Frame_Insertion");
+
+        assertTrue(this.hotspotFilter.filter(singleResidueHotspot, singleResidueTranscript, annotation));
+        assertFalse(this.hotspotFilter.filter(singleResidueHotspot, indelTranscript, annotation));
+
+        assertTrue(this.hotspotFilter.filter(indelHotspot, indelTranscript, annotation));
+        assertFalse(this.hotspotFilter.filter(indelHotspot, singleResidueTranscript, annotation));
+    }
+
+    private void mockVariantClassificationResolverMethod(VariantAnnotation variantAnnotation,
+                                                         TranscriptConsequence transcriptConsequence,
+                                                         String variantClassification)
+    {
+        Set<String> returnValue = new HashSet<>();
+        returnValue.add(variantClassification);
+
+        Mockito.when(this.variantClassificationResolver.resolveAll(
+            variantAnnotation, transcriptConsequence)).thenReturn(returnValue);
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/internal/HotspotFilterTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/internal/HotspotFilterTest.java
@@ -43,6 +43,12 @@ public class HotspotFilterTest
         indelHotspot.setAminoAcidPosition(new IntegerRange(594, 602));
         indelHotspot.setType("in-frame indel");
 
+        // same mutation as the single residue one, except the hotspot type
+        Hotspot hotspot3d = new Hotspot();
+        hotspot3d.setResidue("V600");
+        hotspot3d.setAminoAcidPosition(new IntegerRange(600, 600));
+        hotspot3d.setType("3d");
+
         TranscriptConsequence singleResidueTranscript = new TranscriptConsequence();
         singleResidueTranscript.setProteinStart(600);
         singleResidueTranscript.setProteinEnd(600);
@@ -54,11 +60,20 @@ public class HotspotFilterTest
         this.mockVariantClassificationResolverMethod(annotation, singleResidueTranscript, "Missense_Mutation");
         this.mockVariantClassificationResolverMethod(annotation, indelTranscript, "In_Frame_Insertion");
 
-        assertTrue(this.hotspotFilter.filter(singleResidueHotspot, singleResidueTranscript, annotation));
-        assertFalse(this.hotspotFilter.filter(singleResidueHotspot, indelTranscript, annotation));
+        assertTrue("Single residue missense hotspot should be selected for single residue transcript",
+            this.hotspotFilter.filter(singleResidueHotspot, singleResidueTranscript, annotation));
+        assertFalse("Single residue missense hotspot should be filtered out for indel transcript",
+            this.hotspotFilter.filter(singleResidueHotspot, indelTranscript, annotation));
 
-        assertTrue(this.hotspotFilter.filter(indelHotspot, indelTranscript, annotation));
-        assertFalse(this.hotspotFilter.filter(indelHotspot, singleResidueTranscript, annotation));
+        assertTrue("Indel hotspot should be selected for indel transcript",
+            this.hotspotFilter.filter(indelHotspot, indelTranscript, annotation));
+        assertFalse("Indel hotspot should be filtered out for single residue transcript",
+            this.hotspotFilter.filter(indelHotspot, singleResidueTranscript, annotation));
+
+        assertTrue("3D hotspot should be selected for single residue transcript",
+            this.hotspotFilter.filter(hotspot3d, singleResidueTranscript, annotation));
+        assertFalse("3D hotspot should be filtered out for indel transcript",
+            this.hotspotFilter.filter(hotspot3d, indelTranscript, annotation));
     }
 
     private void mockVariantClassificationResolverMethod(VariantAnnotation variantAnnotation,

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationServiceTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationServiceTest.java
@@ -187,7 +187,11 @@ public class VariantAnnotationServiceTest
         // call the real getHotspots(TranscriptConsequence transcript) method when called with a transcript
         // it is the one calling the getHotspots(String transcriptId)
         Mockito.when(this.cancerHotspotService.getHotspots(
-            Mockito.any(TranscriptConsequence.class))).thenCallRealMethod();
+            Mockito.any(TranscriptConsequence.class), Mockito.any(VariantAnnotation.class))).thenCallRealMethod();
+
+        Mockito.when(this.cancerHotspotService.filterHotspot(Mockito.any(Hotspot.class),
+            Mockito.any(TranscriptConsequence.class),
+            Mockito.any(VariantAnnotation.class))).thenReturn(true);
 
         Mockito.when(this.cancerHotspotService.getHotspots(
             "ENST00000288602")).thenReturn(hotspotMockData.get("ENST00000288602"));

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/CancerHotspotMockData.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/CancerHotspotMockData.java
@@ -1,6 +1,7 @@
 package org.cbioportal.genome_nexus.service.mock;
 
 import org.cbioportal.genome_nexus.model.Hotspot;
+import org.cbioportal.genome_nexus.model.IntegerRange;
 import org.cbioportal.genome_nexus.service.MockData;
 
 import java.util.ArrayList;
@@ -24,21 +25,19 @@ public class CancerHotspotMockData implements MockData<List<Hotspot>>
 
         hotspot = new Hotspot();
         hotspot.setTranscriptId("ENST00000288602");
-        hotspot.setGeneId("ENSG00000157764");
+        //hotspot.setGeneId("ENSG00000157764");
         hotspot.setHugoSymbol("BRAF");
         hotspot.setResidue("V600");
-        hotspot.setProteinStart(600);
-        hotspot.setProteinEnd(600);
+        hotspot.setAminoAcidPosition(new IntegerRange(600, 600));
 
         hotspots.add(hotspot);
 
         hotspot = new Hotspot();
         hotspot.setTranscriptId("ENST00000288602");
-        hotspot.setGeneId("ENSG00000157764");
+        //hotspot.setGeneId("ENSG00000157764");
         hotspot.setHugoSymbol("BRAF");
         hotspot.setResidue("592-604");
-        hotspot.setProteinStart(600);
-        hotspot.setProteinEnd(600);
+        hotspot.setAminoAcidPosition(new IntegerRange(600, 600));
 
         hotspots.add(hotspot);
 
@@ -49,11 +48,10 @@ public class CancerHotspotMockData implements MockData<List<Hotspot>>
 
         hotspot = new Hotspot();
         hotspot.setTranscriptId("ENST00000256078");
-        hotspot.setGeneId("ENSG00000133703");
+        //hotspot.setGeneId("ENSG00000133703");
         hotspot.setHugoSymbol("KRAS");
         hotspot.setResidue("G12");
-        hotspot.setProteinStart(12);
-        hotspot.setProteinEnd(12);
+        hotspot.setAminoAcidPosition(new IntegerRange(12, 12));
 
         hotspots.add(hotspot);
 

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/CancerHotspotMockData.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/CancerHotspotMockData.java
@@ -29,6 +29,7 @@ public class CancerHotspotMockData implements MockData<List<Hotspot>>
         hotspot.setHugoSymbol("BRAF");
         hotspot.setResidue("V600");
         hotspot.setAminoAcidPosition(new IntegerRange(600, 600));
+        hotspot.setType("single residue");
 
         hotspots.add(hotspot);
 
@@ -37,7 +38,8 @@ public class CancerHotspotMockData implements MockData<List<Hotspot>>
         //hotspot.setGeneId("ENSG00000157764");
         hotspot.setHugoSymbol("BRAF");
         hotspot.setResidue("592-604");
-        hotspot.setAminoAcidPosition(new IntegerRange(600, 600));
+        hotspot.setAminoAcidPosition(new IntegerRange(592, 604));
+        hotspot.setType("in-frame indel");
 
         hotspots.add(hotspot);
 
@@ -52,6 +54,7 @@ public class CancerHotspotMockData implements MockData<List<Hotspot>>
         hotspot.setHugoSymbol("KRAS");
         hotspot.setResidue("G12");
         hotspot.setAminoAcidPosition(new IntegerRange(12, 12));
+        hotspot.setType("single residue");
 
         hotspots.add(hotspot);
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -68,6 +68,12 @@
       <artifactId>sentry-spring</artifactId>
       <version>1.6.1</version>
     </dependency>
+    <dependency>
+      <groupId>de.flapdoodle.embed</groupId>
+      <artifactId>de.flapdoodle.embed.mongo</artifactId>
+      <version>1.50.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/web/src/main/java/org/cbioportal/genome_nexus/GenomeNexusAnnotation.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/GenomeNexusAnnotation.java
@@ -37,7 +37,7 @@ import org.cbioportal.genome_nexus.web.config.InternalApi;
 import org.cbioportal.genome_nexus.web.config.PublicApi;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.web.SpringBootServletInitializer;
+import org.springframework.boot.web.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import springfox.documentation.builders.ApiInfoBuilder;

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/CancerHotspotsController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/CancerHotspotsController.java
@@ -3,7 +3,9 @@ package org.cbioportal.genome_nexus.web;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.cbioportal.genome_nexus.model.GenomicLocation;
 import org.cbioportal.genome_nexus.model.Hotspot;
+import org.cbioportal.genome_nexus.model.AggregatedHotspots;
 import org.cbioportal.genome_nexus.service.CancerHotspotService;
 import org.cbioportal.genome_nexus.service.exception.CancerHotspotsWebServiceException;
 import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
@@ -29,12 +31,12 @@ public class CancerHotspotsController
         this.hotspotService = hotspotService;
     }
 
-    @ApiOperation(value = "Retrieves hotspot annotation for a specific variant",
-        nickname = "fetchHotspotAnnotationGET")
-    @RequestMapping(value = "/cancer_hotspots/{variant:.+}",
+    @ApiOperation(value = "Retrieves hotspot annotations for a specific variant",
+        nickname = "fetchHotspotAnnotationByHgvsGET")
+    @RequestMapping(value = "/cancer_hotspots/hgvs/{variant:.+}",
         method = RequestMethod.GET,
         produces = "application/json")
-    public List<Hotspot> fetchHotspotAnnotationGET(
+    public List<Hotspot> fetchHotspotAnnotationByHgvsGET(
         @ApiParam(value="A variant. For example 7:g.140453136A>T",
             required = true,
             allowMultiple = true)
@@ -42,20 +44,50 @@ public class CancerHotspotsController
         throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException,
         CancerHotspotsWebServiceException
     {
-        return this.hotspotService.getHotspotAnnotations(variant);
+        return this.hotspotService.getHotspotAnnotationsByVariant(variant);
     }
 
-    @ApiOperation(value = "Retrieves hotspot annotation for the provided list of variants",
-        nickname = "fetchHotspotAnnotationPOST")
-    @RequestMapping(value = "/cancer_hotspots",
+    @ApiOperation(value = "Retrieves hotspot annotations for the provided list of variants",
+        nickname = "fetchHotspotAnnotationByHgvsPOST")
+    @RequestMapping(value = "/cancer_hotspots/hgvs",
         method = RequestMethod.POST,
         produces = "application/json")
-    public List<Hotspot> fetchHotspotAnnotationPOST(
+    public List<AggregatedHotspots> fetchHotspotAnnotationByHgvsPOST(
         @ApiParam(value="List of variants. For example [\"7:g.140453136A>T\",\"12:g.25398285C>A\"]",
             required = true,
             allowMultiple = true)
         @RequestBody List<String> variants) throws CancerHotspotsWebServiceException
     {
-        return this.hotspotService.getHotspotAnnotations(variants);
+        return this.hotspotService.getHotspotAnnotationsByVariants(variants);
+    }
+
+    @ApiOperation(value = "Retrieves hotspot annotations for a specific genomic location",
+        nickname = "fetchHotspotAnnotationByGenomicLocationGET")
+    @RequestMapping(value = "/cancer_hotspots/genomic/{genomicLocation:.+}",
+        method = RequestMethod.GET,
+        produces = "application/json")
+    public List<Hotspot> fetchHotspotAnnotationByGenomicLocationGET(
+        @ApiParam(value="A genomic location. For example 7,140453136,140453136,A,T",
+            required = true,
+            allowMultiple = true)
+        @PathVariable String genomicLocation)
+        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException,
+        CancerHotspotsWebServiceException
+    {
+        return this.hotspotService.getHotspotAnnotationsByGenomicLocation(genomicLocation);
+    }
+
+    @ApiOperation(value = "Retrieves hotspot annotations for the provided list of genomic locations",
+        nickname = "fetchHotspotAnnotationByGenomicLocationPOST")
+    @RequestMapping(value = "/cancer_hotspots/genomic",
+        method = RequestMethod.POST,
+        produces = "application/json")
+    public List<AggregatedHotspots> fetchHotspotAnnotationByGenomicLocationPOST(
+        @ApiParam(value="List of genomic locations.",
+            required = true,
+            allowMultiple = true)
+        @RequestBody List<GenomicLocation> genomicLocations) throws CancerHotspotsWebServiceException
+    {
+        return this.hotspotService.getHotspotAnnotationsByGenomicLocations(genomicLocations);
     }
 }

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
@@ -26,6 +26,8 @@ public class ApiObjectMapper extends ObjectMapper
         mixinMap.put(EnsemblTranscript.class, EnsemblTranscriptMixin.class);
         mixinMap.put(PfamDomainRange.class, PfamDomainRangeMixin.class);
         mixinMap.put(ExonRange.class, ExonRangeMixin.class);
+        mixinMap.put(GenomicLocation.class, GenomicLocationMixin.class);
+        mixinMap.put(AggregatedHotspots.class, AggregatedHotspotsMixin.class);
 
         super.setMixIns(mixinMap);
     }

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/AggregatedHotspotsMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/AggregatedHotspotsMixin.java
@@ -1,0 +1,21 @@
+package org.cbioportal.genome_nexus.web.mixin;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.annotations.ApiModelProperty;
+import org.cbioportal.genome_nexus.model.GenomicLocation;
+import org.cbioportal.genome_nexus.model.Hotspot;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AggregatedHotspotsMixin
+{
+    @ApiModelProperty(value = "Genomic Location", required = true)
+    private GenomicLocation genomicLocation;
+
+    @ApiModelProperty(value = "HGVS notation", required = true)
+    private String variant;
+
+    @ApiModelProperty(value = "Hotspots", required = true)
+    private List<Hotspot> hotspots;
+}

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/GenomicLocationMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/GenomicLocationMixin.java
@@ -1,0 +1,21 @@
+package org.cbioportal.genome_nexus.web.mixin;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class GenomicLocationMixin
+{
+    @ApiModelProperty(value = "Chromosome", position = 1, required = true)
+    private String chromosome;
+
+    @ApiModelProperty(value = "Start Position", position = 2, required = true)
+    private Integer start;
+
+    @ApiModelProperty(value = "End Position", position = 3, required = true)
+    private Integer end;
+
+    @ApiModelProperty(value = "Reference Allele", position = 4, required = true)
+    private String referenceAllele;
+
+    @ApiModelProperty(value = "Variant Allele", position = 5, required = true)
+    private String variantAllele;
+}

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/HotspotMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/HotspotMixin.java
@@ -2,6 +2,7 @@ package org.cbioportal.genome_nexus.web.mixin;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModelProperty;
+import org.cbioportal.genome_nexus.model.IntegerRange;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class HotspotMixin
@@ -15,12 +16,15 @@ public class HotspotMixin
     @ApiModelProperty(value = "Hotspot Residue", required = false)
     private String residue;
 
-    @ApiModelProperty(value = "Protein start position", required = false)
-    private Integer proteinStart;
+    @ApiModelProperty(value = "Hotspot type", required = false)
+    private String type;
 
-    @ApiModelProperty(value = "Protein end position", required = false)
-    private Integer proteinEnd;
+    @ApiModelProperty(value = "Amino acid position (start - end)", required = false)
+    private IntegerRange aminoAcidPosition;
 
-    @ApiModelProperty(value = "Ensembl gene id", required = false)
-    private String geneId;
+    @ApiModelProperty(value = "Tumor type count", required = false)
+    private Integer tumorTypeCount;
+
+    @ApiModelProperty(value = "Tumor count", required = false)
+    private Integer tumorCount;
 }

--- a/web/src/main/resources/application.properties.EXAMPLE
+++ b/web/src/main/resources/application.properties.EXAMPLE
@@ -5,8 +5,9 @@ vep.url=http://grch37.rest.ensembl.org/vep/human/hgvs/VARIANT?content-type=appli
 # the gene external references URL
 genexrefs.url=http://grch37.rest.ensembl.org/xrefs/id/ACCESSION?content-type=application/json
 
-# Cancer Hotspots web API URL
+# Cancer Hotspots web API URLs
 hotspots.url=http://cancerhotspots.org/api/hotspots/single/
+hotspots.3d.url=http://cancerhotspots.org/3d/api/hotspots/3d/
 
 # Mutation Assessor web API URL
 #"VARIANT" will be replaced with actual variant upon each request.

--- a/web/src/test/java/org/cbioportal/genome_nexus/web/CancerHotspotsIntegrationTest.java
+++ b/web/src/test/java/org/cbioportal/genome_nexus/web/CancerHotspotsIntegrationTest.java
@@ -1,0 +1,191 @@
+package org.cbioportal.genome_nexus.web;
+
+import org.cbioportal.genome_nexus.model.AggregatedHotspots;
+import org.cbioportal.genome_nexus.model.GenomicLocation;
+import org.cbioportal.genome_nexus.model.Hotspot;
+import org.cbioportal.genome_nexus.service.annotation.NotationConverter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = {
+        "vep.url=http://grch37.rest.ensembl.org/vep/human/hgvs/VARIANT?content-type=application/json&xref_refseq=1&ccds=1&canonical=1&domains=1&hgvs=1&numbers=1&protein=1",
+        "hotspots.url=http://cancerhotspots.org/api/hotspots/single/",
+        "hotspots.3d.url=http://cancerhotspots.org/3d/api/hotspots/3d/",
+        "spring.data.mongodb.uri=mongodb://localhost/integration",
+        "server.port=38888"
+    }
+)
+public class CancerHotspotsIntegrationTest
+{
+    private RestTemplate restTemplate = new RestTemplate();
+
+    @Autowired
+    NotationConverter notationConverter;
+
+    @Test
+    public void testSingleResidueHotspots()
+    {
+        String baseUrl = "http://localhost:38888/cancer_hotspots/genomic/";
+
+        // genomic location strings (needed for GET requests)
+        String[] genomicLocations = {
+            "7,140453193,140453193,T,C", // recurrent and 3D
+            "17,37880220,37880220,T,C", // recurrent
+            "17,37879794,37879794,G,C", // recurrent
+            "12,25398284,25398285,CC,GA", // recurrent and 3D
+            "12,25380271,25380271,C,T", // 3D
+            "10,89692940,89692940,C,T" // none
+        };
+
+        // GET requests
+        Hotspot[] hotspots0 = restTemplate.getForObject(
+            baseUrl + genomicLocations[0], Hotspot[].class);
+
+        // expected to be both recurrent and 3D hotspot
+        assertEquals(2, hotspots0.length);
+        assertEquals("N581", hotspots0[0].getResidue());
+        assertEquals("BRAF", hotspots0[0].getHugoSymbol());
+        assertEquals("N581", hotspots0[1].getResidue());
+        assertEquals("BRAF", hotspots0[1].getHugoSymbol());
+
+
+        Hotspot[] hotspots1 = restTemplate.getForObject(
+            baseUrl + genomicLocations[1], Hotspot[].class);
+
+        // expected to be a recurrent hotspot but not 3D
+        assertEquals(1, hotspots1.length);
+        assertEquals("L755", hotspots1[0].getResidue());
+        assertEquals("ERBB2", hotspots1[0].getHugoSymbol());
+        assertEquals("single residue", hotspots1[0].getType());
+
+        Hotspot[] hotspots2 = restTemplate.getForObject(
+            baseUrl + genomicLocations[2], Hotspot[].class);
+
+        // expected to be a recurrent hotspot but not 3D
+        assertEquals(1, hotspots2.length);
+        assertEquals("V697", hotspots2[0].getResidue());
+        assertEquals("ERBB2", hotspots2[0].getHugoSymbol());
+        assertEquals("single residue", hotspots2[0].getType());
+
+        Hotspot[] hotspots3 = restTemplate.getForObject(
+            baseUrl + genomicLocations[3], Hotspot[].class);
+
+        // expected to be both recurrent and 3D hotspot
+        assertEquals(2, hotspots3.length);
+        assertEquals("G12", hotspots3[0].getResidue());
+        assertEquals("KRAS", hotspots3[0].getHugoSymbol());
+        assertEquals("G12", hotspots3[1].getResidue());
+        assertEquals("KRAS", hotspots3[1].getHugoSymbol());
+
+        Hotspot[] hotspots4 = restTemplate.getForObject(
+            baseUrl + genomicLocations[4], Hotspot[].class);
+
+        // expected to be 3D hotspot only
+        assertEquals(1, hotspots4.length);
+        assertEquals("E63", hotspots4[0].getResidue());
+        assertEquals("KRAS", hotspots4[0].getHugoSymbol());
+        assertEquals("3d", hotspots4[0].getType());
+
+        Hotspot[] hotspots5 = restTemplate.getForObject(
+            baseUrl + genomicLocations[5], Hotspot[].class);
+
+        // not a hotspot, there should me no match
+        assertEquals(0, hotspots5.length);
+
+        // genomic location instances (needed for POST requests)
+        List<GenomicLocation> genomicLocationsInstances = Arrays.stream(genomicLocations).map(
+            g -> this.notationConverter.parseGenomicLocation(g, ",")).collect(Collectors.toList());
+
+        // POST request
+        AggregatedHotspots[] aggregatedHotspots = restTemplate.postForObject(
+            baseUrl, genomicLocationsInstances, AggregatedHotspots[].class);
+
+        // for each genomic location we should have one matching AggregatedHotspots instance
+        assertEquals(genomicLocations.length, aggregatedHotspots.length);
+
+        // GET and POST requests should return exact same hotspots
+        assertEquals(aggregatedHotspots[0].getHotspots().size(), hotspots0.length);
+        assertEquals(aggregatedHotspots[1].getHotspots().size(), hotspots1.length);
+        assertEquals(aggregatedHotspots[2].getHotspots().size(), hotspots2.length);
+        assertEquals(aggregatedHotspots[3].getHotspots().size(), hotspots3.length);
+        assertEquals(aggregatedHotspots[4].getHotspots().size(), hotspots4.length);
+        assertEquals(aggregatedHotspots[5].getHotspots().size(), hotspots5.length);
+
+        // genomic locations should be mapped correctly for the POST request
+        assertEquals(this.notationConverter.genomicToHgvs(genomicLocationsInstances.get(0)),
+            this.notationConverter.genomicToHgvs(aggregatedHotspots[0].getGenomicLocation()));
+        assertEquals(this.notationConverter.genomicToHgvs(genomicLocationsInstances.get(1)),
+            this.notationConverter.genomicToHgvs(aggregatedHotspots[1].getGenomicLocation()));
+        assertEquals(this.notationConverter.genomicToHgvs(genomicLocationsInstances.get(2)),
+            this.notationConverter.genomicToHgvs(aggregatedHotspots[2].getGenomicLocation()));
+        assertEquals(this.notationConverter.genomicToHgvs(genomicLocationsInstances.get(3)),
+            this.notationConverter.genomicToHgvs(aggregatedHotspots[3].getGenomicLocation()));
+        assertEquals(this.notationConverter.genomicToHgvs(genomicLocationsInstances.get(4)),
+            this.notationConverter.genomicToHgvs(aggregatedHotspots[4].getGenomicLocation()));
+        assertEquals(this.notationConverter.genomicToHgvs(genomicLocationsInstances.get(5)),
+            this.notationConverter.genomicToHgvs(aggregatedHotspots[5].getGenomicLocation()));
+    }
+
+    @Test
+    public void testIndelHotspots()
+    {
+        String baseUrl = "http://localhost:38888/cancer_hotspots/genomic/";
+
+        // genomic location strings (needed for GET requests)
+        String[] genomicLocations = {
+            "7,55242466,55242480,GAATTAAGAGAAGCA,-",
+            "7,55249002,55249003,-,CAGCGTGGA"
+        };
+
+        // GET requests
+
+        Hotspot[] hotspots0 = restTemplate.getForObject(
+            baseUrl + genomicLocations[0], Hotspot[].class);
+
+        assertEquals(1, hotspots0.length);
+        assertEquals("EGFR", hotspots0[0].getHugoSymbol());
+        assertEquals("in-frame indel", hotspots0[0].getType());
+
+        Hotspot[] hotspots1 = restTemplate.getForObject(
+            baseUrl + genomicLocations[1], Hotspot[].class);
+
+        assertEquals(1, hotspots1.length);
+        assertEquals("EGFR", hotspots1[0].getHugoSymbol());
+        assertEquals("in-frame indel", hotspots1[0].getType());
+
+        // genomic location instances (needed for POST requests)
+        List<GenomicLocation> genomicLocationsInstances = Arrays.stream(genomicLocations).map(
+            g -> this.notationConverter.parseGenomicLocation(g, ",")).collect(Collectors.toList());
+
+        // POST request
+
+        AggregatedHotspots[] aggregatedHotspots = restTemplate.postForObject(
+            baseUrl, genomicLocationsInstances, AggregatedHotspots[].class);
+
+        // for each genomic location we should have one matching AggregatedHotspots instance
+        assertEquals(genomicLocations.length, aggregatedHotspots.length);
+
+        // GET and POST requests should return exact same hotspots
+        assertEquals(aggregatedHotspots[0].getHotspots().size(), hotspots0.length);
+        assertEquals(aggregatedHotspots[1].getHotspots().size(), hotspots1.length);
+
+        // genomic locations should be mapped correctly for the POST request
+        assertEquals(this.notationConverter.genomicToHgvs(genomicLocationsInstances.get(0)),
+            this.notationConverter.genomicToHgvs(aggregatedHotspots[0].getGenomicLocation()));
+        assertEquals(this.notationConverter.genomicToHgvs(genomicLocationsInstances.get(1)),
+            this.notationConverter.genomicToHgvs(aggregatedHotspots[1].getGenomicLocation()));
+    }
+}


### PR DESCRIPTION
Improved cancer hotspot service so that we better filter hotspots for a given transcript.

Needed to move over and refactor some code from `genome-nexus-annotation-pipeline`. Eventually we should move everything there to genome nexus.