### PR TITLE
Added null check to prevent NPE when identifying dup protein changes

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ProteinPositionResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ProteinPositionResolver.java
@@ -26,7 +26,9 @@ public class ProteinPositionResolver
         String proteinChange = this.proteinChangeResolver.resolveHgvspShort(annotation, transcriptConsequence);
 
         // special case for duplication
-        if (proteinChange.toLowerCase().contains("dup")) {
+        if (proteinChange != null &&
+            proteinChange.toLowerCase().contains("dup"))
+        {
             proteinPos = this.extractProteinPos(proteinChange);
         }
 


### PR DESCRIPTION
Locally tested with failing cBioPortal queries (e.g: http://www.cbioportal.org/index.do?session_id=5ab2808e498eb8b3d5654fc7), missing hotspots show up again with this fix.