### PR TITLE
Ignore EnsemblFilter when list is empty

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/EnsemblServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/EnsemblServiceImpl.java
@@ -91,16 +91,16 @@ public class EnsemblServiceImpl implements EnsemblService
 
     @Override
     public List<EnsemblTranscript> getEnsemblTranscripts(List<String> transcriptIds, List<String> geneIds, List<String> proteinIds, List<String> hugoSymbols) {
-        if (transcriptIds != null) {
+        if (transcriptIds != null && transcriptIds.size() > 0) {
             return this.ensemblRepository.findByTranscriptIdIn(transcriptIds);
         }
-        else if (geneIds != null) {
+        else if (geneIds != null && geneIds.size() > 0) {
             return this.ensemblRepository.findByGeneIdIn(geneIds);
         }
-        else if (proteinIds != null) {
+        else if (proteinIds != null && proteinIds.size() > 0) {
             return this.ensemblRepository.findByProteinIdIn(proteinIds);
         }
-        else if (hugoSymbols != null) {
+        else if (hugoSymbols != null && hugoSymbols.size() > 0) {
             return this.ensemblRepository.findByHugoSymbolsIn(hugoSymbols);
         }
         else {


### PR DESCRIPTION
Generated typescript client in frontend requires passing an array for each
field of EnsemblFilter, but passing an empty array doesn't work currently. This
fix will ignore any empty array passed with EnsemblFilter.