### PR TITLE
Added explicit fields for mutation assessor and hotspot annotations

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
@@ -61,6 +61,9 @@ public class VariantAnnotation
     private String mostSevereConsequence;
     private List<TranscriptConsequence> transcriptConsequences;
 
+    private MutationAssessorAnnotation mutationAssessorAnnotation;
+    private HotspotAnnotation hotspotAnnotation;
+
     private Map<String, Object> dynamicProps;
 
     public VariantAnnotation()
@@ -203,6 +206,22 @@ public class VariantAnnotation
     public String toString()
     {
         return annotationJSON;
+    }
+
+    public MutationAssessorAnnotation getMutationAssessorAnnotation() {
+        return mutationAssessorAnnotation;
+    }
+
+    public void setMutationAssessorAnnotation(MutationAssessorAnnotation mutationAssessorAnnotation) {
+        this.mutationAssessorAnnotation = mutationAssessorAnnotation;
+    }
+
+    public HotspotAnnotation getHotspotAnnotation() {
+        return hotspotAnnotation;
+    }
+
+    public void setHotspotAnnotation(HotspotAnnotation hotspotAnnotation) {
+        this.hotspotAnnotation = hotspotAnnotation;
     }
 
     public void setDynamicProp(String key, Object value)

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/HotspotAnnotationEnricher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/HotspotAnnotationEnricher.java
@@ -57,22 +57,7 @@ public class HotspotAnnotationEnricher implements AnnotationEnricher
                 hotspotAnnotation.setAnnotation(hotspotsList);
             }
 
-            annotation.setDynamicProp("hotspots", hotspotAnnotation);
-        }
-    }
-
-    private void enrichWithSummary(TranscriptConsequence transcript, List<Hotspot> hotspots)
-    {
-        // add a boolean field to the transcript
-        transcript.setDynamicProp("isHotspot", hotspots.size() > 0);
-    }
-
-    private void enrichWithFullInfo(TranscriptConsequence transcript, List<Hotspot> hotspots)
-    {
-        // attach the full list of hotspots
-        if (hotspots.size() > 0)
-        {
-            transcript.setDynamicProp("hotspots", hotspots);
+            annotation.setHotspotAnnotation(hotspotAnnotation);
         }
     }
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/MutationAssessorAnnotationEnricher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/MutationAssessorAnnotationEnricher.java
@@ -25,23 +25,23 @@ public class MutationAssessorAnnotationEnricher implements AnnotationEnricher
     public void enrich(VariantAnnotation annotation) {
         if (annotation != null)
         {
-            MutationAssessor mutationAssessorObj = null;
+            MutationAssessor mutationAssessor = null;
 
             try {
-                mutationAssessorObj = mutationAssessorService.getMutationAssessor(annotation);
+                mutationAssessor = mutationAssessorService.getMutationAssessor(annotation);
             } catch (MutationAssessorWebServiceException e) {
                 LOG.warn(e.getLocalizedMessage());
             } catch (MutationAssessorNotFoundException e) {
                 // fail silently for this variant annotation
             }
 
-            if (mutationAssessorObj != null &&
-                mutationAssessorObj.getMappingIssue().length() == 0)
+            if (mutationAssessor != null &&
+                mutationAssessor.getMappingIssue().length() == 0)
             {
-                MutationAssessorAnnotation mutationAnnotation = new MutationAssessorAnnotation();
-                mutationAnnotation.setAnnotation(mutationAssessorObj);
+                MutationAssessorAnnotation mutationAssessorAnnotation = new MutationAssessorAnnotation();
+                mutationAssessorAnnotation.setAnnotation(mutationAssessor);
 
-                annotation.setDynamicProp("mutation_assessor", mutationAnnotation);
+                annotation.setMutationAssessorAnnotation(mutationAssessorAnnotation);
             }
         }
     }

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationServiceTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationServiceTest.java
@@ -99,13 +99,13 @@ public class VariantAnnotationServiceTest
             "7:g.140453136A>T", null, fields);
 
         assertEquals(maMockData.get("7,140453136,A,T"),
-            ((MutationAssessorAnnotation)annotation1.getDynamicProps().get("mutation_assessor")).getAnnotation());
+            annotation1.getMutationAssessorAnnotation().getAnnotation());
 
         VariantAnnotation annotation2 = variantAnnotationService.getAnnotation(
             "12:g.25398285C>A", null, fields);
 
         assertEquals(maMockData.get("12,25398285,C,A"),
-            ((MutationAssessorAnnotation)annotation2.getDynamicProps().get("mutation_assessor")).getAnnotation());
+            annotation2.getMutationAssessorAnnotation().getAnnotation());
     }
 
     @Test
@@ -128,13 +128,13 @@ public class VariantAnnotationServiceTest
             "7:g.140453136A>T", null, fields);
 
         assertEquals(hotspotMockData.get("ENST00000288602"),
-            ((HotspotAnnotation)annotation1.getDynamicProps().get("hotspots")).getAnnotation().get(0));
+            annotation1.getHotspotAnnotation().getAnnotation().get(0));
 
         VariantAnnotation annotation2 = variantAnnotationService.getAnnotation(
             "12:g.25398285C>A", null, fields);
 
         assertEquals(hotspotMockData.get("ENST00000256078"),
-            ((HotspotAnnotation)annotation2.getDynamicProps().get("hotspots")).getAnnotation().get(0));
+            annotation2.getHotspotAnnotation().getAnnotation().get(0));
     }
 
     @Test

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationMixin.java
@@ -2,6 +2,8 @@ package org.cbioportal.genome_nexus.web.mixin;
 
 import com.fasterxml.jackson.annotation.*;
 import io.swagger.annotations.ApiModelProperty;
+import org.cbioportal.genome_nexus.model.HotspotAnnotation;
+import org.cbioportal.genome_nexus.model.MutationAssessorAnnotation;
 import org.cbioportal.genome_nexus.model.TranscriptConsequence;
 
 import java.util.List;
@@ -57,6 +59,14 @@ public class VariantAnnotationMixin {
     @JsonProperty(value="transcript_consequences", required = true)
     @ApiModelProperty(value = "List of transcripts", required = false)
     private List<TranscriptConsequence> transcriptConsequences;
+
+    @JsonProperty(value="mutation_assessor", required = true)
+    @ApiModelProperty(value = "Mutation Assessor Annotation", required = false)
+    private MutationAssessorAnnotation mutationAssessorAnnotation;
+
+    @JsonProperty(value="hotspots", required = true)
+    @ApiModelProperty(value = "Hotspot Annotation", required = false)
+    private HotspotAnnotation hotspotAnnotation;
 
     @JsonIgnore
     private Map<String, Object> dynamicProps;


### PR DESCRIPTION
- So that Swagger UI (and also the code generator) can fully resolve the actual `VariantAnnotation` model
- Enrichers now explicitly set the corresponding fields instead of using the `setDynamicProp` workaround