### PR TITLE
Added protein position resolver

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ProteinChangeResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ProteinChangeResolver.java
@@ -1,0 +1,234 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.TranscriptConsequence;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class ProteinChangeResolver
+{
+    public static final String AA3TO1[][] = {
+        {"Ala", "A"}, {"Arg", "R"}, {"Asn", "N"}, {"Asp", "D"}, {"Asx", "B"}, {"Cys", "C"},
+        {"Glu", "E"}, {"Gln", "Q"}, {"Glx", "Z"}, {"Gly", "G"}, {"His", "H"}, {"Ile", "I"},
+        {"Leu", "L"}, {"Lys", "K"}, {"Met", "M"}, {"Phe", "F"}, {"Pro", "P"}, {"Ser", "S"},
+        {"Thr", "T"}, {"Trp", "W"}, {"Tyr", "Y"}, {"Val", "V"}, {"Xxx", "X"}, {"Ter", "*"}
+    };
+
+    public static final Set<String> SPLICE_SITE_VARIANTS = new HashSet<>(
+        Arrays.asList("splice_acceptor_variant", "splice_donor_variant", "splice_region_variant")
+    );
+
+    private final CanonicalTranscriptResolver canonicalTranscriptResolver;
+    private final VariantClassificationResolver variantClassificationResolver;
+    private final Pattern cDnaExtractor;
+
+    @Autowired
+    public ProteinChangeResolver(CanonicalTranscriptResolver canonicalTranscriptResolver,
+                                 VariantClassificationResolver variantClassificationResolver)
+    {
+        this.canonicalTranscriptResolver = canonicalTranscriptResolver;
+        this.variantClassificationResolver = variantClassificationResolver;
+        this.cDnaExtractor = Pattern.compile(".*[cn].-?\\*?(\\d+).*");
+    }
+
+    /**
+     * Resolves to a single hgvsp short for the given variant annotation.
+     *
+     * @param variantAnnotation
+     * @return
+     */
+    public String resolveHgvspShort(VariantAnnotation variantAnnotation)
+    {
+        TranscriptConsequence canonicalTranscript = this.canonicalTranscriptResolver.resolve(variantAnnotation);
+
+        // resolve for the canonical transcript
+        return this.resolveHgvspShort(variantAnnotation, canonicalTranscript);
+    }
+
+    /**
+     * Resolves to a single hgvsp short for the given transcript consequence and variant annotation.
+     *
+     * @param transcriptConsequence
+     * @return
+     */
+    public String resolveHgvspShort(VariantAnnotation variantAnnotation,
+                                    TranscriptConsequence transcriptConsequence)
+    {
+        String hgvspShort = null;
+
+        String hgvsp = this.resolveHgvsp(transcriptConsequence);
+        String hgvsc = this.resolveHgvsc(transcriptConsequence);
+
+        if (hgvsp != null) {
+            hgvspShort = this.resolveHgvspShortFromHgvsp(hgvsp);
+        }
+        else if (hgvsc != null) {
+            hgvspShort = this.resolveHgvspShortFromHgvsc(hgvsc, variantAnnotation, transcriptConsequence);
+        }
+
+        // if hgvspShort is still unresolved then
+        // try to salvage using protein_start, amino_acids, and consequence_terms
+        if (hgvspShort == null &&
+            transcriptConsequence != null &&
+            transcriptConsequence.getAminoAcids() != null)
+        {
+            hgvspShort = this.resolveHgvspShortFromAAs(transcriptConsequence);
+        }
+
+        return hgvspShort;
+    }
+
+    private String resolveHgvspShortFromHgvsp(String hgvsp)
+    {
+        String hgvspShort = null;
+
+        for (int i = 0; i < 24; i++) {
+            if (hgvsp.contains(AA3TO1[i][0])) {
+                hgvspShort = hgvsp.replaceAll(AA3TO1[i][0], AA3TO1[i][1]);
+            }
+        }
+
+        return hgvspShort;
+    }
+
+    private String resolveHgvspShortFromHgvsc(String hgvsc,
+                                              VariantAnnotation variantAnnotation,
+                                              TranscriptConsequence transcriptConsequence)
+    {
+        String hgvspShort = null;
+
+        Integer cPos = 0;
+        Integer pPos = 0;
+
+        Matcher m = this.cDnaExtractor.matcher(hgvsc);
+
+        if (m.matches())
+        {
+            cPos = Integer.parseInt(m.group(1));
+            cPos = cPos < 1 ? 1 : cPos;
+            pPos = (cPos + 2) / 3;
+
+            if (SPLICE_SITE_VARIANTS.contains(transcriptConsequence.getConsequenceTerms().get(0)))
+            {
+                hgvspShort = "p.X" + String.valueOf(pPos) + "_splice";
+            }
+            else if (transcriptConsequence.getAminoAcids() == null)
+            {
+                String variantClassification = this.variantClassificationResolver.resolve(
+                    variantAnnotation, transcriptConsequence);
+
+                hgvspShort = "*" + String.valueOf(pPos);
+
+                if (variantClassification.toLowerCase().startsWith("frame_shift")) {
+                    hgvspShort += "fs*";
+                }
+                else {
+                    hgvspShort += "*";
+                }
+            }
+        }
+
+        return hgvspShort;
+    }
+
+    private String resolveHgvspShortFromAAs(TranscriptConsequence transcriptConsequence)
+    {
+        String hgvspShort = null;
+
+        try {
+            String[] aaParts = transcriptConsequence.getAminoAcids().split("/");
+
+            if (transcriptConsequence.getConsequenceTerms() != null &&
+                transcriptConsequence.getConsequenceTerms().get(0).toLowerCase().contains("inframe_insertion"))
+            {
+                // to prevent IndexOutOfBoundsException's we check for 'dup' in the HGVSc field (ex: ENST00000357654.3:c.5266dupC)
+                // since the 'amino_acids' may not always be provided in such a way where the reference allele is available
+                // ex: with the reference aa 'N/KN' and without the reference aa '-/K'.
+                // the second format will throw an IndexOutOfBoundsException when trying to access substring index 1
+                if (transcriptConsequence.getHgvsc() != null &&
+                    transcriptConsequence.getHgvsc().contains("dup"))
+                {
+                    hgvspShort = aaParts[1].substring(0,1) +
+                        String.valueOf(transcriptConsequence.getProteinStart() - 1) +
+                        "dup";
+                }
+                else
+                {
+                    hgvspShort = aaParts[1].substring(0,1) +
+                        transcriptConsequence.getProteinStart() + "_" +
+                        aaParts[1].substring(1, 2) + "ins" +
+                        transcriptConsequence.getProteinEnd() +
+                        aaParts[1].substring(2);
+                }
+            }
+            else if (transcriptConsequence.getConsequenceTerms() != null &&
+                transcriptConsequence.getConsequenceTerms().get(0).toLowerCase().contains("inframe_deletion"))
+            {
+                hgvspShort = aaParts[0] + "del";
+            }
+            else
+            {
+                hgvspShort = aaParts[0] + transcriptConsequence.getProteinStart();
+
+                if (transcriptConsequence.getConsequenceTerms() != null &&
+                    transcriptConsequence.getConsequenceTerms().get(0).toLowerCase().contains("frameshift_variant"))
+                {
+                    hgvspShort += "fs";
+                }
+                else
+                {
+                    hgvspShort += aaParts[1];
+                }
+            }
+        } catch (NullPointerException e) {
+            // LOG.debug("Failed to salvage HGVSp_Short from protein start, amino acids, and consequence terms");
+        }
+
+        return hgvspShort;
+    }
+
+    private String resolveHgvsc(TranscriptConsequence transcriptConsequence)
+    {
+        String hgvsc = null;
+
+        if (transcriptConsequence != null &&
+            transcriptConsequence.getHgvsc() != null)
+        {
+            hgvsc = transcriptConsequence.getHgvsc();
+        }
+
+        return hgvsc;
+    }
+
+    private String resolveHgvsp(TranscriptConsequence transcriptConsequence)
+    {
+        String hgvsp = null;
+
+        if (transcriptConsequence != null &&
+            transcriptConsequence.getHgvsp() != null)
+        {
+            hgvsp = this.normalizeHgvsp(transcriptConsequence.getHgvsp());
+        }
+
+        return hgvsp;
+    }
+
+    private String normalizeHgvsp(String hgvsp)
+    {
+        int index = hgvsp.indexOf(":");
+
+        if (hgvsp.contains("(p.%3D)")) {
+            return "p.=";
+        }
+        else {
+            return hgvsp.substring(index+1);
+        }
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ProteinPositionResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ProteinPositionResolver.java
@@ -1,0 +1,68 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.IntegerRange;
+import org.cbioportal.genome_nexus.model.TranscriptConsequence;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.util.Numerical;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ProteinPositionResolver
+{
+    private final ProteinChangeResolver proteinChangeResolver;
+
+    @Autowired
+    public ProteinPositionResolver(ProteinChangeResolver proteinChangeResolver)
+    {
+        this.proteinChangeResolver = proteinChangeResolver;
+    }
+
+    public IntegerRange resolve(VariantAnnotation annotation, TranscriptConsequence transcriptConsequence)
+    {
+        IntegerRange proteinPos = null;
+        String proteinChange = this.proteinChangeResolver.resolveHgvspShort(annotation, transcriptConsequence);
+
+        // special case for duplication
+        if (proteinChange.toLowerCase().contains("dup")) {
+            proteinPos = this.extractProteinPos(proteinChange);
+        }
+
+        // for all other cases use the reported protein start and end positions
+        // (proteinPos may also be null in case of protein change value parse error)
+        if (proteinPos == null) {
+            proteinPos = new IntegerRange(transcriptConsequence.getProteinStart(), transcriptConsequence.getProteinEnd());
+        }
+
+        return proteinPos;
+    }
+
+    private IntegerRange extractProteinPos(String proteinChange)
+    {
+        IntegerRange proteinPos = null;
+        Integer start = -1;
+        Integer end = -1;
+
+        List<Integer> positions = Numerical.extractPositiveIntegers(proteinChange);
+
+        // ideally positions.size() should always be 2
+        if (positions.size() >= 2)
+        {
+            start = positions.get(0);
+            end = positions.get(positions.size() - 1);
+        }
+        // in case no end point, use start as end
+        else if (positions.size() > 0)
+        {
+            start = end = positions.get(0);
+        }
+
+        if (!start.equals(-1)) {
+            proteinPos = new IntegerRange(start, end);
+        }
+
+        return proteinPos;
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/ProteinPositionResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/ProteinPositionResolverTest.java
@@ -1,0 +1,72 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.IntegerRange;
+import org.cbioportal.genome_nexus.model.TranscriptConsequence;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProteinPositionResolverTest
+{
+    @InjectMocks
+    private ProteinPositionResolver proteinPositionResolver;
+
+    @Mock
+    private ProteinChangeResolver proteinChangeResolver;
+
+    @Test
+    public void resolveProteinChangeForDup()
+    {
+        VariantAnnotation annotation = new VariantAnnotation();
+        annotation.setVariantId("4:g.105243050insGGCAGCGGATGATGAAGGTGTTGGGCCGGG");
+
+        TranscriptConsequence transcriptWithDup = new TranscriptConsequence();
+        transcriptWithDup.setProteinStart(78);
+        transcriptWithDup.setProteinEnd(78);
+
+        Mockito.when(this.proteinChangeResolver.resolveHgvspShort(annotation, transcriptWithDup)).thenReturn("P68_C77dup");
+
+        IntegerRange proteinPos = proteinPositionResolver.resolve(annotation, transcriptWithDup);
+
+        assertEquals("Protein start position should be derived from protein change in case of dup",
+            proteinPos.getStart(), new Integer(68));
+
+        assertEquals("Protein end position should be derived from protein change in case of dup",
+            proteinPos.getEnd(), new Integer(77));
+
+        Mockito.when(this.proteinChangeResolver.resolveHgvspShort(annotation, transcriptWithDup)).thenReturn("P*_C*dup");
+
+        proteinPos = proteinPositionResolver.resolve(annotation, transcriptWithDup);
+
+        assertEquals("Protein position should fall back to the reported values in case of invalid dup",
+            proteinPos.getStart(), new Integer(78));
+    }
+
+    @Test
+    public void resolveProteinChangeForNonDup()
+    {
+        VariantAnnotation annotation = new VariantAnnotation();
+        annotation.setVariantId("4:g.105243050insGGCAGCGGATGATGAAGGTGTTGGGCCGGG");
+
+        TranscriptConsequence transcriptWithDup = new TranscriptConsequence();
+        transcriptWithDup.setProteinStart(78);
+        transcriptWithDup.setProteinEnd(78);
+
+        Mockito.when(this.proteinChangeResolver.resolveHgvspShort(annotation, transcriptWithDup)).thenReturn("P68_C77");
+
+        IntegerRange proteinPos = proteinPositionResolver.resolve(annotation, transcriptWithDup);
+
+        assertEquals("Protein start position should NOT be derived from protein change in regular cases",
+            proteinPos.getStart(), new Integer(78));
+
+        assertEquals("Protein end position should NOT be derived from protein change in regular cases",
+            proteinPos.getEnd(), new Integer(78));
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/internal/HotspotFilterTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/internal/HotspotFilterTest.java
@@ -4,6 +4,7 @@ import org.cbioportal.genome_nexus.model.Hotspot;
 import org.cbioportal.genome_nexus.model.IntegerRange;
 import org.cbioportal.genome_nexus.model.TranscriptConsequence;
 import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.annotation.ProteinPositionResolver;
 import org.cbioportal.genome_nexus.service.annotation.VariantClassificationResolver;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,6 +27,9 @@ public class HotspotFilterTest
 
     @Mock
     private VariantClassificationResolver variantClassificationResolver;
+
+    @Mock
+    private ProteinPositionResolver proteinPositionResolver;
 
     @Test
     public void filterHotspotsByPositionAndMutationType()
@@ -60,6 +64,9 @@ public class HotspotFilterTest
         this.mockVariantClassificationResolverMethod(annotation, singleResidueTranscript, "Missense_Mutation");
         this.mockVariantClassificationResolverMethod(annotation, indelTranscript, "In_Frame_Insertion");
 
+        this.mockProteinChangeResolverMethod(annotation, singleResidueTranscript);
+        this.mockProteinChangeResolverMethod(annotation, indelTranscript);
+
         assertTrue("Single residue missense hotspot should be selected for single residue transcript",
             this.hotspotFilter.filter(singleResidueHotspot, singleResidueTranscript, annotation));
         assertFalse("Single residue missense hotspot should be filtered out for indel transcript",
@@ -84,6 +91,16 @@ public class HotspotFilterTest
         returnValue.add(variantClassification);
 
         Mockito.when(this.variantClassificationResolver.resolveAll(
+            variantAnnotation, transcriptConsequence)).thenReturn(returnValue);
+    }
+
+    private void mockProteinChangeResolverMethod(VariantAnnotation variantAnnotation,
+                                                 TranscriptConsequence transcriptConsequence)
+    {
+        IntegerRange returnValue = new IntegerRange(
+            transcriptConsequence.getProteinStart(), transcriptConsequence.getProteinEnd());
+
+        Mockito.when(this.proteinPositionResolver.resolve(
             variantAnnotation, transcriptConsequence)).thenReturn(returnValue);
     }
 }


### PR DESCRIPTION
- In case of `dup` mutations, protein position is derived from protein change value when filtering hotspots.
- `ProteinChangeResolver` is mainly moved over from `genome-nexus-annotation-pipeline`. Ideally we should add some tests for that class too.