### PR TITLE
Moved over remaining annotation resolvers

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/GeneXref.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/GeneXref.java
@@ -32,13 +32,20 @@
 
 package org.cbioportal.genome_nexus.model;
 
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
 import java.util.List;
 
 /**
  *
  * @author ochoaa
  */
-public class GeneXref {
+@Document(collection = "ensembl.gene_xref")
+public class GeneXref
+{
+    @Id
+    private String ensemblGeneId;
 
     private String displayId;
     private String primaryId;
@@ -49,6 +56,14 @@ public class GeneXref {
     private String infoText;
     private String infoType;
     private String dbDisplayName;
+
+    public String getEnsemblGeneId() {
+        return ensemblGeneId;
+    }
+
+    public void setEnsemblGeneId(String ensemblGeneId) {
+        this.ensemblGeneId = ensemblGeneId;
+    }
 
     public String getDisplayId() {
         return displayId;

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/TranscriptConsequenceSummary.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/TranscriptConsequenceSummary.java
@@ -1,0 +1,104 @@
+package org.cbioportal.genome_nexus.model;
+
+public class TranscriptConsequenceSummary
+{
+    private String transcriptId;
+    private String codonChange;
+    private String entrezGeneId;
+    private String consequenceTerms;
+    private String hugoGeneSymbol;
+    private String hgvspShort;
+    private String hgvsp;
+    private String hgvsc;
+    private IntegerRange proteinPosition;
+    private String refSeq;
+    private String variantClassification;
+
+    public String getTranscriptId() {
+        return transcriptId;
+    }
+
+    public void setTranscriptId(String transcriptId) {
+        this.transcriptId = transcriptId;
+    }
+
+    public String getCodonChange() {
+        return codonChange;
+    }
+
+    public void setCodonChange(String codonChange) {
+        this.codonChange = codonChange;
+    }
+
+    public String getEntrezGeneId() {
+        return entrezGeneId;
+    }
+
+    public void setEntrezGeneId(String entrezGeneId) {
+        this.entrezGeneId = entrezGeneId;
+    }
+
+    public String getConsequenceTerms() {
+        return consequenceTerms;
+    }
+
+    public void setConsequenceTerms(String consequenceTerms) {
+        this.consequenceTerms = consequenceTerms;
+    }
+
+    public String getHugoGeneSymbol() {
+        return hugoGeneSymbol;
+    }
+
+    public void setHugoGeneSymbol(String hugoGeneSymbol) {
+        this.hugoGeneSymbol = hugoGeneSymbol;
+    }
+
+    public String getHgvspShort() {
+        return hgvspShort;
+    }
+
+    public void setHgvspShort(String hgvspShort) {
+        this.hgvspShort = hgvspShort;
+    }
+
+    public String getHgvsp() {
+        return hgvsp;
+    }
+
+    public void setHgvsp(String hgvsp) {
+        this.hgvsp = hgvsp;
+    }
+
+    public String getHgvsc() {
+        return hgvsc;
+    }
+
+    public void setHgvsc(String hgvsc) {
+        this.hgvsc = hgvsc;
+    }
+
+    public IntegerRange getProteinPosition() {
+        return proteinPosition;
+    }
+
+    public void setProteinPosition(IntegerRange proteinPosition) {
+        this.proteinPosition = proteinPosition;
+    }
+
+    public String getRefSeq() {
+        return refSeq;
+    }
+
+    public void setRefSeq(String refSeq) {
+        this.refSeq = refSeq;
+    }
+
+    public String getVariantClassification() {
+        return variantClassification;
+    }
+
+    public void setVariantClassification(String variantClassification) {
+        this.variantClassification = variantClassification;
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
@@ -64,6 +64,7 @@ public class VariantAnnotation
 
     private MutationAssessorAnnotation mutationAssessorAnnotation;
     private HotspotAnnotation hotspotAnnotation;
+    private VariantAnnotationSummary annotationSummary;
 
     private Map<String, Object> dynamicProps;
 
@@ -211,6 +212,14 @@ public class VariantAnnotation
     public void setTranscriptConsequences(List<TranscriptConsequence> transcriptConsequences)
     {
         this.transcriptConsequences = transcriptConsequences;
+    }
+
+    public VariantAnnotationSummary getAnnotationSummary() {
+        return annotationSummary;
+    }
+
+    public void setAnnotationSummary(VariantAnnotationSummary annotationSummary) {
+        this.annotationSummary = annotationSummary;
     }
 
     @Override

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotationSummary.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotationSummary.java
@@ -1,0 +1,70 @@
+package org.cbioportal.genome_nexus.model;
+
+import java.util.List;
+
+public class VariantAnnotationSummary
+{
+    private String variant;
+    private GenomicLocation genomicLocation;
+    private String strandSign;
+    private String variantType;
+    private String assemblyName;
+    private String canonicalTranscriptId;
+    private List<TranscriptConsequenceSummary> transcriptConsequences;
+
+    public String getVariant() {
+        return variant;
+    }
+
+    public void setVariant(String variant) {
+        this.variant = variant;
+    }
+
+    public GenomicLocation getGenomicLocation() {
+        return genomicLocation;
+    }
+
+    public void setGenomicLocation(GenomicLocation genomicLocation) {
+        this.genomicLocation = genomicLocation;
+    }
+
+    public String getStrandSign() {
+        return strandSign;
+    }
+
+    public void setStrandSign(String strandSign) {
+        this.strandSign = strandSign;
+    }
+
+    public String getVariantType() {
+        return variantType;
+    }
+
+    public void setVariantType(String variantType) {
+        this.variantType = variantType;
+    }
+
+    public String getAssemblyName() {
+        return assemblyName;
+    }
+
+    public void setAssemblyName(String assemblyName) {
+        this.assemblyName = assemblyName;
+    }
+
+    public String getCanonicalTranscriptId() {
+        return canonicalTranscriptId;
+    }
+
+    public void setCanonicalTranscriptId(String canonicalTranscriptId) {
+        this.canonicalTranscriptId = canonicalTranscriptId;
+    }
+
+    public List<TranscriptConsequenceSummary> getTranscriptConsequences() {
+        return transcriptConsequences;
+    }
+
+    public void setTranscriptConsequences(List<TranscriptConsequenceSummary> transcriptConsequences) {
+        this.transcriptConsequences = transcriptConsequences;
+    }
+}

--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/GeneXrefRepository.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/GeneXrefRepository.java
@@ -1,0 +1,6 @@
+package org.cbioportal.genome_nexus.persistence;
+
+import org.cbioportal.genome_nexus.model.GeneXref;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface GeneXrefRepository extends MongoRepository<GeneXref, String> {}

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.2</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/GeneXrefService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/GeneXrefService.java
@@ -42,4 +42,5 @@ import org.cbioportal.genome_nexus.service.exception.EnsemblWebServiceException;
  */
 public interface GeneXrefService {
     List<GeneXref> getGeneXrefs(String accession) throws EnsemblWebServiceException;
+    GeneXref getEntrezGeneXref(String accession, String geneSymbol) throws EnsemblWebServiceException;
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/VariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/VariantAnnotationService.java
@@ -32,6 +32,7 @@
 
 package org.cbioportal.genome_nexus.service;
 
+import org.cbioportal.genome_nexus.model.GenomicLocation;
 import org.cbioportal.genome_nexus.model.VariantAnnotation;
 import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
 import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
@@ -49,4 +50,13 @@ public interface VariantAnnotationService
     VariantAnnotation getAnnotation(String variant, String isoformOverrideSource, List<String> fields)
         throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException;
     List<VariantAnnotation> getAnnotations(List<String> variants, String isoformOverrideSource, List<String> fields);
+
+    VariantAnnotation getAnnotation(GenomicLocation genomicLocation)
+        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException;
+    VariantAnnotation getAnnotationByGenomicLocation(String genomicLocation)
+        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException;
+    List<VariantAnnotation> getAnnotationsByGenomicLocations(List<GenomicLocation> genomicLocations);
+    VariantAnnotation getAnnotationByGenomicLocation(String genomicLocation, String isoformOverrideSource, List<String> fields)
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException;
+    List<VariantAnnotation> getAnnotationsByGenomicLocations(List<GenomicLocation> genomicLocations, String isoformOverrideSource, List<String> fields);
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/VariantAnnotationSummaryService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/VariantAnnotationSummaryService.java
@@ -1,0 +1,43 @@
+package org.cbioportal.genome_nexus.service;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotationSummary;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
+
+import java.util.List;
+
+public interface VariantAnnotationSummaryService
+{
+    /**
+     * Generate annotation summary for the canonical transcript of the given variant string.
+     */
+    VariantAnnotationSummary getAnnotationSummaryForCanonical(String variant, String isoformOverrideSource)
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException;
+
+    /**
+     * Generate annotation summary for the canonical transcript of the given variant annotation.
+     */
+    VariantAnnotationSummary getAnnotationSummaryForCanonical(VariantAnnotation annotation);
+
+    /**
+     * Generate annotation summary for all transcripts of the given variant annotation.
+     */
+    VariantAnnotationSummary getAnnotationSummary(VariantAnnotation annotation);
+
+    /**
+     * Generate annotation summary for all transcripts of the given variant string.
+     */
+    VariantAnnotationSummary getAnnotationSummary(String variant, String isoformOverrideSource)
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException;
+
+    /**
+     * Generate annotation summaries for all transcripts of the given variant strings.
+     */
+    List<VariantAnnotationSummary> getAnnotationSummary(List<String> variants, String isoformOverrideSource);
+
+    /**
+     * Generate annotation summaries for the canonical transcript of the given variant strings.
+     */
+    List<VariantAnnotationSummary> getAnnotationSummaryForCanonical(List<String> variants, String isoformOverrideSource);
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/CodonChangeResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/CodonChangeResolver.java
@@ -1,0 +1,37 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.TranscriptConsequence;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CodonChangeResolver
+{
+    private final CanonicalTranscriptResolver canonicalTranscriptResolver;
+
+    @Autowired
+    public CodonChangeResolver(CanonicalTranscriptResolver canonicalTranscriptResolver)
+    {
+        this.canonicalTranscriptResolver = canonicalTranscriptResolver;
+    }
+
+    @Nullable
+    public String resolve(TranscriptConsequence transcriptConsequence)
+    {
+        String codonChange = null;
+
+        if(transcriptConsequence != null) {
+            codonChange = transcriptConsequence.getCodons();
+        }
+
+        return codonChange;
+    }
+
+    public String resolve(VariantAnnotation variantAnnotation)
+    {
+        return this.resolve(this.canonicalTranscriptResolver.resolve(variantAnnotation));
+    }
+
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ConsequenceTermsResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ConsequenceTermsResolver.java
@@ -1,0 +1,59 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.apache.commons.lang.StringUtils;
+import org.cbioportal.genome_nexus.model.TranscriptConsequence;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ConsequenceTermsResolver
+{
+    private final CanonicalTranscriptResolver canonicalTranscriptResolver;
+
+    @Autowired
+    public ConsequenceTermsResolver(CanonicalTranscriptResolver canonicalTranscriptResolver)
+    {
+        this.canonicalTranscriptResolver = canonicalTranscriptResolver;
+    }
+
+    @Nullable
+    public String resolve(TranscriptConsequence transcriptConsequence)
+    {
+        String consequence = null;
+        List<String> consequenceTerms = this.resolveAll(transcriptConsequence);
+
+        if (consequenceTerms != null && consequenceTerms.size() > 0) {
+            consequence = StringUtils.join(consequenceTerms, ",");
+        }
+
+        return consequence;
+    }
+
+    @Nullable
+    public String resolve(VariantAnnotation variantAnnotation)
+    {
+        return this.resolve(this.canonicalTranscriptResolver.resolve(variantAnnotation));
+    }
+
+    @Nullable
+    public List<String> resolveAll(TranscriptConsequence transcriptConsequence)
+    {
+        List<String> consequenceTerms = null;
+
+        if (transcriptConsequence != null) {
+            consequenceTerms = transcriptConsequence.getConsequenceTerms();
+        }
+
+        return consequenceTerms;
+    }
+
+    @Nullable
+    public List<String> resolveAll(VariantAnnotation variantAnnotation)
+    {
+        return this.resolveAll(this.canonicalTranscriptResolver.resolve(variantAnnotation));
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/EntrezGeneIdResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/EntrezGeneIdResolver.java
@@ -1,0 +1,82 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.GeneXref;
+import org.cbioportal.genome_nexus.model.TranscriptConsequence;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.GeneXrefService;
+import org.cbioportal.genome_nexus.service.exception.EnsemblWebServiceException;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Component
+public class EntrezGeneIdResolver
+{
+    private final CanonicalTranscriptResolver canonicalTranscriptResolver;
+    private final GeneXrefService geneXrefService;
+
+    public EntrezGeneIdResolver(CanonicalTranscriptResolver canonicalTranscriptResolver,
+                                GeneXrefService geneXrefService)
+    {
+        this.canonicalTranscriptResolver = canonicalTranscriptResolver;
+        this.geneXrefService = geneXrefService;
+    }
+
+    @Nullable
+    public String resolve(TranscriptConsequence transcriptConsequence) throws EnsemblWebServiceException
+    {
+        String entrezGeneId = null;
+
+        if (transcriptConsequence != null &&
+            transcriptConsequence.getGeneId() != null &&
+            !transcriptConsequence.getGeneId().trim().isEmpty())
+        {
+            // TODO in memory cache?
+            // check hashmap first before hitting api for gene cross-ref data
+//            if (ensemblAccessionEntrezIdMap.containsKey(transcriptConsequence.getGeneId())) {
+//                return ensemblAccessionEntrezIdMap.get(transcriptConsequence.getGeneId());
+//            }
+
+            // get xrefs from the service
+            List<GeneXref> geneXrefs = this.geneXrefService.getGeneXrefs(transcriptConsequence.getGeneId());
+
+            // filter xrefs by gene symbol first
+            geneXrefs = geneXrefs.stream().filter(xref ->
+                xref.getDbName().equals("EntrezGene") &&
+                xref.getDisplayId().equals(transcriptConsequence.getGeneSymbol())
+            ).collect(Collectors.toList());
+
+            // if more than one xrefs, then further filter by description
+            if (geneXrefs.size() > 1)
+            {
+                Optional<GeneXref> first = geneXrefs.stream().filter(xref ->
+                    !xref.getDescription().toLowerCase().contains("pseudogene") &&
+                    !xref.getDescription().toLowerCase().contains("uncharacterized")
+                ).findFirst();
+
+                if (first.isPresent()) {
+                    entrezGeneId = first.get().getPrimaryId();
+                }
+            }
+            else if (geneXrefs.size() == 1) {
+                entrezGeneId = geneXrefs.get(0).getPrimaryId();
+            }
+
+            // cache if resolved successfully
+            if (entrezGeneId != null) {
+                // TODO ensemblAccessionEntrezIdMap.put(transcriptConsequence.getGeneId(), entrezGeneId);
+            }
+        }
+
+        return entrezGeneId;
+    }
+
+    @Nullable
+    public String resolve(VariantAnnotation variantAnnotation) throws EnsemblWebServiceException
+    {
+        return this.resolve(this.canonicalTranscriptResolver.resolve(variantAnnotation));
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/EntrezGeneXrefResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/EntrezGeneXrefResolver.java
@@ -1,0 +1,43 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.GeneXref;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Component
+public class EntrezGeneXrefResolver
+{
+    @Nullable
+    public GeneXref resolve(List<GeneXref> geneXrefs, String geneSymbol)
+    {
+        GeneXref entrezGeneXref = null;
+
+        // filter xrefs by gene symbol first
+        geneXrefs = geneXrefs.stream().filter(xref ->
+            xref.getDbName().equals("EntrezGene") &&
+                xref.getDisplayId().equals(geneSymbol)
+        ).collect(Collectors.toList());
+
+        // if more than one xrefs, then further filter by description
+        if (geneXrefs.size() > 1)
+        {
+            Optional<GeneXref> first = geneXrefs.stream().filter(xref ->
+                !xref.getDescription().toLowerCase().contains("pseudogene") &&
+                    !xref.getDescription().toLowerCase().contains("uncharacterized")
+            ).findFirst();
+
+            if (first.isPresent()) {
+                entrezGeneXref = first.get();
+            }
+        }
+        else if (geneXrefs.size() == 1) {
+            entrezGeneXref = geneXrefs.get(0);
+        }
+
+        return entrezGeneXref;
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/GenomicLocationResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/GenomicLocationResolver.java
@@ -1,0 +1,119 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.GenomicLocation;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GenomicLocationResolver
+{
+    @NotNull
+    public GenomicLocation resolve(VariantAnnotation variantAnnotation)
+    {
+        GenomicLocation genomicLocation = new GenomicLocation();
+
+        genomicLocation.setChromosome(this.resolveChromosome(variantAnnotation));
+        genomicLocation.setStart(this.resolveStart(variantAnnotation));
+        genomicLocation.setEnd(this.resolveEnd(variantAnnotation));
+        genomicLocation.setReferenceAllele(this.resolveReferenceAllele(variantAnnotation));
+        genomicLocation.setVariantAllele(this.resolveVariantAllele(variantAnnotation));
+
+        return genomicLocation;
+    }
+
+    @Nullable
+    private String resolveChromosome(VariantAnnotation variantAnnotation)
+    {
+        String chromosome = null;
+
+        if (variantAnnotation != null &&
+            variantAnnotation.getSeqRegionName() != null)
+        {
+            chromosome = variantAnnotation.getSeqRegionName();
+        }
+
+        return chromosome;
+    }
+
+    @Nullable
+    public Integer resolveStart(VariantAnnotation variantAnnotation)
+    {
+        Integer start = variantAnnotation.getStart();
+        Integer end = variantAnnotation.getEnd();
+
+        if (start == null) {
+            start = end;
+        }
+
+        // in case end < start, use end instead of start
+        // (this indicates that start & end points are not properly reported though)
+        if (end != null) {
+            start = Math.min(start, end);
+        }
+
+        return start;
+    }
+
+    @Nullable
+    public Integer resolveEnd(VariantAnnotation variantAnnotation)
+    {
+        Integer start = variantAnnotation.getStart();
+        Integer end = variantAnnotation.getEnd();
+
+        if (end == null) {
+            end = start;
+        }
+
+        // in case end < start, use start instead of end
+        // (this indicates that start & end points are not properly reported though)
+        if (start != null) {
+            end = Math.max(start, end);
+        }
+
+        return end;
+    }
+
+    @Nullable
+    public String resolveReferenceAllele(VariantAnnotation variantAnnotation)
+    {
+        String referenceAllele = null;
+        String[] alleles = extractAlleles(variantAnnotation);
+
+        if (alleles != null && alleles.length == 2)
+        {
+            referenceAllele = alleles[0];
+        }
+
+        return referenceAllele;
+    }
+
+    @Nullable
+    public String resolveVariantAllele(VariantAnnotation variantAnnotation)
+    {
+        String variantAllele = null;
+        String[] alleles = extractAlleles(variantAnnotation);
+
+        if (alleles != null && alleles.length == 2)
+        {
+            variantAllele = alleles[1];
+        }
+
+        return variantAllele;
+    }
+
+    @Nullable
+    private String[] extractAlleles(VariantAnnotation variantAnnotation)
+    {
+        String[] alleles = null;
+
+        if (variantAnnotation != null &&
+            variantAnnotation.getAlleleString() != null)
+        {
+            alleles = variantAnnotation.getAlleleString().split("/", -1);
+        }
+
+        return alleles;
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/HugoGeneSymbolResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/HugoGeneSymbolResolver.java
@@ -1,0 +1,40 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.TranscriptConsequence;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HugoGeneSymbolResolver
+{
+    private final CanonicalTranscriptResolver canonicalTranscriptResolver;
+
+    @Autowired
+    public HugoGeneSymbolResolver(CanonicalTranscriptResolver canonicalTranscriptResolver)
+    {
+        this.canonicalTranscriptResolver = canonicalTranscriptResolver;
+    }
+
+    @Nullable
+    public String resolve(TranscriptConsequence transcriptConsequence)
+    {
+        String hugoSymbol = null;
+
+        if (transcriptConsequence != null &&
+            transcriptConsequence.getGeneSymbol() != null &&
+            !transcriptConsequence.getGeneSymbol().trim().isEmpty())
+        {
+            hugoSymbol = transcriptConsequence.getGeneSymbol();
+        }
+
+        return hugoSymbol;
+    }
+
+    @Nullable
+    public String resolve(VariantAnnotation variantAnnotation)
+    {
+        return this.resolve(this.canonicalTranscriptResolver.resolve(variantAnnotation));
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/NotationConverter.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/NotationConverter.java
@@ -5,9 +5,22 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 @Component
 public class NotationConverter
 {
+    public static final String DEFAULT_DELIMITER = ",";
+
+    @Nullable
+    public GenomicLocation parseGenomicLocation(String genomicLocation)
+    {
+        return this.parseGenomicLocation(genomicLocation, DEFAULT_DELIMITER);
+    }
+
     @Nullable
     public GenomicLocation parseGenomicLocation(String genomicLocation, String delimiter)
     {
@@ -30,6 +43,12 @@ public class NotationConverter
         }
 
         return location;
+    }
+
+    @Nullable
+    public String genomicToHgvs(String genomicLocation)
+    {
+        return this.genomicToHgvs(this.parseGenomicLocation(genomicLocation));
     }
 
     @Nullable
@@ -118,6 +137,31 @@ public class NotationConverter
         }
 
         return hgvs;
+    }
+
+    @NotNull
+    public Map<String, GenomicLocation> genomicToHgvsMap(List<GenomicLocation> genomicLocations)
+    {
+        Map<String, GenomicLocation> variantToGenomicLocation = new LinkedHashMap<>();
+
+        // convert genomic location to hgvs notation (there is always 1-1 mapping)
+        for (GenomicLocation location : genomicLocations) {
+            String hgvs = this.genomicToHgvs(location);
+
+            if (hgvs != null) {
+                variantToGenomicLocation.put(hgvs, location);
+            }
+        }
+
+        return variantToGenomicLocation;
+    }
+
+    public List<String> genomicToHgvs(List<GenomicLocation> genomicLocations)
+    {
+        List<String> hgvsList = new ArrayList<>();
+        hgvsList.addAll(this.genomicToHgvsMap(genomicLocations).keySet());
+
+        return hgvsList;
     }
 
     // TODO factor out to a utility class as a static method if needed

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/NotationConverter.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/NotationConverter.java
@@ -11,6 +11,10 @@ public class NotationConverter
     @Nullable
     public GenomicLocation parseGenomicLocation(String genomicLocation, String delimiter)
     {
+        if (genomicLocation == null) {
+            return null;
+        }
+
         String[] parts = genomicLocation.split(delimiter);
         GenomicLocation location = null;
 
@@ -31,6 +35,10 @@ public class NotationConverter
     @Nullable
     public String genomicToHgvs(GenomicLocation genomicLocation)
     {
+        if (genomicLocation == null) {
+            return null;
+        }
+
         String chr = genomicLocation.getChromosome();
         Integer start = genomicLocation.getStart();
         Integer end = genomicLocation.getEnd();
@@ -116,6 +124,10 @@ public class NotationConverter
     @NotNull
     public String longestCommonPrefix(String str1, String str2)
     {
+        if (str1 == null || str2 == null) {
+            return "";
+        }
+
         for (int prefixLen = 0; prefixLen < str1.length(); prefixLen++)
         {
             char c = str1.charAt(prefixLen);

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ProteinChangeResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ProteinChangeResolver.java
@@ -205,7 +205,7 @@ public class ProteinChangeResolver
     }
 
     @Nullable
-    private String resolveHgvsc(TranscriptConsequence transcriptConsequence)
+    public String resolveHgvsc(TranscriptConsequence transcriptConsequence)
     {
         String hgvsc = null;
 
@@ -219,7 +219,7 @@ public class ProteinChangeResolver
     }
 
     @Nullable
-    private String resolveHgvsp(TranscriptConsequence transcriptConsequence)
+    public String resolveHgvsp(TranscriptConsequence transcriptConsequence)
     {
         String hgvsp = null;
 

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ProteinChangeResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ProteinChangeResolver.java
@@ -91,11 +91,15 @@ public class ProteinChangeResolver
     @Nullable
     private String resolveHgvspShortFromHgvsp(String hgvsp)
     {
-        String hgvspShort = null;
+        if (hgvsp == null) {
+            return null;
+        }
+
+        String hgvspShort = hgvsp;
 
         for (int i = 0; i < 24; i++) {
             if (hgvsp.contains(AA3TO1[i][0])) {
-                hgvspShort = hgvsp.replaceAll(AA3TO1[i][0], AA3TO1[i][1]);
+                hgvspShort = hgvspShort.replaceAll(AA3TO1[i][0], AA3TO1[i][1]);
             }
         }
 

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ProteinPositionResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ProteinPositionResolver.java
@@ -37,7 +37,8 @@ public class ProteinPositionResolver
         // for all other cases use the reported protein start and end positions
         // (proteinPos may also be null in case of protein change value parse error)
         if (proteinPos == null &&
-            transcriptConsequence != null)
+            transcriptConsequence != null &&
+            (transcriptConsequence.getProteinStart() != null || transcriptConsequence.getProteinEnd() != null))
         {
             proteinPos = new IntegerRange(transcriptConsequence.getProteinStart(), transcriptConsequence.getProteinEnd());
         }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/RefSeqResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/RefSeqResolver.java
@@ -1,0 +1,64 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.TranscriptConsequence;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class RefSeqResolver
+{
+    private final CanonicalTranscriptResolver canonicalTranscriptResolver;
+
+    @Autowired
+    public RefSeqResolver(CanonicalTranscriptResolver canonicalTranscriptResolver)
+    {
+        this.canonicalTranscriptResolver = canonicalTranscriptResolver;
+    }
+
+    @Nullable
+    public String resolve(VariantAnnotation variantAnnotation)
+    {
+        return this.resolve(this.canonicalTranscriptResolver.resolve(variantAnnotation));
+    }
+
+    @Nullable
+    public List<String> resolveAll(VariantAnnotation variantAnnotation)
+    {
+        return this.resolveAll(this.canonicalTranscriptResolver.resolve(variantAnnotation));
+    }
+
+    @Nullable
+    public String resolve(TranscriptConsequence transcriptConsequence)
+    {
+        String refSeq = null;
+
+        List<String> refseqTranscriptIds = this.resolveAll(transcriptConsequence);
+
+        // just return the first one
+        if(refseqTranscriptIds != null && refseqTranscriptIds.size() > 0) {
+            refSeq = refseqTranscriptIds.get(0);
+        }
+
+        return refSeq;
+    }
+
+    @Nullable
+    public List<String> resolveAll(TranscriptConsequence transcriptConsequence)
+    {
+        List<String> refseqTranscriptIds = null;
+
+        if(transcriptConsequence != null)
+        {
+            if (transcriptConsequence.getRefseqTranscriptIds() != null)
+            {
+                refseqTranscriptIds = transcriptConsequence.getRefseqTranscriptIds();
+            }
+        }
+
+        return refseqTranscriptIds;
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/StrandSignResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/StrandSignResolver.java
@@ -1,0 +1,28 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StrandSignResolver
+{
+    @Nullable
+    private String resolve(VariantAnnotation variantAnnotation)
+    {
+        String sign = null;
+        Integer strand = variantAnnotation.getStrand();
+
+        if (strand != null)
+        {
+            if (strand < 0) {
+                sign = "-";
+            }
+            else {
+                sign = "+";
+            }
+        }
+
+        return sign;
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/StrandSignResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/StrandSignResolver.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 public class StrandSignResolver
 {
     @Nullable
-    private String resolve(VariantAnnotation variantAnnotation)
+    public String resolve(VariantAnnotation variantAnnotation)
     {
         String sign = null;
         Integer strand = null;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/StrandSignResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/StrandSignResolver.java
@@ -11,7 +11,11 @@ public class StrandSignResolver
     private String resolve(VariantAnnotation variantAnnotation)
     {
         String sign = null;
-        Integer strand = variantAnnotation.getStrand();
+        Integer strand = null;
+
+        if (variantAnnotation != null) {
+            strand = variantAnnotation.getStrand();
+        }
 
         if (strand != null)
         {

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/TranscriptConsequencePrioritizer.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/TranscriptConsequencePrioritizer.java
@@ -17,6 +17,10 @@ public class TranscriptConsequencePrioritizer
     public TranscriptConsequence transcriptWithMostSevereConsequence(List<TranscriptConsequence> transcripts,
                                                                      String mostSevereConsequence)
     {
+        if (transcripts == null) {
+            return null;
+        }
+
         Integer highestPriority = Integer.MAX_VALUE;
         TranscriptConsequence highestPriorityTranscript = null;
 
@@ -54,6 +58,10 @@ public class TranscriptConsequencePrioritizer
     @Nullable
     public String pickHighestPriorityConsequence(List<String> consequences)
     {
+        if (consequences == null) {
+            return null;
+        }
+
         String highestPriorityConsequence = null;
         Integer highestPriority = Integer.MAX_VALUE;
 
@@ -102,24 +110,24 @@ public class TranscriptConsequencePrioritizer
         effectPriority.put("synonymous_variant", 9); // A sequence variant where there is no resulting change to the encoded amino acid
         effectPriority.put("incomplete_terminal_codon_variant", 10); // A sequence variant where at least one base of the final codon of an incompletely annotated transcript is changed
         effectPriority.put("coding_sequence_variant", 11); // A sequence variant that changes the coding sequence
-        effectPriority.put("mature_miRNA_variant", 11); // A transcript variant located with the sequence of the mature miRNA
+        effectPriority.put("mature_mirna_variant", 11); // A transcript variant located with the sequence of the mature miRNA
         effectPriority.put("exon_variant", 11); // A sequence variant that changes exon sequence
-        effectPriority.put("5_prime_UTR_variant", 12); // A UTR variant of the 5" UTR
-        effectPriority.put("5_prime_UTR_premature_start_codon_gain_variant", 12); // snpEff-specific effect, creating a start codon in 5" UTR
-        effectPriority.put("3_prime_UTR_variant", 12); // A UTR variant of the 3" UTR
+        effectPriority.put("5_prime_utr_variant", 12); // A UTR variant of the 5" UTR
+        effectPriority.put("5_prime_utr_premature_start_codon_gain_variant", 12); // snpEff-specific effect, creating a start codon in 5" UTR
+        effectPriority.put("3_prime_utr_variant", 12); // A UTR variant of the 3" UTR
         effectPriority.put("non_coding_exon_variant", 13); // A sequence variant that changes non-coding exon sequence
         effectPriority.put("non_coding_transcript_exon_variant", 13); // snpEff-specific synonym for non_coding_exon_variant
         effectPriority.put("non_coding_transcript_variant", 14); // A transcript variant of a non coding RNA gene
         effectPriority.put("nc_transcript_variant", 14); // A transcript variant of a non coding RNA gene (older alias for non_coding_transcript_variant)
         effectPriority.put("intron_variant", 14); // A transcript variant occurring within an intron
         effectPriority.put("intragenic_variant", 14); // A variant that occurs within a gene but falls outside of all transcript features. This occurs when alternate transcripts of a gene do not share overlapping sequence
-        effectPriority.put("INTRAGENIC", 14); // snpEff-specific synonym of intragenic_variant
-        effectPriority.put("NMD_transcript_variant", 15); // A variant in a transcript that is the target of NMD
+        effectPriority.put("intragenic", 14); // snpEff-specific synonym of intragenic_variant
+        effectPriority.put("nmd_transcript_variant", 15); // A variant in a transcript that is the target of NMD
         effectPriority.put("upstream_gene_variant", 16); // A sequence variant located 5" of a gene
         effectPriority.put("downstream_gene_variant", 16); // A sequence variant located 3" of a gene
-        effectPriority.put("TFBS_ablation", 17); // A feature ablation whereby the deleted region includes a transcription factor binding site
-        effectPriority.put("TFBS_amplification", 17); // A feature amplification of a region containing a transcription factor binding site
-        effectPriority.put("TF_binding_site_variant", 17); // A sequence variant located within a transcription factor binding site
+        effectPriority.put("tfbs_ablation", 17); // A feature ablation whereby the deleted region includes a transcription factor binding site
+        effectPriority.put("tfbs_amplification", 17); // A feature amplification of a region containing a transcription factor binding site
+        effectPriority.put("tf_binding_site_variant", 17); // A sequence variant located within a transcription factor binding site
         effectPriority.put("regulatory_region_ablation", 17); // A feature ablation whereby the deleted region includes a regulatory region
         effectPriority.put("regulatory_region_amplification", 17); // A feature amplification of a region containing a regulatory region
         effectPriority.put("regulatory_region_variant", 17); // A sequence variant located within a regulatory region

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/TranscriptIdResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/TranscriptIdResolver.java
@@ -1,0 +1,35 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.TranscriptConsequence;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TranscriptIdResolver
+{
+    private final CanonicalTranscriptResolver canonicalTranscriptResolver;
+
+    public TranscriptIdResolver(CanonicalTranscriptResolver canonicalTranscriptResolver)
+    {
+        this.canonicalTranscriptResolver = canonicalTranscriptResolver;
+    }
+
+    @Nullable
+    public String resolve(TranscriptConsequence transcriptConsequence)
+    {
+        String transcriptId = null;
+
+        if (transcriptConsequence != null) {
+            transcriptId = transcriptConsequence.getTranscriptId();
+        }
+
+        return transcriptId;
+    }
+
+    @Nullable
+    public String resolve(VariantAnnotation variantAnnotation)
+    {
+        return this.resolve(this.canonicalTranscriptResolver.resolve(variantAnnotation));
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/VariantClassificationResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/VariantClassificationResolver.java
@@ -20,15 +20,18 @@ public class VariantClassificationResolver
     private final CanonicalTranscriptResolver canonicalTranscriptResolver;
     private final TranscriptConsequencePrioritizer consequencePrioritizer;
     private final VariantTypeResolver variantTypeResolver;
+    private final GenomicLocationResolver genomicLocationResolver;
 
     @Autowired
     public VariantClassificationResolver(CanonicalTranscriptResolver canonicalTranscriptResolver,
                                          VariantTypeResolver variantTypeResolver,
-                                         TranscriptConsequencePrioritizer consequencePrioritizer)
+                                         TranscriptConsequencePrioritizer consequencePrioritizer,
+                                         GenomicLocationResolver genomicLocationResolver)
     {
         this.canonicalTranscriptResolver = canonicalTranscriptResolver;
         this.consequencePrioritizer = consequencePrioritizer;
         this.variantTypeResolver = variantTypeResolver;
+        this.genomicLocationResolver = genomicLocationResolver;
     }
 
     /**
@@ -106,18 +109,13 @@ public class VariantClassificationResolver
     {
         Boolean inframe = false;
 
-        if (variantAnnotation != null &&
-            variantAnnotation.getAlleleString() != null)
+        String referenceAllele = this.genomicLocationResolver.resolveReferenceAllele(variantAnnotation);
+        String variantAllele = this.genomicLocationResolver.resolveVariantAllele(variantAnnotation);
+
+        if (referenceAllele != null &&
+            variantAllele != null)
         {
-            String[] alleles = variantAnnotation.getAlleleString().split("/", -1);
-
-            if (alleles.length == 2)
-            {
-                String referenceAllele = alleles[0];
-                String variantAllele = alleles[1];
-
-                inframe = Math.abs(this.calcAlleleLength(referenceAllele) - this.calcAlleleLength(variantAllele)) % 3 == 0;
-            }
+            inframe = Math.abs(this.calcAlleleLength(referenceAllele) - this.calcAlleleLength(variantAllele)) % 3 == 0;
         }
 
         return inframe;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/VariantTypeResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/VariantTypeResolver.java
@@ -2,28 +2,32 @@ package org.cbioportal.genome_nexus.service.annotation;
 
 import org.cbioportal.genome_nexus.model.VariantAnnotation;
 import org.jetbrains.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class VariantTypeResolver
 {
+    private final GenomicLocationResolver genomicLocationResolver;
+
+    @Autowired
+    public VariantTypeResolver(GenomicLocationResolver genomicLocationResolver)
+    {
+        this.genomicLocationResolver = genomicLocationResolver;
+    }
+
     @Nullable
     public String resolve(VariantAnnotation variantAnnotation)
     {
         String variantType = null;
 
-        if (variantAnnotation != null &&
-            variantAnnotation.getAlleleString() != null)
+        String referenceAllele = this.genomicLocationResolver.resolveReferenceAllele(variantAnnotation);
+        String variantAllele = this.genomicLocationResolver.resolveVariantAllele(variantAnnotation);
+
+        if (referenceAllele != null &&
+            variantAllele != null)
         {
-            String[] alleles = variantAnnotation.getAlleleString().split("/", -1);
-
-            if (alleles.length == 2)
-            {
-                String referenceAllele = alleles[0];
-                String variantAllele = alleles[1];
-
-                variantType = resolveVariantType(referenceAllele, variantAllele);
-            }
+            variantType = resolveVariantType(referenceAllele, variantAllele);
         }
 
         return variantType;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/cached/CachedEntrezGeneXrefFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/cached/CachedEntrezGeneXrefFetcher.java
@@ -1,0 +1,87 @@
+package org.cbioportal.genome_nexus.service.cached;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.cbioportal.genome_nexus.model.GeneXref;
+import org.cbioportal.genome_nexus.persistence.GeneXrefRepository;
+import org.cbioportal.genome_nexus.service.annotation.EntrezGeneXrefResolver;
+import org.cbioportal.genome_nexus.service.exception.ResourceMappingException;
+import org.cbioportal.genome_nexus.service.remote.GeneXrefDataFetcher;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+
+import java.util.*;
+
+@Component
+public class CachedEntrezGeneXrefFetcher
+{
+    private static final Log LOG = LogFactory.getLog(CachedEntrezGeneXrefFetcher.class);
+
+    private final GeneXrefDataFetcher externalResourceFetcher;
+    private final GeneXrefRepository repository;
+    private final EntrezGeneXrefResolver entrezGeneXrefResolver;
+
+    @Autowired
+    public CachedEntrezGeneXrefFetcher(GeneXrefDataFetcher externalResourceFetcher,
+                                       GeneXrefRepository repository,
+                                       EntrezGeneXrefResolver entrezGeneXrefResolver)
+    {
+        this.externalResourceFetcher = externalResourceFetcher;
+        this.repository = repository;
+        this.entrezGeneXrefResolver = entrezGeneXrefResolver;
+    }
+
+    // TODO partial code duplication: see BaseCachedExternalResourceFetcher.fetchAndCache
+    public GeneXref fetchAndCache(String accession, String geneSymbol)
+        throws ResourceMappingException, HttpClientErrorException, ResourceAccessException
+    {
+        boolean saveValue = true;
+        GeneXref entrezGeneXref = null;
+
+        try {
+            entrezGeneXref = this.repository.findOne(accession);
+        }
+        catch (DataAccessResourceFailureException e) {
+            LOG.warn("Failed to read from Mongo database - falling back on the external web service. " +
+                "Will not attempt to store variant in Mongo database.");
+            saveValue = false;
+        }
+
+        if (entrezGeneXref == null)
+        {
+            // get the gene xref from the web service and save it to the DB
+            try {
+                entrezGeneXref = this.fetchEntrezGeneXref(accession, geneSymbol);
+
+                if (saveValue && entrezGeneXref != null) {
+                    entrezGeneXref.setEnsemblGeneId(accession);
+                    this.repository.save(entrezGeneXref);
+                }
+            }
+            catch (DataIntegrityViolationException e) {
+                // in case of data integrity violation exception, do not bloat the logs
+                // this is thrown when the annotationJSON can't be stored by mongo
+                // due to the variant annotation key being too large to index
+                LOG.info(e.getLocalizedMessage());
+            }
+        }
+
+        return entrezGeneXref;
+    }
+
+
+    @Nullable
+    public GeneXref fetchEntrezGeneXref(String accession, String geneSymbol)
+        throws ResourceMappingException, HttpClientErrorException, ResourceAccessException
+    {
+        // get xrefs from the service
+        List<GeneXref> geneXrefs = this.externalResourceFetcher.fetchInstances(accession);
+
+        return this.entrezGeneXrefResolver.resolve(geneXrefs, geneSymbol);
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/CanonicalTranscriptAnnotationEnricher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/CanonicalTranscriptAnnotationEnricher.java
@@ -1,0 +1,26 @@
+package org.cbioportal.genome_nexus.service.enricher;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotationSummary;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.AnnotationEnricher;
+import org.cbioportal.genome_nexus.service.VariantAnnotationSummaryService;
+
+
+public class CanonicalTranscriptAnnotationEnricher implements AnnotationEnricher
+{
+    private final VariantAnnotationSummaryService variantAnnotationSummaryService;
+
+    public CanonicalTranscriptAnnotationEnricher(VariantAnnotationSummaryService variantAnnotationSummaryService)
+    {
+        this.variantAnnotationSummaryService = variantAnnotationSummaryService;
+    }
+
+    @Override
+    public void enrich(VariantAnnotation annotation)
+    {
+        VariantAnnotationSummary annotationSummary =
+            this.variantAnnotationSummaryService.getAnnotationSummaryForCanonical(annotation);
+
+        annotation.setAnnotationSummary(annotationSummary);
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
@@ -189,7 +189,7 @@ public class CancerHotspotServiceImpl implements CancerHotspotService
         throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException,
         CancerHotspotsWebServiceException
     {
-        GenomicLocation location = this.notationConverter.parseGenomicLocation(genomicLocation, ",");
+        GenomicLocation location = this.notationConverter.parseGenomicLocation(genomicLocation);
 
         return this.getHotspotAnnotationsByVariant(this.notationConverter.genomicToHgvs(location));
     }
@@ -198,17 +198,8 @@ public class CancerHotspotServiceImpl implements CancerHotspotService
     public List<AggregatedHotspots> getHotspotAnnotationsByGenomicLocations(List<GenomicLocation> genomicLocations)
         throws CancerHotspotsWebServiceException
     {
-        Map<String, GenomicLocation> variantToGenomicLocation = new LinkedHashMap<>();
-
         // convert genomic location to hgvs notation (there is always 1-1 mapping)
-        for (GenomicLocation location : genomicLocations) {
-            String hgvsNotation = notationConverter.genomicToHgvs(location);
-
-            // exclude invalid genomic locations
-            if (hgvsNotation != null) {
-                variantToGenomicLocation.put(hgvsNotation, location);
-            }
-        }
+        Map<String, GenomicLocation> variantToGenomicLocation = notationConverter.genomicToHgvsMap(genomicLocations);
 
         // query hotspots service by variant
         List<AggregatedHotspots> hotspots = this.getHotspotAnnotationsByVariants(

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VEPEnrichmentService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VEPEnrichmentService.java
@@ -38,7 +38,7 @@ import org.cbioportal.genome_nexus.service.EnrichmentService;
 
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -68,7 +68,8 @@ public class VEPEnrichmentService implements EnrichmentService
         // initiate enricher list if not initiated yet
         if (enrichers == null)
         {
-            enrichers = new HashMap<>();
+            // linked hash map ensures that enrichers are executed by the same order they are registered
+            enrichers = new LinkedHashMap<>();
         }
 
         enrichers.put(id, enricher);
@@ -82,6 +83,4 @@ public class VEPEnrichmentService implements EnrichmentService
             enrichers.put(id, null);
         }
     }
-
-
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
@@ -1,0 +1,208 @@
+package org.cbioportal.genome_nexus.service.internal;
+
+import org.cbioportal.genome_nexus.model.TranscriptConsequenceSummary;
+import org.cbioportal.genome_nexus.model.VariantAnnotationSummary;
+import org.cbioportal.genome_nexus.model.TranscriptConsequence;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.VariantAnnotationService;
+import org.cbioportal.genome_nexus.service.VariantAnnotationSummaryService;
+import org.cbioportal.genome_nexus.service.annotation.*;
+import org.cbioportal.genome_nexus.service.exception.EnsemblWebServiceException;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSummaryService
+{
+    private final VariantAnnotationService variantAnnotationService;
+    private final CanonicalTranscriptResolver canonicalTranscriptResolver;
+    private final CodonChangeResolver codonChangeResolver;
+    private final ConsequenceTermsResolver consequenceTermsResolver;
+    private final EntrezGeneIdResolver entrezGeneIdResolver;
+    private final GenomicLocationResolver genomicLocationResolver;
+    private final HugoGeneSymbolResolver hugoGeneSymbolResolver;
+    private final ProteinChangeResolver proteinChangeResolver;
+    private final ProteinPositionResolver proteinPositionResolver;
+    private final RefSeqResolver refSeqResolver;
+    private final StrandSignResolver strandSignResolver;
+    private final TranscriptIdResolver transcriptIdResolver;
+    private final VariantClassificationResolver variantClassificationResolver;
+    private final VariantTypeResolver variantTypeResolver;
+
+    @Autowired
+    public VariantAnnotationSummaryServiceImpl(VariantAnnotationService variantAnnotationService,
+                                               CanonicalTranscriptResolver canonicalTranscriptResolver,
+                                               CodonChangeResolver codonChangeResolver,
+                                               ConsequenceTermsResolver consequenceTermsResolver,
+                                               EntrezGeneIdResolver entrezGeneIdResolver,
+                                               GenomicLocationResolver genomicLocationResolver,
+                                               HugoGeneSymbolResolver hugoGeneSymbolResolver,
+                                               ProteinChangeResolver proteinChangeResolver,
+                                               ProteinPositionResolver proteinPositionResolver,
+                                               RefSeqResolver refSeqResolver,
+                                               StrandSignResolver strandSignResolver,
+                                               TranscriptIdResolver transcriptIdResolver,
+                                               VariantClassificationResolver variantClassificationResolver,
+                                               VariantTypeResolver variantTypeResolver)
+    {
+        this.variantAnnotationService = variantAnnotationService;
+        this.canonicalTranscriptResolver = canonicalTranscriptResolver;
+        this.codonChangeResolver = codonChangeResolver;
+        this.consequenceTermsResolver = consequenceTermsResolver;
+        this.entrezGeneIdResolver = entrezGeneIdResolver;
+        this.genomicLocationResolver = genomicLocationResolver;
+        this.hugoGeneSymbolResolver = hugoGeneSymbolResolver;
+        this.proteinChangeResolver = proteinChangeResolver;
+        this.proteinPositionResolver = proteinPositionResolver;
+        this.refSeqResolver = refSeqResolver;
+        this.strandSignResolver = strandSignResolver;
+        this.transcriptIdResolver = transcriptIdResolver;
+        this.variantClassificationResolver = variantClassificationResolver;
+        this.variantTypeResolver = variantTypeResolver;
+    }
+
+    @Override
+    public VariantAnnotationSummary getAnnotationSummaryForCanonical(String variant, String isoformOverrideSource)
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        return this.getAnnotationSummaryForCanonical(
+            this.variantAnnotationService.getAnnotation(variant, isoformOverrideSource, null));
+    }
+
+    @Override
+    public VariantAnnotationSummary getAnnotationSummaryForCanonical(VariantAnnotation annotation)
+    {
+        VariantAnnotationSummary annotationSummary = this.getVariantAnnotationSummary(annotation);
+        TranscriptConsequence canonicalTranscript = this.canonicalTranscriptResolver.resolve(annotation);
+
+        if (annotationSummary != null && canonicalTranscript != null)
+        {
+            List<TranscriptConsequenceSummary> summaries = new ArrayList<>(1);
+            summaries.add(this.getTranscriptSummary(annotation, canonicalTranscript));
+            annotationSummary.setTranscriptConsequences(summaries);
+            annotationSummary.setCanonicalTranscriptId(canonicalTranscript.getTranscriptId());
+        }
+
+        return annotationSummary;
+    }
+
+    @Override
+    public VariantAnnotationSummary getAnnotationSummary(String variant, String isoformOverrideSource)
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        return this.getAnnotationSummary(
+            this.variantAnnotationService.getAnnotation(variant, isoformOverrideSource, null));
+    }
+
+    @Override
+    public List<VariantAnnotationSummary> getAnnotationSummary(List<String> variants, String isoformOverrideSource) {
+        List<VariantAnnotationSummary> summaries = new ArrayList<>();
+
+        List<VariantAnnotation> annotations =
+            this.variantAnnotationService.getAnnotations(variants, isoformOverrideSource, null);
+
+        for (VariantAnnotation annotation: annotations) {
+            summaries.add(this.getAnnotationSummary(annotation));
+        }
+
+        return summaries;
+    }
+
+    @Override
+    public List<VariantAnnotationSummary> getAnnotationSummaryForCanonical(List<String> variants, String isoformOverrideSource) {
+        List<VariantAnnotationSummary> summaries = new ArrayList<>();
+
+        List<VariantAnnotation> annotations =
+            this.variantAnnotationService.getAnnotations(variants, isoformOverrideSource, null);
+
+        for (VariantAnnotation annotation: annotations) {
+            summaries.add(this.getAnnotationSummaryForCanonical(annotation));
+        }
+
+        return summaries;
+    }
+
+    @Override
+    public VariantAnnotationSummary getAnnotationSummary(VariantAnnotation annotation)
+    {
+        VariantAnnotationSummary annotationSummary = this.getAnnotationSummaryForCanonical(annotation);
+
+        if (annotationSummary != null)
+        {
+            List<TranscriptConsequenceSummary> summaries = new ArrayList<>();
+
+            for (TranscriptConsequence transcriptConsequence: annotation.getTranscriptConsequences()) {
+                summaries.add(this.getTranscriptSummary(annotation, transcriptConsequence));
+            }
+
+            annotationSummary.setTranscriptConsequences(summaries);
+        }
+
+        return annotationSummary;
+    }
+
+    @Nullable
+    private String resolveEntrezGeneId(TranscriptConsequence canonicalTranscript)
+    {
+        String entrezGeneId;
+
+        try {
+            entrezGeneId = this.entrezGeneIdResolver.resolve(canonicalTranscript);
+        } catch (EnsemblWebServiceException e) {
+            entrezGeneId = null;
+        }
+
+        return entrezGeneId;
+    }
+
+    @Nullable
+    private VariantAnnotationSummary getVariantAnnotationSummary(VariantAnnotation annotation)
+    {
+        VariantAnnotationSummary summary = null;
+
+        if (annotation != null)
+        {
+            summary = new VariantAnnotationSummary();
+
+            summary.setVariant(annotation.getVariant());
+            summary.setGenomicLocation(this.genomicLocationResolver.resolve(annotation));
+            summary.setStrandSign(this.strandSignResolver.resolve(annotation));
+            summary.setVariantType(this.variantTypeResolver.resolve(annotation));
+            summary.setAssemblyName(annotation.getAssemblyName());
+        }
+
+        return summary;
+    }
+
+    @Nullable
+    private TranscriptConsequenceSummary getTranscriptSummary(VariantAnnotation annotation,
+                                                              TranscriptConsequence transcriptConsequence)
+    {
+        TranscriptConsequenceSummary summary = null;
+
+        if (transcriptConsequence != null)
+        {
+            summary = new TranscriptConsequenceSummary();
+
+            summary.setTranscriptId(this.transcriptIdResolver.resolve(transcriptConsequence));
+            summary.setCodonChange(this.codonChangeResolver.resolve(transcriptConsequence));
+            summary.setEntrezGeneId(this.resolveEntrezGeneId(transcriptConsequence));
+            summary.setConsequenceTerms(this.consequenceTermsResolver.resolve(transcriptConsequence));
+            summary.setHugoGeneSymbol(this.hugoGeneSymbolResolver.resolve(transcriptConsequence));
+            summary.setHgvspShort(this.proteinChangeResolver.resolveHgvspShort(annotation, transcriptConsequence));
+            summary.setHgvsp(this.proteinChangeResolver.resolveHgvsp(transcriptConsequence));
+            summary.setHgvsc(this.proteinChangeResolver.resolveHgvsc(transcriptConsequence));
+            summary.setProteinPosition(this.proteinPositionResolver.resolve(annotation, transcriptConsequence));
+            summary.setRefSeq(this.refSeqResolver.resolve(transcriptConsequence));
+            summary.setVariantClassification(this.variantClassificationResolver.resolve(annotation, transcriptConsequence));
+        }
+
+        return summary;
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/GeneXrefMixin.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/GeneXrefMixin.java
@@ -29,7 +29,7 @@ public class GeneXrefMixin
     @JsonProperty(value = "info_text", required = true)
     private String infoText;
 
-    @JsonProperty(value = "info_types", required = true)
+    @JsonProperty(value = "info_type", required = true)
     private String infoType;
 
     @JsonProperty(value = "db_display_name", required = true)

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/MockData.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/MockData.java
@@ -1,8 +1,9 @@
 package org.cbioportal.genome_nexus.service;
 
+import java.io.IOException;
 import java.util.Map;
 
 public interface MockData<T>
 {
-    Map<String, T> generateData();
+    Map<String, T> generateData() throws IOException;
 }

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/CanonicalTranscriptResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/CanonicalTranscriptResolverTest.java
@@ -1,0 +1,127 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.mock.VariantAnnotationMockData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CanonicalTranscriptResolverTest
+{
+    @InjectMocks
+    private CanonicalTranscriptResolver canonicalTranscriptResolver;
+
+    @Spy
+    private TranscriptConsequencePrioritizer consequencePrioritizer;
+
+    private final VariantAnnotationMockData variantAnnotationMockData = new VariantAnnotationMockData();
+
+    @Test
+    public void resolveCanonicalTranscript() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+
+        assertEquals(
+            variantMockData.get("1:g.65325832_65325833insG").getTranscriptConsequences().get(0),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("1:g.65325832_65325833insG"))
+        );
+
+        assertEquals(
+            variantMockData.get("3:g.14106026_14106037delCCAGCAGTAGCT").getTranscriptConsequences().get(1),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("3:g.14106026_14106037delCCAGCAGTAGCT"))
+        );
+
+        assertEquals(
+            variantMockData.get("3:g.14940279_14940280insCAT").getTranscriptConsequences().get(0),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("3:g.14940279_14940280insCAT"))
+        );
+
+        assertEquals(
+            variantMockData.get("3:g.114058003_114058003delG").getTranscriptConsequences().get(5),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("3:g.114058003_114058003delG"))
+        );
+
+        assertEquals(
+            variantMockData.get("4:g.9784947_9784948insAGA").getTranscriptConsequences().get(0),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("4:g.9784947_9784948insAGA"))
+        );
+
+        assertEquals(
+            variantMockData.get("4:g.77675978_77675979insC").getTranscriptConsequences().get(0),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("4:g.77675978_77675979insC"))
+        );
+
+        assertEquals(
+            variantMockData.get("6:g.137519505_137519506delCT").getTranscriptConsequences().get(0),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("6:g.137519505_137519506delCT"))
+        );
+
+        assertEquals(
+            variantMockData.get("6:g.137519505_137519506delCTinsA").getTranscriptConsequences().get(0),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("6:g.137519505_137519506delCTinsA"))
+        );
+
+        assertEquals(
+            variantMockData.get("7:g.140453136A>T").getTranscriptConsequences().get(0),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("7:g.140453136A>T"))
+        );
+
+        assertEquals(
+            variantMockData.get("8:g.37696499_37696500insG").getTranscriptConsequences().get(2),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("8:g.37696499_37696500insG"))
+        );
+
+        assertEquals(
+            variantMockData.get("9:g.135797242_135797242delCinsAT").getTranscriptConsequences().get(0),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("9:g.135797242_135797242delCinsAT"))
+        );
+
+        assertEquals(
+            variantMockData.get("10:g.101953779_101953779delT").getTranscriptConsequences().get(0),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("10:g.101953779_101953779delT"))
+        );
+
+        assertEquals(
+            variantMockData.get("11:g.62393546_62393547delGGinsAA").getTranscriptConsequences().get(1),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("11:g.62393546_62393547delGGinsAA"))
+        );
+
+        assertEquals(
+            variantMockData.get("12:g.25398285C>A").getTranscriptConsequences().get(0),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("12:g.25398285C>A"))
+        );
+
+        assertEquals(
+            variantMockData.get("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG").getTranscriptConsequences().get(0),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG"))
+        );
+
+        assertEquals(
+            variantMockData.get("16:g.9057113_9057114insCTG").getTranscriptConsequences().get(0),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("16:g.9057113_9057114insCTG"))
+        );
+
+        assertEquals(
+            variantMockData.get("19:g.46141892_46141893delTCinsAA").getTranscriptConsequences().get(8),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("19:g.46141892_46141893delTCinsAA"))
+        );
+
+        assertEquals(
+            variantMockData.get("22:g.29091840_29091841delTGinsCA").getTranscriptConsequences().get(5),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("22:g.29091840_29091841delTGinsCA"))
+        );
+
+        assertEquals(
+            variantMockData.get("22:g.36689419_36689421delCCT").getTranscriptConsequences().get(0),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("22:g.36689419_36689421delCCT"))
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/CodonChangeResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/CodonChangeResolverTest.java
@@ -1,0 +1,154 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.mock.CanonicalTranscriptResolverMocker;
+import org.cbioportal.genome_nexus.service.mock.VariantAnnotationMockData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CodonChangeResolverTest
+{
+    @InjectMocks
+    private CodonChangeResolver codonChangeResolver;
+
+    @Mock
+    private CanonicalTranscriptResolver canonicalTranscriptResolver;
+
+    private final VariantAnnotationMockData variantAnnotationMockData = new VariantAnnotationMockData();
+    private final CanonicalTranscriptResolverMocker canonicalTranscriptResolverMocker = new CanonicalTranscriptResolverMocker();
+
+    @Test
+    public void resolveCodonChangeForCanonical() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+        this.canonicalTranscriptResolverMocker.mockMethods(variantMockData, this.canonicalTranscriptResolver);
+
+        assertEquals(
+            "ccg/ccCg",
+            this.codonChangeResolver.resolve(variantMockData.get("1:g.65325832_65325833insG"))
+        );
+
+        assertEquals(
+            "cCCAGCAGTAGCTcc/ccc",
+            this.codonChangeResolver.resolve(variantMockData.get("3:g.14106026_14106037delCCAGCAGTAGCT"))
+        );
+
+        assertEquals(
+            "cat/cCATat",
+            this.codonChangeResolver.resolve(variantMockData.get("3:g.14940279_14940280insCAT"))
+        );
+
+        assertEquals(
+            "cCt/ct",
+            this.codonChangeResolver.resolve(variantMockData.get("3:g.114058003_114058003delG"))
+        );
+
+        assertEquals(
+            "ggt/gAGAgt",
+            this.codonChangeResolver.resolve(variantMockData.get("4:g.9784947_9784948insAGA"))
+        );
+
+        assertEquals(
+            "gcc/gCcc",
+            this.codonChangeResolver.resolve(variantMockData.get("4:g.77675978_77675979insC"))
+        );
+
+        assertEquals(
+            "AGt/t",
+            this.codonChangeResolver.resolve(variantMockData.get("6:g.137519505_137519506delCT"))
+        );
+
+        assertEquals(
+            "AGt/Tt",
+            this.codonChangeResolver.resolve(variantMockData.get("6:g.137519505_137519506delCTinsA"))
+        );
+
+        assertEquals(
+            "gTg/gAg",
+            this.codonChangeResolver.resolve(variantMockData.get("7:g.140453136A>T"))
+        );
+
+        assertEquals(
+            "gtg/gtGg",
+            this.codonChangeResolver.resolve(variantMockData.get("8:g.37696499_37696500insG"))
+        );
+
+        assertEquals(
+            "atG/atAT",
+            this.codonChangeResolver.resolve(variantMockData.get("9:g.135797242_135797242delCinsAT"))
+        );
+
+        assertEquals(
+            "Agg/gg",
+            this.codonChangeResolver.resolve(variantMockData.get("10:g.101953779_101953779delT"))
+        );
+
+        assertEquals(
+            "ctCCag/ctTTag",
+            this.codonChangeResolver.resolve(variantMockData.get("11:g.62393546_62393547delGGinsAA"))
+        );
+
+        assertEquals(
+            "Ggt/Tgt",
+            this.codonChangeResolver.resolve(variantMockData.get("12:g.25398285C>A"))
+        );
+
+        assertEquals(
+            "tTCAGAGAATATGAATATGat/tCCCCCCCACCCCat",
+            this.codonChangeResolver.resolve(variantMockData.get("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG"))
+        );
+
+        assertEquals(
+            "cag/caCAGg",
+            this.codonChangeResolver.resolve(variantMockData.get("16:g.9057113_9057114insCTG"))
+        );
+
+        assertNull(
+            this.codonChangeResolver.resolve(variantMockData.get("19:g.46141892_46141893delTCinsAA"))
+        );
+
+        assertEquals(
+            "tcCAag/tcTGag",
+            this.codonChangeResolver.resolve(variantMockData.get("22:g.29091840_29091841delTGinsCA"))
+        );
+
+        assertEquals(
+            "gAGGcc/gcc",
+            this.codonChangeResolver.resolve(variantMockData.get("22:g.36689419_36689421delCCT"))
+        );
+    }
+
+    @Test
+    public void resolveCodonChange() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+
+        assertNull(
+            this.codonChangeResolver.resolve(
+                variantMockData.get("8:g.37696499_37696500insG").getTranscriptConsequences().get(0)
+            )
+        );
+
+        assertNull(
+            this.codonChangeResolver.resolve(
+                variantMockData.get("11:g.62393546_62393547delGGinsAA").getTranscriptConsequences().get(0)
+            )
+        );
+
+        assertNull(
+            this.codonChangeResolver.resolve(
+                variantMockData.get("19:g.46141892_46141893delTCinsAA").getTranscriptConsequences().get(1)
+            )
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/ConsequenceTermsResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/ConsequenceTermsResolverTest.java
@@ -1,0 +1,192 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.mock.CanonicalTranscriptResolverMocker;
+import org.cbioportal.genome_nexus.service.mock.VariantAnnotationMockData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConsequenceTermsResolverTest
+{
+    @InjectMocks
+    private ConsequenceTermsResolver consequenceTermsResolver;
+
+    @Mock
+    private CanonicalTranscriptResolver canonicalTranscriptResolver;
+
+    private final VariantAnnotationMockData variantAnnotationMockData = new VariantAnnotationMockData();
+    private final CanonicalTranscriptResolverMocker canonicalTranscriptResolverMocker = new CanonicalTranscriptResolverMocker();
+
+    @Test
+    public void resolveConsequenceTermsForCanonical() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+        this.canonicalTranscriptResolverMocker.mockMethods(variantMockData, this.canonicalTranscriptResolver);
+
+        assertEquals(
+            "frameshift_variant",
+            this.consequenceTermsResolver.resolve(variantMockData.get("1:g.65325832_65325833insG"))
+        );
+
+        assertEquals(
+            "inframe_deletion",
+            this.consequenceTermsResolver.resolve(variantMockData.get("3:g.14106026_14106037delCCAGCAGTAGCT"))
+        );
+
+        assertEquals(
+            "protein_altering_variant",
+            this.consequenceTermsResolver.resolve(variantMockData.get("3:g.14940279_14940280insCAT"))
+        );
+
+        assertEquals(
+            "frameshift_variant",
+            this.consequenceTermsResolver.resolve(variantMockData.get("3:g.114058003_114058003delG"))
+        );
+
+        assertEquals(
+            "protein_altering_variant",
+            this.consequenceTermsResolver.resolve(variantMockData.get("4:g.9784947_9784948insAGA"))
+        );
+
+        assertEquals(
+            "frameshift_variant",
+            this.consequenceTermsResolver.resolve(variantMockData.get("4:g.77675978_77675979insC"))
+        );
+
+        assertEquals(
+            "frameshift_variant",
+            this.consequenceTermsResolver.resolve(variantMockData.get("6:g.137519505_137519506delCT"))
+        );
+
+        assertEquals(
+            "frameshift_variant",
+            this.consequenceTermsResolver.resolve(variantMockData.get("6:g.137519505_137519506delCTinsA"))
+        );
+
+        assertEquals(
+            "missense_variant",
+            this.consequenceTermsResolver.resolve(variantMockData.get("7:g.140453136A>T"))
+        );
+
+        assertEquals(
+            "frameshift_variant",
+            this.consequenceTermsResolver.resolve(variantMockData.get("8:g.37696499_37696500insG"))
+        );
+
+        assertEquals(
+            "frameshift_variant",
+            this.consequenceTermsResolver.resolve(variantMockData.get("9:g.135797242_135797242delCinsAT"))
+        );
+
+        assertEquals(
+            "frameshift_variant",
+            this.consequenceTermsResolver.resolve(variantMockData.get("10:g.101953779_101953779delT"))
+        );
+
+        assertEquals(
+            "stop_gained",
+            this.consequenceTermsResolver.resolve(variantMockData.get("11:g.62393546_62393547delGGinsAA"))
+        );
+
+        assertEquals(
+            "missense_variant",
+            this.consequenceTermsResolver.resolve(variantMockData.get("12:g.25398285C>A"))
+        );
+
+        assertEquals(
+            "protein_altering_variant",
+            this.consequenceTermsResolver.resolve(variantMockData.get("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG"))
+        );
+
+        assertEquals(
+            "protein_altering_variant",
+            this.consequenceTermsResolver.resolve(variantMockData.get("16:g.9057113_9057114insCTG"))
+        );
+
+        assertEquals(
+            "splice_acceptor_variant,coding_sequence_variant",
+            this.consequenceTermsResolver.resolve(variantMockData.get("19:g.46141892_46141893delTCinsAA"))
+        );
+
+        assertEquals(
+            "missense_variant",
+            this.consequenceTermsResolver.resolve(variantMockData.get("22:g.29091840_29091841delTGinsCA"))
+        );
+
+        assertEquals(
+            "inframe_deletion",
+            this.consequenceTermsResolver.resolve(variantMockData.get("22:g.36689419_36689421delCCT"))
+        );
+    }
+
+    @Test
+    public void resolveConsequenceTerms() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+
+        assertEquals(
+            "downstream_gene_variant",
+            this.consequenceTermsResolver.resolve(
+                variantMockData.get("8:g.37696499_37696500insG").getTranscriptConsequences().get(0)
+            )
+        );
+
+        assertEquals(
+            "upstream_gene_variant",
+            this.consequenceTermsResolver.resolve(
+                variantMockData.get("11:g.62393546_62393547delGGinsAA").getTranscriptConsequences().get(0)
+            )
+        );
+
+        assertEquals(
+            "downstream_gene_variant",
+            this.consequenceTermsResolver.resolve(
+                variantMockData.get("19:g.46141892_46141893delTCinsAA").getTranscriptConsequences().get(1)
+            )
+        );
+
+        assertEquals(
+            "splice_acceptor_variant,coding_sequence_variant",
+            this.consequenceTermsResolver.resolve(
+                variantMockData.get("19:g.46141892_46141893delTCinsAA").getTranscriptConsequences().get(0))
+        );
+
+        assertEquals(
+            "splice_acceptor_variant,coding_sequence_variant,NMD_transcript_variant",
+            this.consequenceTermsResolver.resolve(
+                variantMockData.get("19:g.46141892_46141893delTCinsAA").getTranscriptConsequences().get(2))
+        );
+    }
+
+    @Test
+    public void resolveAllConsequenceTerms() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+
+        String[] consequenceTerms1 = {"splice_acceptor_variant", "coding_sequence_variant"};
+
+        assertEquals(
+            Arrays.asList(consequenceTerms1),
+            this.consequenceTermsResolver.resolveAll(
+                variantMockData.get("19:g.46141892_46141893delTCinsAA").getTranscriptConsequences().get(0))
+        );
+
+        String[] consequenceTerms2 = {"splice_acceptor_variant", "coding_sequence_variant", "NMD_transcript_variant"};
+
+        assertEquals(
+            Arrays.asList(consequenceTerms2),
+            this.consequenceTermsResolver.resolveAll(
+                variantMockData.get("19:g.46141892_46141893delTCinsAA").getTranscriptConsequences().get(2))
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/EntrezGeneIdResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/EntrezGeneIdResolverTest.java
@@ -1,0 +1,142 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.GeneXref;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.GeneXrefService;
+import org.cbioportal.genome_nexus.service.exception.EnsemblWebServiceException;
+import org.cbioportal.genome_nexus.service.mock.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EntrezGeneIdResolverTest
+{
+    @InjectMocks
+    private EntrezGeneIdResolver entrezGeneIdResolver;
+
+    @Mock
+    private CanonicalTranscriptResolver canonicalTranscriptResolver;
+
+    @Mock
+    private GeneXrefService geneXrefService;
+
+    private final VariantAnnotationMockData variantAnnotationMockData = new VariantAnnotationMockData();
+    private final GeneXrefMockData geneXrefMockData = new GeneXrefMockData();
+    private final CanonicalTranscriptResolverMocker canonicalTranscriptResolverMocker = new CanonicalTranscriptResolverMocker();
+    private final GeneXrefServiceMocker geneXrefServiceMocker = new GeneXrefServiceMocker();
+
+    @Test
+    public void resolveEntrezGeneIdForCanonical() throws IOException, EnsemblWebServiceException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+        Map<String, List<GeneXref>> geneXrefMockData = this.geneXrefMockData.generateData();
+
+        this.canonicalTranscriptResolverMocker.mockMethods(variantMockData, this.canonicalTranscriptResolver);
+        this.geneXrefServiceMocker.mockMethods(geneXrefMockData, this.geneXrefService);
+
+        assertEquals(
+            "3716",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("1:g.65325832_65325833insG"))
+        );
+
+        assertNull(
+            "No EntrezGene info exists for the canonical transcript of 3:g.14106026_14106037delCCAGCAGTAGCT",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("3:g.14106026_14106037delCCAGCAGTAGCT"))
+        );
+
+        assertEquals(
+            "152273",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("3:g.14940279_14940280insCAT"))
+        );
+
+        assertEquals(
+            "26137",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("3:g.114058003_114058003delG"))
+        );
+
+        assertEquals(
+            "1816",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("4:g.9784947_9784948insAGA"))
+        );
+
+        assertEquals(
+            "57619",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("4:g.77675978_77675979insC"))
+        );
+
+        assertEquals(
+            "3459",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("6:g.137519505_137519506delCT"))
+        );
+
+        assertEquals(
+            "3459",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("6:g.137519505_137519506delCTinsA"))
+        );
+
+        assertEquals(
+            "673",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("7:g.140453136A>T"))
+        );
+
+        assertEquals(
+            "25960",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("8:g.37696499_37696500insG"))
+        );
+
+        assertEquals(
+            "7248",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("9:g.135797242_135797242delCinsAT"))
+        );
+
+        assertEquals(
+            "1147",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("10:g.101953779_101953779delT"))
+        );
+
+        assertEquals(
+            "23193",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("11:g.62393546_62393547delGGinsAA"))
+        );
+
+        assertEquals(
+            "3845",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("12:g.25398285C>A"))
+        );
+
+        assertEquals(
+            "2322",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG"))
+        );
+
+        assertEquals(
+            "7874",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("16:g.9057113_9057114insCTG"))
+        );
+
+        assertEquals(
+            "24139",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("19:g.46141892_46141893delTCinsAA"))
+        );
+
+        assertEquals(
+            "11200",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("22:g.29091840_29091841delTGinsCA"))
+        );
+
+        assertEquals(
+            "4627",
+            this.entrezGeneIdResolver.resolve(variantMockData.get("22:g.36689419_36689421delCCT"))
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/EntrezGeneXrefResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/EntrezGeneXrefResolverTest.java
@@ -1,0 +1,160 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.GeneXref;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.GeneXrefService;
+import org.cbioportal.genome_nexus.service.exception.EnsemblWebServiceException;
+import org.cbioportal.genome_nexus.service.mock.CanonicalTranscriptResolverMocker;
+import org.cbioportal.genome_nexus.service.mock.GeneXrefMockData;
+import org.cbioportal.genome_nexus.service.mock.GeneXrefServiceMocker;
+import org.cbioportal.genome_nexus.service.mock.VariantAnnotationMockData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EntrezGeneXrefResolverTest
+{
+    private EntrezGeneXrefResolver entrezGeneXrefResolver = new EntrezGeneXrefResolver();
+
+    @Mock
+    private GeneXrefService geneXrefService;
+
+    @Mock
+    private CanonicalTranscriptResolver canonicalTranscriptResolver;
+
+    private final VariantAnnotationMockData variantAnnotationMockData = new VariantAnnotationMockData();
+    private final GeneXrefMockData geneXrefMockData = new GeneXrefMockData();
+    private final GeneXrefServiceMocker geneXrefServiceMocker = new GeneXrefServiceMocker();
+    private final CanonicalTranscriptResolverMocker canonicalTranscriptResolverMocker = new CanonicalTranscriptResolverMocker();
+
+    @Test
+    public void resolveEntrezGeneIdForCanonical() throws IOException, EnsemblWebServiceException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+        Map<String, List<GeneXref>> geneXrefMockData = this.geneXrefMockData.generateData();
+
+        this.geneXrefServiceMocker.mockMethods(geneXrefMockData, this.geneXrefService);
+        this.canonicalTranscriptResolverMocker.mockMethods(variantMockData, this.canonicalTranscriptResolver);
+
+        assertEquals(
+            "3716",
+            this.resolveGeneXref("1:g.65325832_65325833insG", variantMockData).getPrimaryId()
+        );
+
+        assertNull(
+            "No EntrezGene info exists for the canonical transcript of 3:g.14106026_14106037delCCAGCAGTAGCT",
+            this.resolveGeneXref("3:g.14106026_14106037delCCAGCAGTAGCT", variantMockData)
+        );
+
+        assertEquals(
+            "152273",
+            this.resolveGeneXref("3:g.14940279_14940280insCAT", variantMockData).getPrimaryId()
+        );
+
+        assertEquals(
+            "152273",
+            this.resolveGeneXref("3:g.14940279_14940280insCAT", variantMockData).getPrimaryId()
+        );
+
+        assertEquals(
+            "26137",
+            this.resolveGeneXref("3:g.114058003_114058003delG", variantMockData).getPrimaryId()
+        );
+
+        assertEquals(
+            "1816",
+            this.resolveGeneXref("4:g.9784947_9784948insAGA", variantMockData).getPrimaryId()
+        );
+
+        assertEquals(
+            "57619",
+            this.resolveGeneXref("4:g.77675978_77675979insC", variantMockData).getPrimaryId()
+        );
+
+        assertEquals(
+            "3459",
+            this.resolveGeneXref("6:g.137519505_137519506delCT", variantMockData).getPrimaryId()
+        );
+
+        assertEquals(
+            "3459",
+            this.resolveGeneXref("6:g.137519505_137519506delCTinsA", variantMockData).getPrimaryId()
+        );
+
+        assertEquals(
+            "673",
+            this.resolveGeneXref("7:g.140453136A>T", variantMockData).getPrimaryId()
+        );
+
+        assertEquals(
+            "25960",
+            this.resolveGeneXref("8:g.37696499_37696500insG", variantMockData).getPrimaryId()
+        );
+
+        assertEquals(
+            "7248",
+            this.resolveGeneXref("9:g.135797242_135797242delCinsAT", variantMockData).getPrimaryId()
+        );
+
+        assertEquals(
+            "1147",
+            this.resolveGeneXref("10:g.101953779_101953779delT", variantMockData).getPrimaryId()
+        );
+
+        assertEquals(
+            "23193",
+            this.resolveGeneXref("11:g.62393546_62393547delGGinsAA", variantMockData).getPrimaryId()
+        );
+
+        assertEquals(
+            "3845",
+            this.resolveGeneXref("12:g.25398285C>A", variantMockData).getPrimaryId()
+        );
+
+        assertEquals(
+            "2322",
+            this.resolveGeneXref("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG", variantMockData).getPrimaryId()
+        );
+
+        assertEquals(
+            "7874",
+            this.resolveGeneXref("16:g.9057113_9057114insCTG", variantMockData).getPrimaryId()
+        );
+
+        assertEquals(
+            "24139",
+            this.resolveGeneXref("19:g.46141892_46141893delTCinsAA", variantMockData).getPrimaryId()
+        );
+
+        assertEquals(
+            "11200",
+            this.resolveGeneXref("22:g.29091840_29091841delTGinsCA", variantMockData).getPrimaryId()
+        );
+
+        assertEquals(
+            "4627",
+            this.resolveGeneXref("22:g.36689419_36689421delCCT", variantMockData).getPrimaryId()
+        );
+    }
+
+    private GeneXref resolveGeneXref(String variantId,
+                                     Map<String, VariantAnnotation> variantMockData)
+        throws IOException, EnsemblWebServiceException
+    {
+        return this.entrezGeneXrefResolver.resolve(
+            this.geneXrefService.getGeneXrefs(
+                this.canonicalTranscriptResolver.resolve(variantMockData.get(variantId)).getGeneId()
+            ),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get(variantId)).getGeneSymbol()
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/GenomicLocationResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/GenomicLocationResolverTest.java
@@ -1,0 +1,173 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.GenomicLocation;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.mock.VariantAnnotationMockData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GenomicLocationResolverTest
+{
+    private GenomicLocationResolver genomicLocationResolver = new GenomicLocationResolver();
+
+    private VariantAnnotationMockData variantAnnotationMockData = new VariantAnnotationMockData();
+
+    @Test
+    public void resolveGenomicLocation() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+
+        // allele_string: "-/G"
+        assertEquals(
+            "Genomic location for 1:g.65325832_65325833insG should be 1,65325832,65325833,-,G",
+            "1,65325832,65325833,-,G",
+            this.resolveGenomicLocationString(variantMockData.get("1:g.65325832_65325833insG"))
+        );
+
+        // allele_string: "CCAGCAGTAGCT/-"
+        assertEquals(
+            "Genomic location for 3:g.14106026_14106037delCCAGCAGTAGCT should be 3,14106026,14106037,CCAGCAGTAGCT,-",
+            "3,14106026,14106037,CCAGCAGTAGCT,-",
+            this.resolveGenomicLocationString(variantMockData.get("3:g.14106026_14106037delCCAGCAGTAGCT"))
+        );
+
+        // allele_string: "-/CAT"
+        assertEquals(
+            "Genomic location for 3:g.14940279_14940280insCAT should be 3,14940279,14940280,-,CAT",
+            "3,14940279,14940280,-,CAT",
+            this.resolveGenomicLocationString(variantMockData.get("3:g.14940279_14940280insCAT"))
+        );
+
+        // allele_string: "G/-"
+        assertEquals(
+            "Genomic location for 3:g.114058003_114058003delG should be 3,114058003,114058003,G,-",
+            "3,114058003,114058003,G,-",
+            this.resolveGenomicLocationString(variantMockData.get("3:g.114058003_114058003delG"))
+        );
+
+        // allele_string: "-/AGA"
+        assertEquals(
+            "Genomic location for 4:g.9784947_9784948insAGA should be 4,9784947,9784948,-,AGA",
+            "4,9784947,9784948,-,AGA",
+            this.resolveGenomicLocationString(variantMockData.get("4:g.9784947_9784948insAGA"))
+        );
+
+        // allele_string: "-/C"
+        assertEquals(
+            "Genomic location for 4:g.77675978_77675979insC should be 4,77675978,77675979,-,C",
+            "4,77675978,77675979,-,C",
+            this.resolveGenomicLocationString(variantMockData.get("4:g.77675978_77675979insC"))
+        );
+
+        // allele_string: "CT/-"
+        assertEquals(
+            "Genomic location for 6:g.137519505_137519506delCT should be 6,137519505,137519506,CT,-",
+            "6,137519505,137519506,CT,-",
+            this.resolveGenomicLocationString(variantMockData.get("6:g.137519505_137519506delCT"))
+        );
+
+        // allele_string: "CT/A"
+        assertEquals(
+            "Genomic location for 6:g.137519505_137519506delCTinsA should be 6,137519505,137519506,CT,A",
+            "6,137519505,137519506,CT,A",
+            this.resolveGenomicLocationString(variantMockData.get("6:g.137519505_137519506delCTinsA"))
+        );
+
+        // allele_string: "A/T"
+        assertEquals(
+            "Genomic location for 7:g.140453136A>T should be 7,140453136,A,T",
+            "7,140453136,140453136,A,T",
+            this.resolveGenomicLocationString(variantMockData.get("7:g.140453136A>T"))
+        );
+
+        // allele_string: "-/G"
+        assertEquals(
+            "Genomic location for 8:g.37696499_37696500insG should be 8,37696499,37696500,-,G",
+            "8,37696499,37696500,-,G",
+            this.resolveGenomicLocationString(variantMockData.get("8:g.37696499_37696500insG"))
+        );
+
+        // allele_string: "C/AT"
+        assertEquals(
+            "Genomic location for 9:g.135797242_135797242delCinsAT should be 9,135797242,135797242,C,AT",
+            "9,135797242,135797242,C,AT",
+            this.resolveGenomicLocationString(variantMockData.get("9:g.135797242_135797242delCinsAT"))
+        );
+
+        // allele_string: "T/-"
+        assertEquals(
+            "Genomic location for 10:g.101953779_101953779delT should be 10,101953779,101953779,T,-",
+            "10,101953779,101953779,T,-",
+            this.resolveGenomicLocationString(variantMockData.get("10:g.101953779_101953779delT"))
+        );
+
+        // allele_string: "GG/AA"
+        assertEquals(
+            "Genomic location for 11:g.62393546_62393547delGGinsAA should be 11,62393546,62393547,GG,AA",
+            "11,62393546,62393547,GG,AA",
+            this.resolveGenomicLocationString(variantMockData.get("11:g.62393546_62393547delGGinsAA"))
+        );
+
+        // allele_string: "C/A"
+        assertEquals(
+            "Genomic location for 12:g.25398285C>A should be 12,25398285,25398285,C,A",
+            "12,25398285,25398285,C,A",
+            this.resolveGenomicLocationString(variantMockData.get("12:g.25398285C>A"))
+        );
+
+        // allele_string: "CATATTCATATTCTCTGA/GGGGTGGGGGGG"
+        assertEquals(
+            "Genomic location for 13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG should be 13,28608258,28608275,CATATTCATATTCTCTGA,GGGGTGGGGGGG",
+            "13,28608258,28608275,CATATTCATATTCTCTGA,GGGGTGGGGGGG",
+            this.resolveGenomicLocationString(variantMockData.get("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG"))
+        );
+
+        // allele_string: "-/CTG"
+        assertEquals(
+            "Genomic location for 16:g.9057113_9057114insCTG should be 16,9057113,9057114,-,CTG",
+            "16,9057113,9057114,-,CTG",
+            this.resolveGenomicLocationString(variantMockData.get("16:g.9057113_9057114insCTG"))
+        );
+
+        // allele_string: "TC/AA"
+        assertEquals(
+            "Genomic location for 19:g.46141892_46141893delTCinsAA should be 19,46141892,46141893,TC,AA",
+            "19,46141892,46141893,TC,AA",
+            this.resolveGenomicLocationString(variantMockData.get("19:g.46141892_46141893delTCinsAA"))
+        );
+
+        // allele_string: "TG/CA"
+        assertEquals(
+            "Genomic location for 22:g.29091840_29091841delTGinsCA should be 22,29091840,29091841,TG,CA",
+            "22,29091840,29091841,TG,CA",
+            this.resolveGenomicLocationString(variantMockData.get("22:g.29091840_29091841delTGinsCA"))
+        );
+
+        // allele_string: "CCT/-"
+        assertEquals(
+            "Genomic location for 22:g.36689419_36689421delCCT should be 22,36689419,36689421,CCT,-",
+            "22,36689419,36689421,CCT,-",
+            this.resolveGenomicLocationString(variantMockData.get("22:g.36689419_36689421delCCT"))
+        );
+    }
+
+    private String resolveGenomicLocationString(VariantAnnotation annotation)
+    {
+        GenomicLocation genomicLocation = this.genomicLocationResolver.resolve(annotation);
+
+        return (
+            genomicLocation.getChromosome() + "," +
+            genomicLocation.getStart() + "," +
+            genomicLocation.getEnd() + "," +
+            genomicLocation.getReferenceAllele() + "," +
+            genomicLocation.getVariantAllele()
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/HugoGeneSymbolResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/HugoGeneSymbolResolverTest.java
@@ -1,0 +1,157 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.mock.CanonicalTranscriptResolverMocker;
+import org.cbioportal.genome_nexus.service.mock.VariantAnnotationMockData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HugoGeneSymbolResolverTest
+{
+    @InjectMocks
+    private HugoGeneSymbolResolver hugoGeneSymbolResolver;
+
+    @Mock
+    private CanonicalTranscriptResolver canonicalTranscriptResolver;
+
+    private final VariantAnnotationMockData variantAnnotationMockData = new VariantAnnotationMockData();
+    private final CanonicalTranscriptResolverMocker canonicalTranscriptResolverMocker = new CanonicalTranscriptResolverMocker();
+
+    @Test
+    public void resolveHugoGeneSymbolForCanonical() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+        this.canonicalTranscriptResolverMocker.mockMethods(variantMockData, this.canonicalTranscriptResolver);
+
+        assertEquals(
+            "JAK1",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("1:g.65325832_65325833insG"))
+        );
+
+        assertEquals(
+            "TPRXL",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("3:g.14106026_14106037delCCAGCAGTAGCT"))
+        );
+
+        assertEquals(
+            "FGD5",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("3:g.14940279_14940280insCAT"))
+        );
+
+        assertEquals(
+            "ZBTB20",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("3:g.114058003_114058003delG"))
+        );
+
+        assertEquals(
+            "DRD5",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("4:g.9784947_9784948insAGA"))
+        );
+
+        assertEquals(
+            "SHROOM3",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("4:g.77675978_77675979insC"))
+        );
+
+        assertEquals(
+            "IFNGR1",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("6:g.137519505_137519506delCT"))
+        );
+
+        assertEquals(
+            "IFNGR1",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("6:g.137519505_137519506delCTinsA"))
+        );
+
+        assertEquals(
+            "BRAF",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("7:g.140453136A>T"))
+        );
+
+        assertEquals(
+            "GPR124",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("8:g.37696499_37696500insG"))
+        );
+
+        assertEquals(
+            "TSC1",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("9:g.135797242_135797242delCinsAT"))
+        );
+
+        assertEquals(
+            "CHUK",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("10:g.101953779_101953779delT"))
+        );
+
+        assertEquals(
+            "GANAB",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("11:g.62393546_62393547delGGinsAA"))
+        );
+
+        assertEquals(
+            "KRAS",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("12:g.25398285C>A"))
+        );
+
+        assertEquals(
+            "FLT3",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG"))
+        );
+
+        assertEquals(
+            "USP7",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("16:g.9057113_9057114insCTG"))
+        );
+
+        assertEquals(
+            "EML2",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("19:g.46141892_46141893delTCinsAA"))
+        );
+
+        assertEquals(
+            "CHEK2",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("22:g.29091840_29091841delTGinsCA"))
+        );
+
+        assertEquals(
+            "MYH9",
+            this.hugoGeneSymbolResolver.resolve(variantMockData.get("22:g.36689419_36689421delCCT"))
+        );
+    }
+
+    @Test
+    public void resolveHugoGeneSymbol() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+
+        assertEquals(
+            "BRF2",
+            this.hugoGeneSymbolResolver.resolve(
+                variantMockData.get("8:g.37696499_37696500insG").getTranscriptConsequences().get(0)
+            )
+        );
+
+        assertEquals(
+            "B3GAT3",
+            this.hugoGeneSymbolResolver.resolve(
+                variantMockData.get("11:g.62393546_62393547delGGinsAA").getTranscriptConsequences().get(0)
+            )
+        );
+
+        assertEquals(
+            "MIR330",
+            this.hugoGeneSymbolResolver.resolve(
+                variantMockData.get("19:g.46141892_46141893delTCinsAA").getTranscriptConsequences().get(1)
+            )
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/NotationConverterTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/NotationConverterTest.java
@@ -1,0 +1,100 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.GenomicLocation;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NotationConverterTest
+{
+    private final NotationConverter notationConverter = new NotationConverter();
+
+    @Test
+    public void parseGenomicLocation()
+    {
+        assertNull("Null genomic location input string -> Null output",
+            this.notationConverter.parseGenomicLocation(null));
+
+        assertNull("Invalid genomic location input string -> Null output",
+            this.notationConverter.parseGenomicLocation("6,6,6"));
+
+        GenomicLocation location = this.notationConverter.parseGenomicLocation("4,9784947,9784948,-,AGA");
+
+        assertEquals("4", location.getChromosome());
+        assertEquals((Integer)9784947, location.getStart());
+        assertEquals((Integer)9784948, location.getEnd());
+        assertEquals("-", location.getReferenceAllele());
+        assertEquals("AGA", location.getVariantAllele());
+    }
+
+    @Test
+    public void genomicToHgvs()
+    {
+        assertNull("Null genomic location input string -> Null output",
+            this.notationConverter.genomicToHgvs((String)null));
+
+        assertNull("Invalid genomic location input string -> Null output",
+            this.notationConverter.genomicToHgvs("6,6,6"));
+
+        assertEquals("4:g.9784947_9784948insAGA",
+            this.notationConverter.genomicToHgvs("4,9784947,9784948,-,AGA"));
+
+        assertEquals("3:g.14940279_14940280insCAT",
+            this.notationConverter.genomicToHgvs("3,14940279,14940280,-,CAT"));
+
+        assertEquals("16:g.9057113_9057114insCTG",
+            this.notationConverter.genomicToHgvs("16,9057113,9057114,-,CTG"));
+
+        assertEquals("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG",
+            this.notationConverter.genomicToHgvs("13,28608258,28608275,CATATTCATATTCTCTGA,GGGGTGGGGGGG"));
+
+        assertEquals("22:g.36689419_36689421delCCT",
+            this.notationConverter.genomicToHgvs("22,36689419,36689421,CCT,-"));
+
+        assertEquals("3:g.14106026_14106037delCCAGCAGTAGCT",
+            this.notationConverter.genomicToHgvs("3,14106026,14106037,CCAGCAGTAGCT,-"));
+
+        assertEquals("22:g.29091840_29091841delTGinsCA",
+            this.notationConverter.genomicToHgvs("22,29091840,29091841,TG,CA"));
+
+        assertEquals("19:g.46141892_46141893delTCinsAA",
+            this.notationConverter.genomicToHgvs("19,46141892,46141893,TC,AA"));
+
+        assertEquals("11:g.62393546_62393547delGGinsAA",
+            this.notationConverter.genomicToHgvs("11,62393546,62393547,GG,AA"));
+
+        assertEquals("1:g.65325832_65325833insG",
+            this.notationConverter.genomicToHgvs("1,65325832,65325833,-,G"));
+
+        assertEquals("4:g.77675978_77675979insC",
+            this.notationConverter.genomicToHgvs("4,77675978,77675979,-,C"));
+
+        assertEquals("8:g.37696499_37696500insG",
+            this.notationConverter.genomicToHgvs("8,37696499,37696500,-,G"));
+
+        assertEquals("10:g.101953779_101953779delT",
+            this.notationConverter.genomicToHgvs("10,101953779,101953779,T,-"));
+
+        assertEquals("6:g.137519505_137519506delCT",
+            this.notationConverter.genomicToHgvs("6,137519505,137519506,CT,-"));
+
+        assertEquals("3:g.114058003_114058003delG",
+            this.notationConverter.genomicToHgvs("3,114058003,114058003,G,-"));
+
+        assertEquals("9:g.135797242_135797242delCinsAT",
+            this.notationConverter.genomicToHgvs("9,135797242,135797242,C,AT"));
+
+        assertEquals("6:g.137519505_137519506delCTinsA",
+            this.notationConverter.genomicToHgvs("6,137519505,137519506,CT,A"));
+
+        assertEquals("7:g.140453136A>T",
+            this.notationConverter.genomicToHgvs("7,140453136,140453136,A,T"));
+
+        assertEquals("12:g.25398285C>A",
+            this.notationConverter.genomicToHgvs("12,25398285,25398285,C,A"));
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/ProteinChangeResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/ProteinChangeResolverTest.java
@@ -1,0 +1,174 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.mock.CanonicalTranscriptResolverMocker;
+import org.cbioportal.genome_nexus.service.mock.VariantAnnotationMockData;
+import org.cbioportal.genome_nexus.service.mock.VariantClassificationResolverMocker;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProteinChangeResolverTest
+{
+    @InjectMocks
+    private ProteinChangeResolver proteinChangeResolver;
+
+    @Mock
+    private VariantClassificationResolver variantClassificationResolver;
+
+    @Mock
+    private CanonicalTranscriptResolver canonicalTranscriptResolver;
+
+    private final VariantAnnotationMockData variantAnnotationMockData = new VariantAnnotationMockData();
+    private final CanonicalTranscriptResolverMocker canonicalTranscriptResolverMocker = new CanonicalTranscriptResolverMocker();
+    private final VariantClassificationResolverMocker variantClassificationResolverMocker = new VariantClassificationResolverMocker();
+
+    @Test
+    public void resolveHgvspShortForCanonical() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+        this.canonicalTranscriptResolverMocker.mockMethods(variantMockData, this.canonicalTranscriptResolver);
+        this.variantClassificationResolverMocker.mockMethods(variantMockData, this.variantClassificationResolver);
+
+        assertEquals(
+            "p.L431Vfs*22",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("1:g.65325832_65325833insG"))
+        );
+
+        assertEquals(
+            "p.S124_S127del",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("3:g.14106026_14106037delCCAGCAGTAGCT"))
+        );
+
+        assertEquals(
+            "p.H1034delinsPY",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("3:g.14940279_14940280insCAT"))
+        );
+
+        assertEquals(
+            "p.P692Lfs*43",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("3:g.114058003_114058003delG"))
+        );
+
+        assertEquals(
+            "p.G432delinsES",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("4:g.9784947_9784948insAGA"))
+        );
+
+        assertEquals(
+            "p.D1450*",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("4:g.77675978_77675979insC"))
+        );
+
+        assertEquals(
+            "p.S378Ffs*6",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("6:g.137519505_137519506delCT"))
+        );
+
+        assertEquals(
+            "p.S378Ffs*5",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("6:g.137519505_137519506delCTinsA"))
+        );
+
+        assertEquals(
+            "p.V600E",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("7:g.140453136A>T"))
+        );
+
+        assertEquals(
+            "p.A765Rfs*98",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("8:g.37696499_37696500insG"))
+        );
+
+        assertEquals(
+            "p.M209Ifs*2",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("9:g.135797242_135797242delCinsAT"))
+        );
+
+        assertEquals(
+            "p.R646Gfs*22",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("10:g.101953779_101953779delT"))
+        );
+
+        assertEquals(
+            "p.Q928*",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("11:g.62393546_62393547delGGinsAA"))
+        );
+
+        assertEquals(
+            "p.G12C",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("12:g.25398285C>A"))
+        );
+
+        assertEquals(
+            "p.F594_D600delinsSPPPH",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG"))
+        );
+
+        assertEquals(
+            "p.Q10delinsHR",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("16:g.9057113_9057114insCTG"))
+        );
+
+        assertEquals(
+            "p.X218_splice",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("19:g.46141892_46141893delTCinsAA"))
+        );
+
+        assertEquals(
+            "p.K416E",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("22:g.29091840_29091841delTGinsCA"))
+        );
+
+        assertEquals(
+            "p.E1350del",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("22:g.36689419_36689421delCCT"))
+        );
+    }
+
+    @Test
+    public void resolveHgvspShort() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+        this.variantClassificationResolverMocker.mockMethods(variantMockData, this.variantClassificationResolver);
+
+        assertNull(
+            this.proteinChangeResolver.resolveHgvspShort(
+                variantMockData.get("8:g.37696499_37696500insG"),
+                variantMockData.get("8:g.37696499_37696500insG").getTranscriptConsequences().get(0)
+            )
+        );
+
+        assertNull(
+            this.proteinChangeResolver.resolveHgvspShort(
+                variantMockData.get("11:g.62393546_62393547delGGinsAA"),
+                variantMockData.get("11:g.62393546_62393547delGGinsAA").getTranscriptConsequences().get(0)
+            )
+        );
+
+        assertEquals(
+            "p.X17_splice",
+            this.proteinChangeResolver.resolveHgvspShort(
+                variantMockData.get("19:g.46141892_46141893delTCinsAA"),
+                variantMockData.get("19:g.46141892_46141893delTCinsAA").getTranscriptConsequences().get(0)
+            )
+        );
+
+        assertEquals(
+            "p.K373E",
+            this.proteinChangeResolver.resolveHgvspShort(
+                variantMockData.get("22:g.29091840_29091841delTGinsCA"),
+                variantMockData.get("22:g.29091840_29091841delTGinsCA").getTranscriptConsequences().get(0)
+            )
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/RefSeqResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/RefSeqResolverTest.java
@@ -1,0 +1,156 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.mock.CanonicalTranscriptResolverMocker;
+import org.cbioportal.genome_nexus.service.mock.VariantAnnotationMockData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RefSeqResolverTest
+{
+    @InjectMocks
+    private RefSeqResolver refSeqResolver;
+
+    @Mock
+    private CanonicalTranscriptResolver canonicalTranscriptResolver;
+
+    private final VariantAnnotationMockData variantAnnotationMockData = new VariantAnnotationMockData();
+    private final CanonicalTranscriptResolverMocker canonicalTranscriptResolverMocker = new CanonicalTranscriptResolverMocker();
+
+    @Test
+    public void resolveRefSeqForCanonical() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+        this.canonicalTranscriptResolverMocker.mockMethods(variantMockData, this.canonicalTranscriptResolver);
+
+        assertEquals(
+            "NM_002227.2",
+            this.refSeqResolver.resolve(variantMockData.get("1:g.65325832_65325833insG"))
+        );
+
+        assertNull(
+            this.refSeqResolver.resolve(variantMockData.get("3:g.14106026_14106037delCCAGCAGTAGCT"))
+        );
+
+        assertEquals(
+            "NM_152536.3",
+            this.refSeqResolver.resolve(variantMockData.get("3:g.14940279_14940280insCAT"))
+        );
+
+        assertEquals(
+            "NM_001164342.1",
+            this.refSeqResolver.resolve(variantMockData.get("3:g.114058003_114058003delG"))
+        );
+
+        assertEquals(
+            "NM_000798.4",
+            this.refSeqResolver.resolve(variantMockData.get("4:g.9784947_9784948insAGA"))
+        );
+
+        assertEquals(
+            "NM_020859.3",
+            this.refSeqResolver.resolve(variantMockData.get("4:g.77675978_77675979insC"))
+        );
+
+        assertEquals(
+            "NM_000416.2",
+            this.refSeqResolver.resolve(variantMockData.get("6:g.137519505_137519506delCT"))
+        );
+
+        assertEquals(
+            "NM_000416.2",
+            this.refSeqResolver.resolve(variantMockData.get("6:g.137519505_137519506delCTinsA"))
+        );
+
+        assertEquals(
+            "NM_004333.4",
+            this.refSeqResolver.resolve(variantMockData.get("7:g.140453136A>T"))
+        );
+
+        assertEquals(
+            "NM_032777.9",
+            this.refSeqResolver.resolve(variantMockData.get("8:g.37696499_37696500insG"))
+        );
+
+        assertEquals(
+            "NM_001162426.1",
+            this.refSeqResolver.resolve(variantMockData.get("9:g.135797242_135797242delCinsAT"))
+        );
+
+        assertEquals(
+            "NM_001278.3",
+            this.refSeqResolver.resolve(variantMockData.get("10:g.101953779_101953779delT"))
+        );
+
+        assertEquals(
+            "NM_198335.3",
+            this.refSeqResolver.resolve(variantMockData.get("11:g.62393546_62393547delGGinsAA"))
+        );
+
+        assertEquals(
+            "NM_033360.2",
+            this.refSeqResolver.resolve(variantMockData.get("12:g.25398285C>A"))
+        );
+
+        assertEquals(
+            "NM_004119.2",
+            this.refSeqResolver.resolve(variantMockData.get("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG"))
+        );
+
+        assertEquals(
+            "NM_003470.2",
+            this.refSeqResolver.resolve(variantMockData.get("16:g.9057113_9057114insCTG"))
+        );
+
+        assertEquals(
+            "NM_001193268.1",
+            this.refSeqResolver.resolve(variantMockData.get("19:g.46141892_46141893delTCinsAA"))
+        );
+
+        assertEquals(
+            "NM_001005735.1",
+            this.refSeqResolver.resolve(variantMockData.get("22:g.29091840_29091841delTGinsCA"))
+        );
+
+        assertEquals(
+            "NM_002473.4",
+            this.refSeqResolver.resolve(variantMockData.get("22:g.36689419_36689421delCCT"))
+        );
+    }
+
+    @Test
+    public void resolveRefSeq() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+
+        assertEquals(
+            "NM_018310.3",
+            this.refSeqResolver.resolve(
+                variantMockData.get("8:g.37696499_37696500insG").getTranscriptConsequences().get(0)
+            )
+        );
+
+        assertEquals(
+            "NM_012200.3",
+            this.refSeqResolver.resolve(
+                variantMockData.get("11:g.62393546_62393547delGGinsAA").getTranscriptConsequences().get(0)
+            )
+        );
+
+        assertNull(
+            this.refSeqResolver.resolve(
+                variantMockData.get("19:g.46141892_46141893delTCinsAA").getTranscriptConsequences().get(1)
+            )
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/StrandSignResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/StrandSignResolverTest.java
@@ -1,0 +1,169 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.mock.VariantAnnotationMockData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StrandSignResolverTest
+{
+    private final StrandSignResolver strandSignResolver = new StrandSignResolver();
+
+    private VariantAnnotationMockData variantAnnotationMockData = new VariantAnnotationMockData();
+
+    @Test
+    public void resolveStrandSign() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+
+        assertNull(
+            "Null annotation input -> Null output",
+            this.strandSignResolver.resolve(null)
+        );
+
+        assertNull(
+            "Variant annotation with null strand -> Null output",
+            this.strandSignResolver.resolve(new VariantAnnotation())
+        );
+
+        VariantAnnotation annotation = new VariantAnnotation();
+        annotation.setStrand(-1);
+
+        assertEquals(
+            "Variant annotation with strand < 0 -> Minus (-)",
+            "-",
+            this.strandSignResolver.resolve(annotation)
+        );
+
+        annotation = new VariantAnnotation();
+        annotation.setStrand(0);
+
+        assertEquals(
+            "Variant annotation with strand >= 0 -> Plus (+)",
+            "+",
+            this.strandSignResolver.resolve(annotation)
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("1:g.65325832_65325833insG"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("3:g.14106026_14106037delCCAGCAGTAGCT"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("3:g.14940279_14940280insCAT"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("3:g.114058003_114058003delG"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("4:g.9784947_9784948insAGA"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("4:g.77675978_77675979insC"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("6:g.137519505_137519506delCT"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("6:g.137519505_137519506delCTinsA"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("7:g.140453136A>T"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("8:g.37696499_37696500insG"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("9:g.135797242_135797242delCinsAT"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("10:g.101953779_101953779delT"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("11:g.62393546_62393547delGGinsAA"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("12:g.25398285C>A"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("16:g.9057113_9057114insCTG"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("19:g.46141892_46141893delTCinsAA"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("22:g.29091840_29091841delTGinsCA"))
+        );
+
+        // strand: 1
+        assertEquals(
+            "+",
+            this.strandSignResolver.resolve(variantMockData.get("22:g.36689419_36689421delCCT"))
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/TranscriptConsequencePrioritizerTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/TranscriptConsequencePrioritizerTest.java
@@ -1,0 +1,147 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.mock.VariantAnnotationMockData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TranscriptConsequencePrioritizerTest
+{
+    @InjectMocks
+    private TranscriptConsequencePrioritizer transcriptConsequencePrioritizer;
+
+    private final VariantAnnotationMockData variantAnnotationMockData = new VariantAnnotationMockData();
+
+    @Test
+    public void transcriptWithMostSevereConsequence() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+        VariantAnnotation annotation;
+
+        annotation = variantMockData.get("1:g.65325832_65325833insG");
+
+        // "most_severe_consequence": "frameshift_variant"
+        // "transcript_consequences"[0]["consequence_terms"]: ["frameshift_variant"]
+        assertEquals(
+            "transcript at index 0 should be selected for 1:g.65325832_65325833insG",
+            annotation.getTranscriptConsequences().get(0),
+            transcriptConsequencePrioritizer.transcriptWithMostSevereConsequence(annotation.getTranscriptConsequences(),
+                annotation.getMostSevereConsequence())
+        );
+
+        annotation = variantMockData.get("8:g.37696499_37696500insG");
+
+        // "most_severe_consequence": "frameshift_variant"
+        // "transcript_consequences"[1]["consequence_terms"]: ["frameshift_variant"]
+        assertEquals(
+            "transcript at index 1 should be selected for 8:g.37696499_37696500insG",
+            annotation.getTranscriptConsequences().get(1),
+            transcriptConsequencePrioritizer.transcriptWithMostSevereConsequence(annotation.getTranscriptConsequences(),
+                annotation.getMostSevereConsequence())
+        );
+
+        annotation = variantMockData.get("11:g.62393546_62393547delGGinsAA");
+
+        // "most_severe_consequence": "frameshift_variant"
+        // "transcript_consequences"[1]["consequence_terms"]: ["frameshift_variant"]
+        assertEquals(
+            "transcript at index 1 should be selected for 11:g.62393546_62393547delGGinsAA",
+            annotation.getTranscriptConsequences().get(1),
+            transcriptConsequencePrioritizer.transcriptWithMostSevereConsequence(annotation.getTranscriptConsequences(),
+                annotation.getMostSevereConsequence())
+        );
+
+        annotation = variantMockData.get("19:g.46141892_46141893delTCinsAA");
+
+        // "most_severe_consequence": "splice_acceptor_variant"
+        // "transcript_consequences"[0]["consequence_terms"]: ["splice_acceptor_variant"]
+        assertEquals(
+            "transcript at index 0 should be selected for 19:g.46141892_46141893delTCinsAA",
+            annotation.getTranscriptConsequences().get(0),
+            transcriptConsequencePrioritizer.transcriptWithMostSevereConsequence(annotation.getTranscriptConsequences(),
+                annotation.getMostSevereConsequence())
+        );
+    }
+
+    @Test
+    public void pickHighestPriorityConsequence()
+    {
+        String[][] consequenceTerms = {
+            {},
+            {"INVALID"},
+            {"INVALID_ONE", "INVALID_TWO"},
+            {"frameshift_variant"},
+            {"splice_acceptor_variant", "coding_sequence_variant", "NMD_transcript_variant"},
+            {"3_prime_UTR_variant", "NMD_transcript_variant"},
+            {"intron_variant", "non_coding_transcript_variant"},
+            {"missense_variant", "NMD_transcript_variant"},
+            {"protein_altering_variant", "NMD_transcript_variant"},
+            {"splice_acceptor_variant", "5_prime_UTR_variant"},
+            {"splice_acceptor_variant", "non_coding_transcript_exon_variant"},
+            {"INVALID", "5_prime_UTR_variant"},
+        };
+
+        assertNull(
+            this.transcriptConsequencePrioritizer.pickHighestPriorityConsequence(null)
+        );
+
+        assertNull(
+            "No consequence to select for an empty list",
+            this.transcriptConsequencePrioritizer.pickHighestPriorityConsequence(Arrays.asList(consequenceTerms[0]))
+        );
+
+        assertNull("No known consequence to select",
+            this.transcriptConsequencePrioritizer.pickHighestPriorityConsequence(Arrays.asList(consequenceTerms[1]))
+        );
+
+        assertNull("No known consequence to select",
+            this.transcriptConsequencePrioritizer.pickHighestPriorityConsequence(Arrays.asList(consequenceTerms[2]))
+        );
+
+        assertEquals("frameshift_variant",
+            this.transcriptConsequencePrioritizer.pickHighestPriorityConsequence(Arrays.asList(consequenceTerms[3]))
+        );
+
+        assertEquals("splice_acceptor_variant",
+            this.transcriptConsequencePrioritizer.pickHighestPriorityConsequence(Arrays.asList(consequenceTerms[4]))
+        );
+
+        assertEquals("3_prime_UTR_variant",
+            this.transcriptConsequencePrioritizer.pickHighestPriorityConsequence(Arrays.asList(consequenceTerms[5]))
+        );
+
+        assertEquals("intron_variant",
+            this.transcriptConsequencePrioritizer.pickHighestPriorityConsequence(Arrays.asList(consequenceTerms[6]))
+        );
+
+        assertEquals("missense_variant",
+            this.transcriptConsequencePrioritizer.pickHighestPriorityConsequence(Arrays.asList(consequenceTerms[7]))
+        );
+
+        assertEquals("protein_altering_variant",
+            this.transcriptConsequencePrioritizer.pickHighestPriorityConsequence(Arrays.asList(consequenceTerms[8]))
+        );
+
+        assertEquals("splice_acceptor_variant",
+            this.transcriptConsequencePrioritizer.pickHighestPriorityConsequence(Arrays.asList(consequenceTerms[9]))
+        );
+
+        assertEquals("splice_acceptor_variant",
+            this.transcriptConsequencePrioritizer.pickHighestPriorityConsequence(Arrays.asList(consequenceTerms[10]))
+        );
+
+        assertEquals("5_prime_UTR_variant",
+            this.transcriptConsequencePrioritizer.pickHighestPriorityConsequence(Arrays.asList(consequenceTerms[11]))
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/TranscriptIdResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/TranscriptIdResolverTest.java
@@ -1,0 +1,130 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.mock.CanonicalTranscriptResolverMocker;
+import org.cbioportal.genome_nexus.service.mock.VariantAnnotationMockData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TranscriptIdResolverTest
+{
+    @InjectMocks
+    private TranscriptIdResolver transcriptIdResolver;
+
+    @Mock
+    private CanonicalTranscriptResolver canonicalTranscriptResolver;
+
+    private final VariantAnnotationMockData variantAnnotationMockData = new VariantAnnotationMockData();
+    private final CanonicalTranscriptResolverMocker canonicalTranscriptResolverMocker = new CanonicalTranscriptResolverMocker();
+
+    @Test
+    public void resolveTranscriptIdForCanonical() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+        this.canonicalTranscriptResolverMocker.mockMethods(variantMockData, this.canonicalTranscriptResolver);
+
+        assertEquals(
+            "ENST00000342505",
+            this.transcriptIdResolver.resolve(variantMockData.get("1:g.65325832_65325833insG"))
+        );
+
+        assertEquals(
+            "ENST00000424053",
+            this.transcriptIdResolver.resolve(variantMockData.get("3:g.14106026_14106037delCCAGCAGTAGCT"))
+        );
+
+        assertEquals(
+            "ENST00000285046",
+            this.transcriptIdResolver.resolve(variantMockData.get("3:g.14940279_14940280insCAT"))
+        );
+
+        assertEquals(
+            "ENST00000474710",
+            this.transcriptIdResolver.resolve(variantMockData.get("3:g.114058003_114058003delG"))
+        );
+
+        assertEquals(
+            "ENST00000304374",
+            this.transcriptIdResolver.resolve(variantMockData.get("4:g.9784947_9784948insAGA"))
+        );
+
+        assertEquals(
+            "ENST00000296043",
+            this.transcriptIdResolver.resolve(variantMockData.get("4:g.77675978_77675979insC"))
+        );
+
+        assertEquals(
+            "ENST00000367739",
+            this.transcriptIdResolver.resolve(variantMockData.get("6:g.137519505_137519506delCT"))
+        );
+
+        assertEquals(
+            "ENST00000367739",
+            this.transcriptIdResolver.resolve(variantMockData.get("6:g.137519505_137519506delCTinsA"))
+        );
+
+        assertEquals(
+            "ENST00000288602",
+            this.transcriptIdResolver.resolve(variantMockData.get("7:g.140453136A>T"))
+        );
+
+        assertEquals(
+            "ENST00000412232",
+            this.transcriptIdResolver.resolve(variantMockData.get("8:g.37696499_37696500insG"))
+        );
+
+        assertEquals(
+            "ENST00000298552",
+            this.transcriptIdResolver.resolve(variantMockData.get("9:g.135797242_135797242delCinsAT"))
+        );
+
+        assertEquals(
+            "ENST00000370397",
+            this.transcriptIdResolver.resolve(variantMockData.get("10:g.101953779_101953779delT"))
+        );
+
+        assertEquals(
+            "ENST00000346178",
+            this.transcriptIdResolver.resolve(variantMockData.get("11:g.62393546_62393547delGGinsAA"))
+        );
+
+        assertEquals(
+            "ENST00000256078",
+            this.transcriptIdResolver.resolve(variantMockData.get("12:g.25398285C>A"))
+        );
+
+        assertEquals(
+            "ENST00000241453",
+            this.transcriptIdResolver.resolve(variantMockData.get("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG"))
+        );
+
+        assertEquals(
+            "ENST00000344836",
+            this.transcriptIdResolver.resolve(variantMockData.get("16:g.9057113_9057114insCTG"))
+        );
+
+        assertEquals(
+            "ENST00000587152",
+            this.transcriptIdResolver.resolve(variantMockData.get("19:g.46141892_46141893delTCinsAA"))
+        );
+
+        assertEquals(
+            "ENST00000382580",
+            this.transcriptIdResolver.resolve(variantMockData.get("22:g.29091840_29091841delTGinsCA"))
+        );
+
+        assertEquals(
+            "ENST00000216181",
+            this.transcriptIdResolver.resolve(variantMockData.get("22:g.36689419_36689421delCCT"))
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/VariantClassificationResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/VariantClassificationResolverTest.java
@@ -1,0 +1,174 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.mock.CanonicalTranscriptResolverMocker;
+import org.cbioportal.genome_nexus.service.mock.VariantAnnotationMockData;
+import org.cbioportal.genome_nexus.service.mock.VariantTypeResolverMocker;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VariantClassificationResolverTest
+{
+    @InjectMocks
+    private VariantClassificationResolver variantClassificationResolver;
+
+    @Mock
+    private CanonicalTranscriptResolver canonicalTranscriptResolver;
+
+    @Mock
+    private VariantTypeResolver variantTypeResolver;
+
+    @Spy
+    private TranscriptConsequencePrioritizer consequencePrioritizer;
+
+    @Spy
+    private GenomicLocationResolver genomicLocationResolver;
+
+    private final VariantAnnotationMockData variantAnnotationMockData = new VariantAnnotationMockData();
+    private final CanonicalTranscriptResolverMocker canonicalTranscriptResolverMocker = new CanonicalTranscriptResolverMocker();
+    private final VariantTypeResolverMocker variantTypeResolverMocker = new VariantTypeResolverMocker();
+
+    @Test
+    public void resolveVariantClassificationForCanonical() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+        this.canonicalTranscriptResolverMocker.mockMethods(variantMockData, this.canonicalTranscriptResolver);
+        this.variantTypeResolverMocker.mockMethods(variantMockData, this.variantTypeResolver);
+
+        assertEquals(
+            "Frame_Shift_Ins",
+            this.variantClassificationResolver.resolve(variantMockData.get("1:g.65325832_65325833insG"))
+        );
+
+        assertEquals(
+            "In_Frame_Del",
+            this.variantClassificationResolver.resolve(variantMockData.get("3:g.14106026_14106037delCCAGCAGTAGCT"))
+        );
+
+        assertEquals(
+            "In_Frame_Ins",
+            this.variantClassificationResolver.resolve(variantMockData.get("3:g.14940279_14940280insCAT"))
+        );
+
+        assertEquals(
+            "Frame_Shift_Del",
+            this.variantClassificationResolver.resolve(variantMockData.get("3:g.114058003_114058003delG"))
+        );
+
+        assertEquals(
+            "In_Frame_Ins",
+            this.variantClassificationResolver.resolve(variantMockData.get("4:g.9784947_9784948insAGA"))
+        );
+
+        assertEquals(
+            "Frame_Shift_Ins",
+            this.variantClassificationResolver.resolve(variantMockData.get("4:g.77675978_77675979insC"))
+        );
+
+        assertEquals(
+            "Frame_Shift_Del",
+            this.variantClassificationResolver.resolve(variantMockData.get("6:g.137519505_137519506delCT"))
+        );
+
+        assertEquals(
+            "Frame_Shift_Del",
+            this.variantClassificationResolver.resolve(variantMockData.get("6:g.137519505_137519506delCTinsA"))
+        );
+
+        assertEquals(
+            "Missense_Mutation",
+            this.variantClassificationResolver.resolve(variantMockData.get("7:g.140453136A>T"))
+        );
+
+        assertEquals(
+            "Frame_Shift_Ins",
+            this.variantClassificationResolver.resolve(variantMockData.get("8:g.37696499_37696500insG"))
+        );
+
+        assertEquals(
+            "Frame_Shift_Ins",
+            this.variantClassificationResolver.resolve(variantMockData.get("9:g.135797242_135797242delCinsAT"))
+        );
+
+        assertEquals(
+            "Frame_Shift_Del",
+            this.variantClassificationResolver.resolve(variantMockData.get("10:g.101953779_101953779delT"))
+        );
+
+        assertEquals(
+            "Nonsense_Mutation",
+            this.variantClassificationResolver.resolve(variantMockData.get("11:g.62393546_62393547delGGinsAA"))
+        );
+
+        assertEquals(
+            "Missense_Mutation",
+            this.variantClassificationResolver.resolve(variantMockData.get("12:g.25398285C>A"))
+        );
+
+        assertEquals(
+            "In_Frame_Del",
+            this.variantClassificationResolver.resolve(variantMockData.get("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG"))
+        );
+
+        assertEquals(
+            "In_Frame_Ins",
+            this.variantClassificationResolver.resolve(variantMockData.get("16:g.9057113_9057114insCTG"))
+        );
+
+        assertEquals(
+            "Splice_Site",
+            this.variantClassificationResolver.resolve(variantMockData.get("19:g.46141892_46141893delTCinsAA"))
+        );
+
+        assertEquals(
+            "Missense_Mutation",
+            this.variantClassificationResolver.resolve(variantMockData.get("22:g.29091840_29091841delTGinsCA"))
+        );
+
+        assertEquals(
+            "In_Frame_Del",
+            this.variantClassificationResolver.resolve(variantMockData.get("22:g.36689419_36689421delCCT"))
+        );
+    }
+
+    @Test
+    public void resolveVariantClassification() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+        this.variantTypeResolverMocker.mockMethods(variantMockData, this.variantTypeResolver);
+
+        assertEquals(
+            "3'Flank",
+            this.variantClassificationResolver.resolve(
+                variantMockData.get("8:g.37696499_37696500insG"),
+                variantMockData.get("8:g.37696499_37696500insG").getTranscriptConsequences().get(0)
+            )
+        );
+
+        assertEquals(
+            "5'Flank",
+            this.variantClassificationResolver.resolve(
+                variantMockData.get("11:g.62393546_62393547delGGinsAA"),
+                variantMockData.get("11:g.62393546_62393547delGGinsAA").getTranscriptConsequences().get(0)
+            )
+        );
+
+        assertEquals(
+            "3'Flank",
+            this.variantClassificationResolver.resolve(
+                variantMockData.get("19:g.46141892_46141893delTCinsAA"),
+                variantMockData.get("19:g.46141892_46141893delTCinsAA").getTranscriptConsequences().get(1)
+            )
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/VariantTypeResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/VariantTypeResolverTest.java
@@ -1,0 +1,174 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.mock.VariantAnnotationMockData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VariantTypeResolverTest
+{
+    @InjectMocks
+    private VariantTypeResolver variantTypeResolver;
+
+    @Mock
+    private GenomicLocationResolver genomicLocationResolver;
+
+    private VariantAnnotationMockData variantAnnotationMockData = new VariantAnnotationMockData();
+
+    @Test
+    public void resolveVariantType() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+
+        Mockito.when(
+            this.genomicLocationResolver.resolveReferenceAllele(Mockito.any(VariantAnnotation.class))
+        ).thenCallRealMethod();
+
+        Mockito.when(
+            this.genomicLocationResolver.resolveVariantAllele(Mockito.any(VariantAnnotation.class))
+        ).thenCallRealMethod();
+
+        // allele_string: "-/G" => expected: INS
+        assertEquals(
+            "Variant type for 1:g.65325832_65325833insG should be INS",
+            "INS",
+            this.variantTypeResolver.resolve(variantMockData.get("1:g.65325832_65325833insG"))
+        );
+
+        // allele_string: "CCAGCAGTAGCT/-" => expected: DEL
+        assertEquals(
+            "Variant type for 3:g.14106026_14106037delCCAGCAGTAGCT should be DEL",
+            "DEL",
+            this.variantTypeResolver.resolve(variantMockData.get("3:g.14106026_14106037delCCAGCAGTAGCT"))
+        );
+
+        // allele_string: "-/CAT" => expected: INS
+        assertEquals(
+            "Variant type for 3:g.14940279_14940280insCAT should be INS",
+            "INS",
+            this.variantTypeResolver.resolve(variantMockData.get("3:g.14940279_14940280insCAT"))
+        );
+
+        // allele_string: "G/-" => expected: DEL
+        assertEquals(
+            "Variant type for 3:g.114058003_114058003delG should be DEL",
+            "DEL",
+            this.variantTypeResolver.resolve(variantMockData.get("3:g.114058003_114058003delG"))
+        );
+
+        // allele_string: "-/AGA" => expected: INS
+        assertEquals(
+            "Variant type for 4:g.9784947_9784948insAGA should be INS",
+            "INS",
+            this.variantTypeResolver.resolve(variantMockData.get("4:g.9784947_9784948insAGA"))
+        );
+
+        // allele_string: "-/C" => expected: INS
+        assertEquals(
+            "Variant type for 4:g.77675978_77675979insC should be INS",
+            "INS",
+            this.variantTypeResolver.resolve(variantMockData.get("4:g.77675978_77675979insC"))
+        );
+
+        // allele_string: "CT/-" => expected: INS
+        assertEquals(
+            "Variant type for 6:g.137519505_137519506delCT should be DEL",
+            "DEL",
+            this.variantTypeResolver.resolve(variantMockData.get("6:g.137519505_137519506delCT"))
+        );
+
+        // allele_string: "CT/A" => expected: INS
+        assertEquals(
+            "Variant type for 6:g.137519505_137519506delCTinsA should be DEL",
+            "DEL",
+            this.variantTypeResolver.resolve(variantMockData.get("6:g.137519505_137519506delCTinsA"))
+        );
+
+        // allele_string: "A/T" => expected: SNP
+        assertEquals(
+            "Variant type for 7:g.140453136A>T should be SNP",
+            "SNP",
+            this.variantTypeResolver.resolve(variantMockData.get("7:g.140453136A>T"))
+        );
+
+        // allele_string: "-/G" => expected: INS
+        assertEquals(
+            "Variant type for 8:g.37696499_37696500insG should be INS",
+            "INS",
+            this.variantTypeResolver.resolve(variantMockData.get("8:g.37696499_37696500insG"))
+        );
+
+        // allele_string: "C/AT" => expected: INS
+        assertEquals(
+            "Variant type for 9:g.135797242_135797242delCinsAT should be INS",
+            "INS",
+            this.variantTypeResolver.resolve(variantMockData.get("9:g.135797242_135797242delCinsAT"))
+        );
+
+        // allele_string: "T/-" => expected: DEL
+        assertEquals(
+            "Variant type for 10:g.101953779_101953779delT should be DEL",
+            "DEL",
+            this.variantTypeResolver.resolve(variantMockData.get("10:g.101953779_101953779delT"))
+        );
+
+        // allele_string: "GG/AA" => expected: DNP
+        assertEquals(
+            "Variant type for 11:g.62393546_62393547delGGinsAA should be DNP",
+            "DNP",
+            this.variantTypeResolver.resolve(variantMockData.get("11:g.62393546_62393547delGGinsAA"))
+        );
+
+        // allele_string: "C/A" => expected: SNP
+        assertEquals(
+            "Variant type for 12:g.25398285C>A should be SNP",
+            "SNP",
+            this.variantTypeResolver.resolve(variantMockData.get("12:g.25398285C>A"))
+        );
+
+        // allele_string: "CATATTCATATTCTCTGA/GGGGTGGGGGGG" => expected: DEL
+        assertEquals(
+            "Variant type for 13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG should be DEL",
+            "DEL",
+            this.variantTypeResolver.resolve(variantMockData.get("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG"))
+        );
+
+        // allele_string: "-/CTG" => expected: DEL
+        assertEquals(
+            "Variant type for 16:g.9057113_9057114insCTG should be INS",
+            "INS",
+            this.variantTypeResolver.resolve(variantMockData.get("16:g.9057113_9057114insCTG"))
+        );
+
+        // allele_string: "TC/AA" => expected: DNP
+        assertEquals(
+            "Variant type for 19:g.46141892_46141893delTCinsAA should be DNP",
+            "DNP",
+            this.variantTypeResolver.resolve(variantMockData.get("19:g.46141892_46141893delTCinsAA"))
+        );
+
+        // allele_string: "TG/CA" => expected: DNP
+        assertEquals(
+            "Variant type for 22:g.29091840_29091841delTGinsCA should be DNP",
+            "DNP",
+            this.variantTypeResolver.resolve(variantMockData.get("22:g.29091840_29091841delTGinsCA"))
+        );
+
+        // allele_string: "CCT/-" => expected: DEL
+        assertEquals(
+            "Variant type for 22:g.36689419_36689421delCCT should be DEL",
+            "DEL",
+            this.variantTypeResolver.resolve(variantMockData.get("22:g.36689419_36689421delCCT"))
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/config/ExternalResourceObjectMapperTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/config/ExternalResourceObjectMapperTest.java
@@ -1,0 +1,94 @@
+package org.cbioportal.genome_nexus.service.config;
+
+import org.cbioportal.genome_nexus.model.GeneXref;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.mock.JsonToObjectMapper;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ExternalResourceObjectMapperTest
+{
+    private final JsonToObjectMapper objectMapper;
+
+    public ExternalResourceObjectMapperTest()
+    {
+        this.objectMapper = new JsonToObjectMapper();
+    }
+
+    @Test
+    public void testVariantAnnotationMapping() throws IOException
+    {
+        VariantAnnotation annotation =
+            this.objectMapper.readVariantAnnotation("1_g.65325832_65325833insG.json");
+
+        assertEquals("1:g.65325832_65325833insG", annotation.getVariantId());
+        assertEquals("GRCh37", annotation.getAssemblyName());
+        assertEquals("1", annotation.getSeqRegionName());
+        assertEquals((Integer)65325833, annotation.getStart());
+        assertEquals((Integer)65325832, annotation.getEnd());
+        assertEquals("-/G", annotation.getAlleleString());
+        assertEquals((Integer)1, annotation.getStrand());
+        assertEquals("frameshift_variant", annotation.getMostSevereConsequence());
+
+        assertEquals(2, annotation.getTranscriptConsequences().size());
+
+        assertEquals("ENST00000342505",
+            annotation.getTranscriptConsequences().get(0).getTranscriptId());
+        assertEquals("ENSP00000343204.4:p.Leu431ValfsTer22",
+            annotation.getTranscriptConsequences().get(0).getHgvsp());
+        assertEquals("ENST00000342505.4:c.1289dup",
+            annotation.getTranscriptConsequences().get(0).getHgvsc());
+        assertEquals((Integer)430,
+            annotation.getTranscriptConsequences().get(0).getProteinStart());
+        assertEquals((Integer)430,
+            annotation.getTranscriptConsequences().get(0).getProteinEnd());
+        assertEquals(1,
+            annotation.getTranscriptConsequences().get(0).getRefseqTranscriptIds().size());
+        assertEquals(1,
+            annotation.getTranscriptConsequences().get(0).getConsequenceTerms().size());
+
+        assertEquals("ENST00000494904",
+            annotation.getTranscriptConsequences().get(1).getTranscriptId());
+        assertEquals("G",
+            annotation.getTranscriptConsequences().get(1).getVariantAllele());
+        assertEquals("JAK1",
+            annotation.getTranscriptConsequences().get(1).getGeneSymbol());
+        assertEquals(1,
+            annotation.getTranscriptConsequences().get(1).getConsequenceTerms().size());
+        assertNull(
+            annotation.getTranscriptConsequences().get(1).getRefseqTranscriptIds());
+
+        assertNull(annotation.getAnnotationSummary());
+    }
+
+    @Test
+    public void testGeneXrefMapping() throws IOException
+    {
+        List<GeneXref> xrefs =
+            this.objectMapper.readGeneXrefs("ENSG00000020181.json");
+
+        assertEquals(8, xrefs.size());
+
+        assertEquals("GPR124", xrefs.get(0).getDisplayId());
+        assertEquals("GPR124", xrefs.get(0).getPrimaryId());
+        assertEquals("0", xrefs.get(0).getVersion());
+        assertEquals("KIAA1531", xrefs.get(0).getSynonyms().get(0));
+        assertEquals("TEM5", xrefs.get(0).getSynonyms().get(1));
+        assertEquals("", xrefs.get(0).getInfoText());
+        assertEquals("DEPENDENT", xrefs.get(0).getInfoType());
+        assertEquals("UniProtKB Gene Name", xrefs.get(0).getDbDisplayName());
+
+        assertEquals("GPR124", xrefs.get(5).getDisplayId());
+        assertEquals("25960", xrefs.get(5).getPrimaryId());
+        assertEquals("EntrezGene", xrefs.get(5).getDbName());
+        assertEquals("EntrezGene", xrefs.get(5).getDbDisplayName());
+        assertEquals("G protein-coupled receptor 124", xrefs.get(5).getDescription());
+    }
+
+    // TODO add tests for other external resources as well
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/internal/MutationAssessorServiceTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/internal/MutationAssessorServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.io.IOException;
 import java.util.Map;
 
 import static org.junit.Assert.*;
@@ -54,7 +55,8 @@ public class MutationAssessorServiceTest
 
     @Test
     public void getMutationAssessorByVariantAnnotation()
-        throws ResourceMappingException, MutationAssessorWebServiceException, MutationAssessorNotFoundException
+        throws ResourceMappingException, MutationAssessorWebServiceException, MutationAssessorNotFoundException,
+        IOException
     {
         Map<String, MutationAssessor> maMockData = this.mutationAssessorMockData.generateData();
         Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationServiceTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +48,8 @@ public class VariantAnnotationServiceTest
 
     @Test
     public void getAnnotationByVariantString()
-        throws ResourceMappingException, VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+        throws ResourceMappingException, VariantAnnotationWebServiceException, VariantAnnotationNotFoundException,
+        IOException
     {
         Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
         this.mockVariantFetcherMethods(variantMockData);
@@ -63,7 +65,8 @@ public class VariantAnnotationServiceTest
 
     @Test
     public void getAnnotationsByVariantString()
-        throws ResourceMappingException, VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+        throws ResourceMappingException, VariantAnnotationWebServiceException, VariantAnnotationNotFoundException,
+        IOException
     {
         Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
         this.mockVariantFetcherMethods(variantMockData);
@@ -82,7 +85,8 @@ public class VariantAnnotationServiceTest
     @Test
     public void getMutationAssessorEnrichedAnnotationByVariantString()
         throws ResourceMappingException, VariantAnnotationWebServiceException, VariantAnnotationNotFoundException,
-        MutationAssessorWebServiceException, MutationAssessorNotFoundException, IsoformOverrideNotFoundException
+        MutationAssessorWebServiceException, MutationAssessorNotFoundException, IsoformOverrideNotFoundException,
+        IOException
     {
         Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
         Map<String, MutationAssessor> maMockData = this.mutationAssessorMockData.generateData();
@@ -111,7 +115,7 @@ public class VariantAnnotationServiceTest
     @Test
     public void getHotspotEnrichedAnnotationByVariantString()
         throws ResourceMappingException, VariantAnnotationWebServiceException, VariantAnnotationNotFoundException,
-        CancerHotspotsWebServiceException, IsoformOverrideNotFoundException
+        CancerHotspotsWebServiceException, IsoformOverrideNotFoundException, IOException
     {
         Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
         Map<String, List<Hotspot>> hotspotMockData = this.cancerHotspotMockData.generateData();
@@ -140,7 +144,7 @@ public class VariantAnnotationServiceTest
     @Test
     public void getIsorformOverrideEnrichedAnnotationByVariantString()
         throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException, ResourceMappingException,
-        IsoformOverrideNotFoundException
+        IsoformOverrideNotFoundException, IOException
     {
         Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
         Map<String, IsoformOverride> isoformOverrideMockData = this.isoformOverrideMockData.generateData();

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/CanonicalTranscriptResolverMocker.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/CanonicalTranscriptResolverMocker.java
@@ -1,0 +1,128 @@
+package org.cbioportal.genome_nexus.service.mock;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.annotation.CanonicalTranscriptResolver;
+import org.mockito.Mockito;
+
+import java.util.Map;
+
+public class CanonicalTranscriptResolverMocker
+{
+    public void mockMethods(Map<String, VariantAnnotation> variantMockData,
+                             CanonicalTranscriptResolver canonicalTranscriptResolver)
+    {
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("1:g.65325832_65325833insG"))
+        ).thenReturn(
+            variantMockData.get("1:g.65325832_65325833insG").getTranscriptConsequences().get(0)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("3:g.14106026_14106037delCCAGCAGTAGCT"))
+        ).thenReturn(
+            variantMockData.get("3:g.14106026_14106037delCCAGCAGTAGCT").getTranscriptConsequences().get(1)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("3:g.14940279_14940280insCAT"))
+        ).thenReturn(
+            variantMockData.get("3:g.14940279_14940280insCAT").getTranscriptConsequences().get(0)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("3:g.114058003_114058003delG"))
+        ).thenReturn(
+            variantMockData.get("3:g.114058003_114058003delG").getTranscriptConsequences().get(5)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("4:g.9784947_9784948insAGA"))
+        ).thenReturn(
+            variantMockData.get("4:g.9784947_9784948insAGA").getTranscriptConsequences().get(0)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("4:g.77675978_77675979insC"))
+        ).thenReturn(
+            variantMockData.get("4:g.77675978_77675979insC").getTranscriptConsequences().get(0)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("6:g.137519505_137519506delCT"))
+        ).thenReturn(
+            variantMockData.get("6:g.137519505_137519506delCT").getTranscriptConsequences().get(0)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("6:g.137519505_137519506delCTinsA"))
+        ).thenReturn(
+            variantMockData.get("6:g.137519505_137519506delCTinsA").getTranscriptConsequences().get(0)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("7:g.140453136A>T"))
+        ).thenReturn(
+            variantMockData.get("7:g.140453136A>T").getTranscriptConsequences().get(0)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("8:g.37696499_37696500insG"))
+        ).thenReturn(
+            variantMockData.get("8:g.37696499_37696500insG").getTranscriptConsequences().get(2)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("9:g.135797242_135797242delCinsAT"))
+        ).thenReturn(
+            variantMockData.get("9:g.135797242_135797242delCinsAT").getTranscriptConsequences().get(0)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("10:g.101953779_101953779delT"))
+        ).thenReturn(
+            variantMockData.get("10:g.101953779_101953779delT").getTranscriptConsequences().get(0)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("11:g.62393546_62393547delGGinsAA"))
+        ).thenReturn(
+            variantMockData.get("11:g.62393546_62393547delGGinsAA").getTranscriptConsequences().get(1)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("12:g.25398285C>A"))
+        ).thenReturn(
+            variantMockData.get("12:g.25398285C>A").getTranscriptConsequences().get(0)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG"))
+        ).thenReturn(
+            variantMockData.get("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG").getTranscriptConsequences().get(0)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("16:g.9057113_9057114insCTG"))
+        ).thenReturn(
+            variantMockData.get("16:g.9057113_9057114insCTG").getTranscriptConsequences().get(0)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("19:g.46141892_46141893delTCinsAA"))
+        ).thenReturn(
+            variantMockData.get("19:g.46141892_46141893delTCinsAA").getTranscriptConsequences().get(8)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("22:g.29091840_29091841delTGinsCA"))
+        ).thenReturn(
+            variantMockData.get("22:g.29091840_29091841delTGinsCA").getTranscriptConsequences().get(5)
+        );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("22:g.36689419_36689421delCCT"))
+        ).thenReturn(
+            variantMockData.get("22:g.36689419_36689421delCCT").getTranscriptConsequences().get(0)
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/GeneXrefMockData.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/GeneXrefMockData.java
@@ -1,0 +1,64 @@
+package org.cbioportal.genome_nexus.service.mock;
+
+import org.cbioportal.genome_nexus.model.GeneXref;
+import org.cbioportal.genome_nexus.service.MockData;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class GeneXrefMockData implements MockData<List<GeneXref>>
+{
+    private final JsonToObjectMapper objectMapper;
+
+    public GeneXrefMockData()
+    {
+        this.objectMapper = new JsonToObjectMapper();
+    }
+
+    @Override
+    public Map<String, List<GeneXref>> generateData() throws IOException
+    {
+        Map<String, List<GeneXref>> mockData = new LinkedHashMap<>();
+
+        mockData.put("ENSG00000020181",
+            this.objectMapper.readGeneXrefs("ENSG00000020181.json"));
+        mockData.put("ENSG00000027697",
+            this.objectMapper.readGeneXrefs("ENSG00000027697.json"));
+        mockData.put("ENSG00000089597",
+            this.objectMapper.readGeneXrefs("ENSG00000089597.json"));
+        mockData.put("ENSG00000100345",
+            this.objectMapper.readGeneXrefs("ENSG00000100345.json"));
+        mockData.put("ENSG00000122025",
+            this.objectMapper.readGeneXrefs("ENSG00000122025.json"));
+        mockData.put("ENSG00000125746",
+            this.objectMapper.readGeneXrefs("ENSG00000125746.json"));
+        mockData.put("ENSG00000133703",
+            this.objectMapper.readGeneXrefs("ENSG00000133703.json"));
+        mockData.put("ENSG00000138771",
+            this.objectMapper.readGeneXrefs("ENSG00000138771.json"));
+        mockData.put("ENSG00000154783",
+            this.objectMapper.readGeneXrefs("ENSG00000154783.json"));
+        mockData.put("ENSG00000157764",
+            this.objectMapper.readGeneXrefs("ENSG00000157764.json"));
+        mockData.put("ENSG00000162434",
+            this.objectMapper.readGeneXrefs("ENSG00000162434.json"));
+        mockData.put("ENSG00000165699",
+            this.objectMapper.readGeneXrefs("ENSG00000165699.json"));
+        mockData.put("ENSG00000169676",
+            this.objectMapper.readGeneXrefs("ENSG00000169676.json"));
+        mockData.put("ENSG00000180438",
+            this.objectMapper.readGeneXrefs("ENSG00000180438.json"));
+        mockData.put("ENSG00000181722",
+            this.objectMapper.readGeneXrefs("ENSG00000181722.json"));
+        mockData.put("ENSG00000183765",
+            this.objectMapper.readGeneXrefs("ENSG00000183765.json"));
+        mockData.put("ENSG00000187555",
+            this.objectMapper.readGeneXrefs("ENSG00000187555.json"));
+        mockData.put("ENSG00000213341",
+            this.objectMapper.readGeneXrefs("ENSG00000213341.json"));
+
+        return mockData;
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/GeneXrefServiceMocker.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/GeneXrefServiceMocker.java
@@ -1,0 +1,125 @@
+package org.cbioportal.genome_nexus.service.mock;
+
+import org.cbioportal.genome_nexus.model.GeneXref;
+import org.cbioportal.genome_nexus.service.GeneXrefService;
+import org.cbioportal.genome_nexus.service.exception.EnsemblWebServiceException;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Map;
+
+public class GeneXrefServiceMocker
+{
+    public void mockMethods(Map<String, List<GeneXref>> geneXrefMockData,
+                            GeneXrefService geneXrefService)
+        throws EnsemblWebServiceException
+    {
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000020181")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000020181")
+        );
+
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000027697")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000027697")
+        );
+
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000089597")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000089597")
+        );
+
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000100345")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000100345")
+        );
+
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000122025")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000122025")
+        );
+
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000125746")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000125746")
+        );
+
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000133703")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000133703")
+        );
+
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000138771")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000138771")
+        );
+
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000154783")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000154783")
+        );
+
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000157764")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000157764")
+        );
+
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000162434")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000162434")
+        );
+
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000165699")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000165699")
+        );
+
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000169676")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000169676")
+        );
+
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000180438")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000180438")
+        );
+
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000181722")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000181722")
+        );
+
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000183765")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000183765")
+        );
+
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000187555")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000187555")
+        );
+
+        Mockito.when(
+            geneXrefService.getGeneXrefs("ENSG00000213341")
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000213341")
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/GeneXrefServiceMocker.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/GeneXrefServiceMocker.java
@@ -8,10 +8,20 @@ import org.mockito.Mockito;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.Matchers.eq;
+
 public class GeneXrefServiceMocker
 {
     public void mockMethods(Map<String, List<GeneXref>> geneXrefMockData,
                             GeneXrefService geneXrefService)
+        throws EnsemblWebServiceException
+    {
+        this.mockGetGeneXrefs(geneXrefMockData, geneXrefService);
+        this.mockGetEntrezGeneXref(geneXrefMockData, geneXrefService);
+    }
+
+    public void mockGetGeneXrefs(Map<String, List<GeneXref>> geneXrefMockData,
+                                 GeneXrefService geneXrefService)
         throws EnsemblWebServiceException
     {
         Mockito.when(
@@ -120,6 +130,119 @@ public class GeneXrefServiceMocker
             geneXrefService.getGeneXrefs("ENSG00000213341")
         ).thenReturn(
             geneXrefMockData.get("ENSG00000213341")
+        );
+    }
+
+    public void mockGetEntrezGeneXref(Map<String, List<GeneXref>> geneXrefMockData,
+                                      GeneXrefService geneXrefService)
+        throws EnsemblWebServiceException
+    {
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000020181"), Mockito.anyString())
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000020181").get(5)
+        );
+
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000027697"), Mockito.anyString())
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000027697").get(8)
+        );
+
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000089597"), Mockito.anyString())
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000089597").get(5)
+        );
+
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000100345"), Mockito.anyString())
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000100345").get(12)
+        );
+
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000122025"), Mockito.anyString())
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000122025").get(8)
+        );
+
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000125746"), Mockito.anyString())
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000125746").get(4)
+        );
+
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000133703"), Mockito.anyString())
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000133703").get(15)
+        );
+
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000138771"), Mockito.anyString())
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000138771").get(9)
+        );
+
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000154783"), Mockito.anyString())
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000154783").get(5)
+        );
+
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000157764"), Mockito.anyString())
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000157764").get(19)
+        );
+
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000162434"), Mockito.anyString())
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000162434").get(4)
+        );
+
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000165699"), Mockito.anyString())
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000165699").get(8)
+        );
+
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000169676"), Mockito.anyString())
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000169676").get(8)
+        );
+
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000180438"), Mockito.anyString())
+        ).thenReturn(
+            null
+        );
+
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000181722"), Mockito.anyString())
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000181722").get(3)
+        );
+
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000183765"), Mockito.anyString())
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000183765").get(10)
+        );
+
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000187555"), Mockito.anyString())
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000187555").get(8)
+        );
+
+        Mockito.when(
+            geneXrefService.getEntrezGeneXref(eq("ENSG00000213341"), Mockito.anyString())
+        ).thenReturn(
+            geneXrefMockData.get("ENSG00000213341").get(5)
         );
     }
 }

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/JsonToObjectMapper.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/JsonToObjectMapper.java
@@ -1,0 +1,35 @@
+package org.cbioportal.genome_nexus.service.mock;
+
+import org.cbioportal.genome_nexus.model.GeneXref;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.config.ExternalResourceObjectMapper;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.util.List;
+
+public class JsonToObjectMapper
+{
+    private final ExternalResourceObjectMapper objectMapper;
+
+    public JsonToObjectMapper()
+    {
+        this.objectMapper = new ExternalResourceObjectMapper();
+    }
+
+    public VariantAnnotation readVariantAnnotation(String resourceName) throws IOException
+    {
+        return this.objectMapper.readValue(
+            new ClassPathResource("variant/" + resourceName).getInputStream(),
+            VariantAnnotation.class
+        );
+    }
+
+    public List<GeneXref> readGeneXrefs(String resourceName) throws IOException
+    {
+        return this.objectMapper.readValue(
+            new ClassPathResource("xref/" + resourceName).getInputStream(),
+            this.objectMapper.getTypeFactory().constructCollectionType(List.class, GeneXref.class)
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantAnnotationMockData.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantAnnotationMockData.java
@@ -1,83 +1,64 @@
 package org.cbioportal.genome_nexus.service.mock;
 
-import org.cbioportal.genome_nexus.model.TranscriptConsequence;
 import org.cbioportal.genome_nexus.model.VariantAnnotation;
 import org.cbioportal.genome_nexus.service.MockData;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class VariantAnnotationMockData implements MockData<VariantAnnotation>
 {
-    @Override
-    public Map<String, VariantAnnotation> generateData()
+    private final JsonToObjectMapper objectMapper;
+
+    public VariantAnnotationMockData()
     {
-        Map<String, VariantAnnotation> mockData = new HashMap<>();
+        this.objectMapper = new JsonToObjectMapper();
+    }
 
-        VariantAnnotation variantAnnotation;
-        List<TranscriptConsequence> transcriptConsequences;
-        List<String> consequenceTerms;
-        TranscriptConsequence consequence;
+    @Override
+    public Map<String, VariantAnnotation> generateData() throws IOException
+    {
+        Map<String, VariantAnnotation> mockData = new LinkedHashMap<>();
 
-        // mock data for variant: 7:g.140453136A>T
-        variantAnnotation = new VariantAnnotation();
-
-        variantAnnotation.setVariant("7:g.140453136A>T");
-        variantAnnotation.setSeqRegionName("7");
-        variantAnnotation.setStart(140453136);
-        variantAnnotation.setEnd(140453136);
-        variantAnnotation.setAlleleString("A/T");
-        variantAnnotation.setMostSevereConsequence("missense_variant");
-
-        transcriptConsequences = new ArrayList<>();
-
-        consequence = new TranscriptConsequence();
-        consequenceTerms = new ArrayList<>();
-        consequenceTerms.add("missense_variant");
-        consequence.setConsequenceTerms(consequenceTerms);
-        consequence.setTranscriptId("ENST00000288602");
-        consequence.setGeneSymbol("BRAF");
-        consequence.setProteinStart(600);
-        consequence.setProteinEnd(600);
-
-        transcriptConsequences.add(consequence);
-
-        consequence = new TranscriptConsequence();
-        consequenceTerms = new ArrayList<>();
-        consequenceTerms.add("missense_variant");
-        consequenceTerms.add("NMD_transcript_variant");
-        consequence.setConsequenceTerms(consequenceTerms);
-        consequence.setGeneSymbol("BRAF");
-        consequence.setTranscriptId("ENST00000479537");
-        consequence.setProteinStart(28);
-        consequence.setProteinEnd(28);
-
-        transcriptConsequences.add(consequence);
-        variantAnnotation.setTranscriptConsequences(transcriptConsequences);
-
-        mockData.put("7:g.140453136A>T", variantAnnotation);
-
-        // mock data for variant: 12:g.25398285C>A
-        variantAnnotation = new VariantAnnotation();
-        variantAnnotation.setVariant("12:g.25398285C>A");
-        variantAnnotation.setSeqRegionName("12");
-        variantAnnotation.setStart(25398285);
-        variantAnnotation.setEnd(25398285);
-        variantAnnotation.setAlleleString("C/A");
-
-        transcriptConsequences = new ArrayList<>();
-
-        consequence = new TranscriptConsequence();
-        consequence.setTranscriptId("ENST00000256078");
-        consequence.setProteinStart(12);
-        consequence.setProteinEnd(12);
-
-        transcriptConsequences.add(consequence);
-        variantAnnotation.setTranscriptConsequences(transcriptConsequences);
-
-        mockData.put("12:g.25398285C>A", variantAnnotation);
+        mockData.put("1:g.65325832_65325833insG",
+            this.objectMapper.readVariantAnnotation("1_g.65325832_65325833insG.json"));
+        mockData.put("3:g.14106026_14106037delCCAGCAGTAGCT",
+            this.objectMapper.readVariantAnnotation("3_g.14106026_14106037delCCAGCAGTAGCT.json"));
+        mockData.put("3:g.14940279_14940280insCAT",
+            this.objectMapper.readVariantAnnotation("3_g.14940279_14940280insCAT.json"));
+        mockData.put("3:g.114058003_114058003delG",
+            this.objectMapper.readVariantAnnotation("3_g.114058003_114058003delG.json"));
+        mockData.put("4:g.9784947_9784948insAGA",
+            this.objectMapper.readVariantAnnotation("4_g.9784947_9784948insAGA.json"));
+        mockData.put("4:g.77675978_77675979insC",
+            this.objectMapper.readVariantAnnotation("4_g.77675978_77675979insC.json"));
+        mockData.put("6:g.137519505_137519506delCTinsA",
+            this.objectMapper.readVariantAnnotation("6_g.137519505_137519506delCTinsA.json"));
+        mockData.put("6:g.137519505_137519506delCT",
+            this.objectMapper.readVariantAnnotation("6_g.137519505_137519506delCT.json"));
+        mockData.put("7:g.140453136A>T",
+            this.objectMapper.readVariantAnnotation("7_g.140453136A_T.json"));
+        mockData.put("8:g.37696499_37696500insG",
+            this.objectMapper.readVariantAnnotation("8_g.37696499_37696500insG.json"));
+        mockData.put("9:g.135797242_135797242delCinsAT",
+            this.objectMapper.readVariantAnnotation("9_g.135797242_135797242delCinsAT.json"));
+        mockData.put("10:g.101953779_101953779delT",
+            this.objectMapper.readVariantAnnotation("10_g.101953779_101953779delT.json"));
+        mockData.put("11:g.62393546_62393547delGGinsAA",
+            this.objectMapper.readVariantAnnotation("11_g.62393546_62393547delGGinsAA.json"));
+        mockData.put("12:g.25398285C>A",
+            this.objectMapper.readVariantAnnotation("12_g.25398285C_A.json"));
+        mockData.put("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG",
+            this.objectMapper.readVariantAnnotation("13_g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG.json"));
+        mockData.put("16:g.9057113_9057114insCTG",
+            this.objectMapper.readVariantAnnotation("16_g.9057113_9057114insCTG.json"));
+        mockData.put("19:g.46141892_46141893delTCinsAA",
+            this.objectMapper.readVariantAnnotation("19_g.46141892_46141893delTCinsAA.json"));
+        mockData.put("22:g.29091840_29091841delTGinsCA",
+            this.objectMapper.readVariantAnnotation("22_g.29091840_29091841delTGinsCA.json"));
+        mockData.put("22:g.36689419_36689421delCCT",
+            this.objectMapper.readVariantAnnotation("22_g.36689419_36689421delCCT.json"));
 
         return mockData;
     }

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantClassificationResolverMocker.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantClassificationResolverMocker.java
@@ -1,0 +1,128 @@
+package org.cbioportal.genome_nexus.service.mock;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.annotation.VariantClassificationResolver;
+import org.mockito.Mockito;
+
+import java.util.Map;
+
+public class VariantClassificationResolverMocker
+{
+    public void mockMethods(Map<String, VariantAnnotation> variantMockData,
+                            VariantClassificationResolver variantClassificationResolver)
+    {
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("1:g.65325832_65325833insG"))
+        ).thenReturn(
+            "Frame_Shift_Ins"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("3:g.14106026_14106037delCCAGCAGTAGCT"))
+        ).thenReturn(
+            "In_Frame_Del"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("3:g.14940279_14940280insCAT"))
+        ).thenReturn(
+            "In_Frame_Ins"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("3:g.114058003_114058003delG"))
+        ).thenReturn(
+            "Frame_Shift_Del"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("4:g.9784947_9784948insAGA"))
+        ).thenReturn(
+            "In_Frame_Ins"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("4:g.77675978_77675979insC"))
+        ).thenReturn(
+            "Frame_Shift_Ins"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("6:g.137519505_137519506delCT"))
+        ).thenReturn(
+            "Frame_Shift_Del"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("6:g.137519505_137519506delCTinsA"))
+        ).thenReturn(
+            "Frame_Shift_Del"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("7:g.140453136A>T"))
+        ).thenReturn(
+            "Missense_Mutation"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("8:g.37696499_37696500insG"))
+        ).thenReturn(
+            "Frame_Shift_Ins"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("9:g.135797242_135797242delCinsAT"))
+        ).thenReturn(
+            "Frame_Shift_Ins"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("10:g.101953779_101953779delT"))
+        ).thenReturn(
+            "Frame_Shift_Del"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("11:g.62393546_62393547delGGinsAA"))
+        ).thenReturn(
+            "Nonsense_Mutation"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("12:g.25398285C>A"))
+        ).thenReturn(
+            "Missense_Mutation"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG"))
+        ).thenReturn(
+            "In_Frame_Del"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("16:g.9057113_9057114insCTG"))
+        ).thenReturn(
+            "In_Frame_Ins"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("19:g.46141892_46141893delTCinsAA"))
+        ).thenReturn(
+            "Splice_Site"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("22:g.29091840_29091841delTGinsCA"))
+        ).thenReturn(
+            "Missense_Mutation"
+        );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(variantMockData.get("22:g.36689419_36689421delCCT"))
+        ).thenReturn(
+            "In_Frame_Del"
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantTypeResolverMocker.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantTypeResolverMocker.java
@@ -1,0 +1,128 @@
+package org.cbioportal.genome_nexus.service.mock;
+
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.annotation.VariantTypeResolver;
+import org.mockito.Mockito;
+
+import java.util.Map;
+
+public class VariantTypeResolverMocker
+{
+    public void mockMethods(Map<String, VariantAnnotation> variantMockData,
+                            VariantTypeResolver variantTypeResolver)
+    {
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("1:g.65325832_65325833insG"))
+        ).thenReturn(
+            "INS"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("3:g.14106026_14106037delCCAGCAGTAGCT"))
+        ).thenReturn(
+            "DEL"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("3:g.14940279_14940280insCAT"))
+        ).thenReturn(
+            "INS"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("3:g.114058003_114058003delG"))
+        ).thenReturn(
+            "DEL"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("4:g.9784947_9784948insAGA"))
+        ).thenReturn(
+            "INS"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("4:g.77675978_77675979insC"))
+        ).thenReturn(
+            "INS"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("6:g.137519505_137519506delCT"))
+        ).thenReturn(
+            "DEL"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("6:g.137519505_137519506delCTinsA"))
+        ).thenReturn(
+            "DEL"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("7:g.140453136A>T"))
+        ).thenReturn(
+            "SNP"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("8:g.37696499_37696500insG"))
+        ).thenReturn(
+            "INS"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("9:g.135797242_135797242delCinsAT"))
+        ).thenReturn(
+            "INS"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("10:g.101953779_101953779delT"))
+        ).thenReturn(
+            "DEL"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("11:g.62393546_62393547delGGinsAA"))
+        ).thenReturn(
+            "DNP"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("12:g.25398285C>A"))
+        ).thenReturn(
+            "SNP"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG"))
+        ).thenReturn(
+            "DEL"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("16:g.9057113_9057114insCTG"))
+        ).thenReturn(
+            "INS"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("19:g.46141892_46141893delTCinsAA"))
+        ).thenReturn(
+            "DNP"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("22:g.29091840_29091841delTGinsCA"))
+        ).thenReturn(
+            "DNP"
+        );
+
+        Mockito.when(
+            variantTypeResolver.resolve(variantMockData.get("22:g.36689419_36689421delCCT"))
+        ).thenReturn(
+            "DEL"
+        );
+    }
+}

--- a/service/src/test/resources/variant/10_g.101953779_101953779delT.json
+++ b/service/src/test/resources/variant/10_g.101953779_101953779delT.json
@@ -1,0 +1,76 @@
+{
+    "variant": "10:g.101953779_101953779delT",
+    "id": "10:g.101953779_101953779delT",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "10",
+    "start": 101953779,
+    "end": 101953779,
+    "allele_string": "T/-",
+    "strand": 1,
+    "most_severe_consequence": "frameshift_variant",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000370397",
+            "hgvsp": "ENSP00000359424.6:p.Arg646GlyfsTer22",
+            "hgvsc": "ENST00000370397.7:c.1936del",
+            "variant_allele": "-",
+            "codons": "Agg/gg",
+            "protein_id": "ENSP00000359424",
+            "protein_start": 646,
+            "protein_end": 646,
+            "gene_symbol": "CHUK",
+            "gene_id": "ENSG00000213341",
+            "amino_acids": "R/X",
+            "hgnc_id": 1974,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_001278.3"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000443919",
+            "variant_allele": "-",
+            "gene_symbol": "RP11-316M21.7",
+            "gene_id": "ENSG00000236308",
+            "canonical": "1",
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000585551",
+            "variant_allele": "-",
+            "gene_symbol": "CHUK",
+            "gene_id": "ENSG00000213341",
+            "hgnc_id": 1974,
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000588656",
+            "hgvsc": "ENST00000588656.1:n.58del",
+            "variant_allele": "-",
+            "gene_symbol": "CHUK",
+            "gene_id": "ENSG00000213341",
+            "hgnc_id": 1974,
+            "consequence_terms": [
+                "non_coding_transcript_exon_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000590930",
+            "hgvsc": "ENST00000590930.1:n.1921del",
+            "variant_allele": "-",
+            "gene_symbol": "CHUK",
+            "gene_id": "ENSG00000213341",
+            "hgnc_id": 1974,
+            "consequence_terms": [
+                "non_coding_transcript_exon_variant"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/11_g.62393546_62393547delGGinsAA.json
+++ b/service/src/test/resources/variant/11_g.62393546_62393547delGGinsAA.json
@@ -1,0 +1,188 @@
+{
+    "variant": "11:g.62393546_62393547delGGinsAA",
+    "id": "11:g.62393546_62393547delGGinsAA",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "11",
+    "start": 62393546,
+    "end": 62393547,
+    "allele_string": "GG/AA",
+    "strand": 1,
+    "most_severe_consequence": "stop_gained",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000265471",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000265471",
+            "gene_symbol": "B3GAT3",
+            "gene_id": "ENSG00000149541",
+            "hgnc_id": 923,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_012200.3"
+            ],
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000346178",
+            "hgvsp": "ENSP00000340466.4:p.Gln928Ter",
+            "hgvsc": "ENST00000346178.4:c.2781_2782delinsTT",
+            "variant_allele": "AA",
+            "codons": "ctCCag/ctTTag",
+            "protein_id": "ENSP00000340466",
+            "protein_start": 927,
+            "protein_end": 928,
+            "gene_symbol": "GANAB",
+            "gene_id": "ENSG00000089597",
+            "amino_acids": "LQ/L*",
+            "hgnc_id": 4138,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_198335.3"
+            ],
+            "consequence_terms": [
+                "stop_gained"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000356638",
+            "hgvsp": "ENSP00000349053.3:p.Gln906Ter",
+            "hgvsc": "ENST00000356638.3:c.2715_2716delinsTT",
+            "variant_allele": "AA",
+            "codons": "ctCCag/ctTTag",
+            "protein_id": "ENSP00000349053",
+            "protein_start": 905,
+            "protein_end": 906,
+            "gene_symbol": "GANAB",
+            "gene_id": "ENSG00000089597",
+            "amino_acids": "LQ/L*",
+            "hgnc_id": 4138,
+            "refseq_transcript_ids": [
+                "NM_198334.2"
+            ],
+            "consequence_terms": [
+                "stop_gained"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000528503",
+            "hgvsc": "ENST00000528503.1:n.404_405delinsTT",
+            "variant_allele": "AA",
+            "gene_symbol": "GANAB",
+            "gene_id": "ENSG00000089597",
+            "hgnc_id": 4138,
+            "consequence_terms": [
+                "non_coding_transcript_exon_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000531383",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000431359",
+            "gene_symbol": "B3GAT3",
+            "gene_id": "ENSG00000149541",
+            "hgnc_id": 923,
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000531563",
+            "variant_allele": "AA",
+            "gene_symbol": "GANAB",
+            "gene_id": "ENSG00000089597",
+            "hgnc_id": 4138,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000532402",
+            "hgvsc": "ENST00000532402.1:c.*2447_*2448delinsTT",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000432181",
+            "gene_symbol": "GANAB",
+            "gene_id": "ENSG00000089597",
+            "hgnc_id": 4138,
+            "consequence_terms": [
+                "3_prime_UTR_variant",
+                "NMD_transcript_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000532585",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000432604",
+            "gene_symbol": "B3GAT3",
+            "gene_id": "ENSG00000149541",
+            "hgnc_id": 923,
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000534026",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000432474",
+            "gene_symbol": "B3GAT3",
+            "gene_id": "ENSG00000149541",
+            "hgnc_id": 923,
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000534715",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000432854",
+            "gene_symbol": "B3GAT3",
+            "gene_id": "ENSG00000149541",
+            "hgnc_id": 923,
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000534779",
+            "hgvsp": "ENSP00000435306.1:p.Gln814Ter",
+            "hgvsc": "ENST00000534779.1:c.2439_2440delinsTT",
+            "variant_allele": "AA",
+            "codons": "ctCCag/ctTTag",
+            "protein_id": "ENSP00000435306",
+            "protein_start": 813,
+            "protein_end": 814,
+            "gene_symbol": "GANAB",
+            "gene_id": "ENSG00000089597",
+            "amino_acids": "LQ/L*",
+            "hgnc_id": 4138,
+            "refseq_transcript_ids": [
+                "NM_001278193.1",
+                "NM_001278192.1"
+            ],
+            "consequence_terms": [
+                "stop_gained"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000540933",
+            "hgvsp": "ENSP00000442962.1:p.Gln809Ter",
+            "hgvsc": "ENST00000540933.1:c.2424_2425delinsTT",
+            "variant_allele": "AA",
+            "codons": "ctCCag/ctTTag",
+            "protein_id": "ENSP00000442962",
+            "protein_start": 808,
+            "protein_end": 809,
+            "gene_symbol": "GANAB",
+            "gene_id": "ENSG00000089597",
+            "amino_acids": "LQ/L*",
+            "hgnc_id": 4138,
+            "refseq_transcript_ids": [
+                "NM_001278194.1"
+            ],
+            "consequence_terms": [
+                "stop_gained"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/12_g.25398285C_A.json
+++ b/service/src/test/resources/variant/12_g.25398285C_A.json
@@ -1,0 +1,104 @@
+{
+    "variant": "12:g.25398285C>A",
+    "id": "12:g.25398285C>A",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "12",
+    "start": 25398285,
+    "end": 25398285,
+    "allele_string": "C/A",
+    "strand": 1,
+    "most_severe_consequence": "missense_variant",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000256078",
+            "hgvsp": "ENSP00000256078.4:p.Gly12Cys",
+            "hgvsc": "ENST00000256078.4:c.34G>T",
+            "variant_allele": "A",
+            "codons": "Ggt/Tgt",
+            "protein_id": "ENSP00000256078",
+            "protein_start": 12,
+            "protein_end": 12,
+            "gene_symbol": "KRAS",
+            "gene_id": "ENSG00000133703",
+            "amino_acids": "G/C",
+            "hgnc_id": 6407,
+            "canonical": "1",
+            "polyphen_score": 0.991,
+            "polyphen_prediction": "probably_damaging",
+            "sift_score": 0.04,
+            "sift_prediction": "deleterious",
+            "refseq_transcript_ids": [
+                "NM_033360.2"
+            ],
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000311936",
+            "hgvsp": "ENSP00000308495.3:p.Gly12Cys",
+            "hgvsc": "ENST00000311936.3:c.34G>T",
+            "variant_allele": "A",
+            "codons": "Ggt/Tgt",
+            "protein_id": "ENSP00000308495",
+            "protein_start": 12,
+            "protein_end": 12,
+            "gene_symbol": "KRAS",
+            "gene_id": "ENSG00000133703",
+            "amino_acids": "G/C",
+            "hgnc_id": 6407,
+            "polyphen_score": 0.99,
+            "polyphen_prediction": "probably_damaging",
+            "sift_score": 0.02,
+            "sift_prediction": "deleterious",
+            "refseq_transcript_ids": [
+                "NM_004985.3"
+            ],
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000556131",
+            "hgvsp": "ENSP00000451856.1:p.Gly12Cys",
+            "hgvsc": "ENST00000556131.1:c.34G>T",
+            "variant_allele": "A",
+            "codons": "Ggt/Tgt",
+            "protein_id": "ENSP00000451856",
+            "protein_start": 12,
+            "protein_end": 12,
+            "gene_symbol": "KRAS",
+            "gene_id": "ENSG00000133703",
+            "amino_acids": "G/C",
+            "hgnc_id": 6407,
+            "polyphen_score": 0.938,
+            "polyphen_prediction": "probably_damaging",
+            "sift_score": 0.03,
+            "sift_prediction": "deleterious",
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000557334",
+            "hgvsp": "ENSP00000452512.1:p.Gly12Cys",
+            "hgvsc": "ENST00000557334.1:c.34G>T",
+            "variant_allele": "A",
+            "codons": "Ggt/Tgt",
+            "protein_id": "ENSP00000452512",
+            "protein_start": 12,
+            "protein_end": 12,
+            "gene_symbol": "KRAS",
+            "gene_id": "ENSG00000133703",
+            "amino_acids": "G/C",
+            "hgnc_id": 6407,
+            "polyphen_score": 0.984,
+            "polyphen_prediction": "probably_damaging",
+            "sift_score": 0.02,
+            "sift_prediction": "deleterious_low_confidence",
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/13_g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG.json
+++ b/service/src/test/resources/variant/13_g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG.json
@@ -1,0 +1,86 @@
+{
+    "variant": "13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG",
+    "id": "13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "13",
+    "start": 28608258,
+    "end": 28608275,
+    "allele_string": "CATATTCATATTCTCTGA/GGGGTGGGGGGG",
+    "strand": 1,
+    "most_severe_consequence": "protein_altering_variant",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000241453",
+            "hgvsp": "ENSP00000241453.7:p.Phe594_Asp600delinsSerProProProHis",
+            "hgvsc": "ENST00000241453.7:c.1781_1798delinsCCCCCCCACCCC",
+            "variant_allele": "GGGGTGGGGGGG",
+            "codons": "tTCAGAGAATATGAATATGat/tCCCCCCCACCCCat",
+            "protein_id": "ENSP00000241453",
+            "protein_start": 594,
+            "protein_end": 600,
+            "gene_symbol": "FLT3",
+            "gene_id": "ENSG00000122025",
+            "amino_acids": "FREYEYD/SPPPH",
+            "hgnc_id": 3765,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_004119.2"
+            ],
+            "consequence_terms": [
+                "protein_altering_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000380982",
+            "hgvsp": "ENSP00000370369.4:p.Phe594_Asp600delinsSerProProProHis",
+            "hgvsc": "ENST00000380982.4:c.1781_1798delinsCCCCCCCACCCC",
+            "variant_allele": "GGGGTGGGGGGG",
+            "codons": "tTCAGAGAATATGAATATGat/tCCCCCCCACCCCat",
+            "protein_id": "ENSP00000370369",
+            "protein_start": 594,
+            "protein_end": 600,
+            "gene_symbol": "FLT3",
+            "gene_id": "ENSG00000122025",
+            "amino_acids": "FREYEYD/SPPPH",
+            "hgnc_id": 3765,
+            "consequence_terms": [
+                "protein_altering_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000380987",
+            "hgvsp": "ENSP00000370374.2:p.Phe594_Asp600delinsSerProProProHis",
+            "hgvsc": "ENST00000380987.2:c.1781_1798delinsCCCCCCCACCCC",
+            "variant_allele": "GGGGTGGGGGGG",
+            "codons": "tTCAGAGAATATGAATATGat/tCCCCCCCACCCCat",
+            "protein_id": "ENSP00000370374",
+            "protein_start": 594,
+            "protein_end": 600,
+            "gene_symbol": "FLT3",
+            "gene_id": "ENSG00000122025",
+            "amino_acids": "FREYEYD/SPPPH",
+            "hgnc_id": 3765,
+            "consequence_terms": [
+                "protein_altering_variant",
+                "NMD_transcript_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000537084",
+            "hgvsp": "ENSP00000438139.1:p.Phe594_Asp600delinsSerProProProHis",
+            "hgvsc": "ENST00000537084.1:c.1781_1798delinsCCCCCCCACCCC",
+            "variant_allele": "GGGGTGGGGGGG",
+            "codons": "tTCAGAGAATATGAATATGat/tCCCCCCCACCCCat",
+            "protein_id": "ENSP00000438139",
+            "protein_start": 594,
+            "protein_end": 600,
+            "gene_symbol": "FLT3",
+            "gene_id": "ENSG00000122025",
+            "amino_acids": "FREYEYD/SPPPH",
+            "hgnc_id": 3765,
+            "consequence_terms": [
+                "protein_altering_variant"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/16_g.9057113_9057114insCTG.json
+++ b/service/src/test/resources/variant/16_g.9057113_9057114insCTG.json
@@ -1,0 +1,88 @@
+{
+    "variant": "16:g.9057113_9057114insCTG",
+    "id": "16:g.9057113_9057114insCTG",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "16",
+    "start": 9057114,
+    "end": 9057113,
+    "allele_string": "-/CTG",
+    "strand": 1,
+    "most_severe_consequence": "protein_altering_variant",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000344836",
+            "hgvsp": "ENSP00000343535.4:p.Gln10delinsHisArg",
+            "hgvsc": "ENST00000344836.4:c.29_30insCAG",
+            "variant_allele": "CTG",
+            "codons": "cag/caCAGg",
+            "protein_id": "ENSP00000343535",
+            "protein_start": 10,
+            "protein_end": 10,
+            "gene_symbol": "USP7",
+            "gene_id": "ENSG00000187555",
+            "amino_acids": "Q/HR",
+            "hgnc_id": 12630,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_003470.2",
+                "NM_001286458.1"
+            ],
+            "consequence_terms": [
+                "protein_altering_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000563961",
+            "hgvsp": "ENSP00000454362.1:p.Gln10delinsHisArg",
+            "hgvsc": "ENST00000563961.1:c.29_30insCAG",
+            "variant_allele": "CTG",
+            "codons": "cag/caCAGg",
+            "protein_id": "ENSP00000454362",
+            "protein_start": 10,
+            "protein_end": 10,
+            "gene_symbol": "USP7",
+            "gene_id": "ENSG00000187555",
+            "amino_acids": "Q/HR",
+            "hgnc_id": 12630,
+            "consequence_terms": [
+                "protein_altering_variant",
+                "NMD_transcript_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000564485",
+            "hgvsc": "ENST00000564485.1:n.189+362_189+363insCTG",
+            "variant_allele": "CTG",
+            "gene_symbol": "RP11-77H9.8",
+            "gene_id": "ENSG00000260979",
+            "canonical": "1",
+            "consequence_terms": [
+                "intron_variant",
+                "non_coding_transcript_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000566273",
+            "variant_allele": "CTG",
+            "protein_id": "ENSP00000455719",
+            "gene_symbol": "USP7",
+            "gene_id": "ENSG00000187555",
+            "hgnc_id": 12630,
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000569230",
+            "hgvsc": "ENST00000569230.1:c.-96+1137_-96+1138insCAG",
+            "variant_allele": "CTG",
+            "protein_id": "ENSP00000457237",
+            "gene_symbol": "USP7",
+            "gene_id": "ENSG00000187555",
+            "hgnc_id": 12630,
+            "consequence_terms": [
+                "intron_variant"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/19_g.46141892_46141893delTCinsAA.json
+++ b/service/src/test/resources/variant/19_g.46141892_46141893delTCinsAA.json
@@ -1,0 +1,319 @@
+{
+    "variant": "19:g.46141892_46141893delTCinsAA",
+    "id": "19:g.46141892_46141893delTCinsAA",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "19",
+    "start": 46141892,
+    "end": 46141893,
+    "allele_string": "TC/AA",
+    "strand": 1,
+    "most_severe_consequence": "splice_acceptor_variant",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000245925",
+            "hgvsc": "ENST00000245925.3:c.50-1_50delinsTT",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000245925",
+            "protein_end": 17,
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "refseq_transcript_ids": [
+                "NM_012155.2"
+            ],
+            "consequence_terms": [
+                "splice_acceptor_variant",
+                "coding_sequence_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000362196",
+            "variant_allele": "AA",
+            "gene_symbol": "MIR330",
+            "gene_id": "ENSG00000199066",
+            "hgnc_id": 31771,
+            "canonical": "1",
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000399594",
+            "hgvsc": "ENST00000399594.3:c.524-1_524delinsTT",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000382503",
+            "protein_end": 175,
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "consequence_terms": [
+                "splice_acceptor_variant",
+                "coding_sequence_variant",
+                "NMD_transcript_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000536630",
+            "hgvsc": "ENST00000536630.1:c.491-1_491delinsTT",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000442365",
+            "protein_end": 164,
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "refseq_transcript_ids": [
+                "NM_001193269.1"
+            ],
+            "consequence_terms": [
+                "splice_acceptor_variant",
+                "coding_sequence_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000585386",
+            "variant_allele": "AA",
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000586195",
+            "hgvsc": "ENST00000586195.1:c.49+210_49+211delinsTT",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000465339",
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "consequence_terms": [
+                "intron_variant",
+                "NMD_transcript_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000586770",
+            "hgvsc": "ENST00000586770.1:c.-17-1_-17delinsTT",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000465786",
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "consequence_terms": [
+                "splice_acceptor_variant",
+                "5_prime_UTR_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000587092",
+            "variant_allele": "AA",
+            "gene_symbol": "C19orf83",
+            "gene_id": "ENSG00000267757",
+            "hgnc_id": 48331,
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000587152",
+            "hgvsc": "ENST00000587152.1:c.653-1_653delinsTT",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000468312",
+            "protein_end": 218,
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_001193268.1"
+            ],
+            "consequence_terms": [
+                "splice_acceptor_variant",
+                "coding_sequence_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000587804",
+            "variant_allele": "AA",
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000588000",
+            "hgvsc": "ENST00000588000.1:n.75-1_75delinsTT",
+            "variant_allele": "AA",
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "consequence_terms": [
+                "splice_acceptor_variant",
+                "non_coding_transcript_exon_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000588172",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000468768",
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000588308",
+            "hgvsc": "ENST00000588308.1:c.50-1_50delinsTT",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000468329",
+            "protein_end": 17,
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "consequence_terms": [
+                "splice_acceptor_variant",
+                "coding_sequence_variant",
+                "NMD_transcript_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000588420",
+            "variant_allele": "AA",
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000588610",
+            "hgvsc": "ENST00000588610.1:n.71-1_71delinsTT",
+            "variant_allele": "AA",
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "consequence_terms": [
+                "splice_acceptor_variant",
+                "non_coding_transcript_exon_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000588889",
+            "hgvsc": "ENST00000588889.1:n.507-1_507delinsTT",
+            "variant_allele": "AA",
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "consequence_terms": [
+                "splice_acceptor_variant",
+                "non_coding_transcript_exon_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000589876",
+            "hgvsc": "ENST00000589876.1:c.50-1_50delinsTT",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000464789",
+            "protein_end": 17,
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "consequence_terms": [
+                "splice_acceptor_variant",
+                "coding_sequence_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000590018",
+            "hgvsc": "ENST00000590018.1:c.-18_-17delinsTT",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000468373",
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "consequence_terms": [
+                "5_prime_UTR_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000590043",
+            "hgvsc": "ENST00000590043.1:c.-17-1_-17delinsTT",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000464804",
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "consequence_terms": [
+                "splice_acceptor_variant",
+                "5_prime_UTR_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000591087",
+            "variant_allele": "AA",
+            "gene_symbol": "C19orf83",
+            "gene_id": "ENSG00000267757",
+            "hgnc_id": 48331,
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000591721",
+            "hgvsc": "ENST00000591721.1:c.-17-1_-17delinsTT",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000468470",
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "consequence_terms": [
+                "splice_acceptor_variant",
+                "5_prime_UTR_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000592901",
+            "variant_allele": "AA",
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000593161",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000464956",
+            "gene_symbol": "C19orf83",
+            "gene_id": "ENSG00000267757",
+            "hgnc_id": 48331,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_001242348.1"
+            ],
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000593255",
+            "hgvsc": "ENST00000593255.1:c.-17-1_-17delinsTT",
+            "variant_allele": "AA",
+            "protein_id": "ENSP00000467941",
+            "gene_symbol": "EML2",
+            "gene_id": "ENSG00000125746",
+            "hgnc_id": 18035,
+            "consequence_terms": [
+                "splice_acceptor_variant",
+                "5_prime_UTR_variant"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/1_g.65325832_65325833insG.json
+++ b/service/src/test/resources/variant/1_g.65325832_65325833insG.json
@@ -1,0 +1,45 @@
+{
+    "variant": "1:g.65325832_65325833insG",
+    "id": "1:g.65325832_65325833insG",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "1",
+    "start": 65325833,
+    "end": 65325832,
+    "allele_string": "-/G",
+    "strand": 1,
+    "most_severe_consequence": "frameshift_variant",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000342505",
+            "hgvsp": "ENSP00000343204.4:p.Leu431ValfsTer22",
+            "hgvsc": "ENST00000342505.4:c.1289dup",
+            "variant_allele": "G",
+            "codons": "ccg/ccCg",
+            "protein_id": "ENSP00000343204",
+            "protein_start": 430,
+            "protein_end": 430,
+            "gene_symbol": "JAK1",
+            "gene_id": "ENSG00000162434",
+            "amino_acids": "P/PX",
+            "hgnc_id": 6190,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_002227.2"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000494904",
+            "hgvsc": "ENST00000494904.1:n.183dup",
+            "variant_allele": "G",
+            "gene_symbol": "JAK1",
+            "gene_id": "ENSG00000162434",
+            "hgnc_id": 6190,
+            "consequence_terms": [
+                "non_coding_transcript_exon_variant"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/22_g.29091840_29091841delTGinsCA.json
+++ b/service/src/test/resources/variant/22_g.29091840_29091841delTGinsCA.json
@@ -1,0 +1,348 @@
+{
+    "variant": "22:g.29091840_29091841delTGinsCA",
+    "id": "22:g.29091840_29091841delTGinsCA",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "22",
+    "start": 29091840,
+    "end": 29091841,
+    "allele_string": "TG/CA",
+    "strand": 1,
+    "most_severe_consequence": "missense_variant",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000328354",
+            "hgvsp": "ENSP00000329178.6:p.Lys373Glu",
+            "hgvsc": "ENST00000328354.6:c.1116_1117inv",
+            "variant_allele": "CA",
+            "codons": "tcCAag/tcTGag",
+            "protein_id": "ENSP00000329178",
+            "protein_start": 372,
+            "protein_end": 373,
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "amino_acids": "SK/SE",
+            "hgnc_id": 16627,
+            "refseq_transcript_ids": [
+                "NM_007194.3"
+            ],
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000348295",
+            "hgvsp": "ENSP00000329012.5:p.Lys344Glu",
+            "hgvsc": "ENST00000348295.3:c.1029_1030inv",
+            "variant_allele": "CA",
+            "codons": "tcCAag/tcTGag",
+            "protein_id": "ENSP00000329012",
+            "protein_start": 343,
+            "protein_end": 344,
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "amino_acids": "SK/SE",
+            "hgnc_id": 16627,
+            "refseq_transcript_ids": [
+                "NM_145862.2"
+            ],
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000382565",
+            "hgvsc": "ENST00000382565.1:c.320-6587_320-6586inv",
+            "variant_allele": "CA",
+            "protein_id": "ENSP00000372006",
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "intron_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000382566",
+            "hgvsc": "ENST00000382566.1:c.*184_*185inv",
+            "variant_allele": "CA",
+            "protein_id": "ENSP00000372007",
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "3_prime_UTR_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000382578",
+            "hgvsp": "ENSP00000372021.1:p.Lys282Glu",
+            "hgvsc": "ENST00000382578.1:c.843_844inv",
+            "variant_allele": "CA",
+            "codons": "tcCAag/tcTGag",
+            "protein_id": "ENSP00000372021",
+            "protein_start": 281,
+            "protein_end": 282,
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "amino_acids": "SK/SE",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000382580",
+            "hgvsp": "ENSP00000372023.2:p.Lys416Glu",
+            "hgvsc": "ENST00000382580.2:c.1245_1246inv",
+            "variant_allele": "CA",
+            "codons": "tcCAag/tcTGag",
+            "protein_id": "ENSP00000372023",
+            "protein_start": 415,
+            "protein_end": 416,
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "amino_acids": "SK/SE",
+            "hgnc_id": 16627,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_001005735.1"
+            ],
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000402731",
+            "hgvsp": "ENSP00000384835.1:p.Lys344Glu",
+            "hgvsc": "ENST00000402731.1:c.1029_1030inv",
+            "variant_allele": "CA",
+            "codons": "tcCAag/tcTGag",
+            "protein_id": "ENSP00000384835",
+            "protein_start": 343,
+            "protein_end": 344,
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "amino_acids": "SK/SE",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000403642",
+            "hgvsp": "ENSP00000384919.1:p.Lys282Glu",
+            "hgvsc": "ENST00000403642.1:c.843_844inv",
+            "variant_allele": "CA",
+            "codons": "tcCAag/tcTGag",
+            "protein_id": "ENSP00000384919",
+            "protein_start": 281,
+            "protein_end": 282,
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "amino_acids": "SK/SE",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000404276",
+            "hgvsp": "ENSP00000385747.1:p.Lys373Glu",
+            "hgvsc": "ENST00000404276.1:c.1116_1117inv",
+            "variant_allele": "CA",
+            "codons": "tcCAag/tcTGag",
+            "protein_id": "ENSP00000385747",
+            "protein_start": 372,
+            "protein_end": 373,
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "amino_acids": "SK/SE",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000405598",
+            "hgvsp": "ENSP00000386087.1:p.Lys373Glu",
+            "hgvsc": "ENST00000405598.1:c.1116_1117inv",
+            "variant_allele": "CA",
+            "codons": "tcCAag/tcTGag",
+            "protein_id": "ENSP00000386087",
+            "protein_start": 372,
+            "protein_end": 373,
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "amino_acids": "SK/SE",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000416671",
+            "hgvsc": "ENST00000416671.1:c.*606_*607inv",
+            "variant_allele": "CA",
+            "protein_id": "ENSP00000402225",
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "3_prime_UTR_variant",
+                "NMD_transcript_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000417588",
+            "hgvsc": "ENST00000417588.1:c.*413_*414inv",
+            "variant_allele": "CA",
+            "protein_id": "ENSP00000412901",
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "3_prime_UTR_variant",
+                "NMD_transcript_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000425190",
+            "variant_allele": "CA",
+            "protein_id": "ENSP00000390244",
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000433028",
+            "variant_allele": "CA",
+            "protein_id": "ENSP00000403659",
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000433728",
+            "hgvsc": "ENST00000433728.1:c.*184_*185inv",
+            "variant_allele": "CA",
+            "protein_id": "ENSP00000404400",
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "3_prime_UTR_variant",
+                "NMD_transcript_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000434810",
+            "hgvsp": "ENSP00000416721.1:p.Lys117Glu",
+            "hgvsc": "ENST00000434810.1:c.347_348inv",
+            "variant_allele": "CA",
+            "codons": "tcCAag/tcTGag",
+            "protein_id": "ENSP00000416721",
+            "protein_start": 116,
+            "protein_end": 117,
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "amino_acids": "SK/SE",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000439346",
+            "variant_allele": "CA",
+            "protein_id": "ENSP00000396903",
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000447421",
+            "variant_allele": "CA",
+            "protein_id": "ENSP00000397478",
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000448511",
+            "hgvsc": "ENST00000448511.1:c.*508_*509inv",
+            "variant_allele": "CA",
+            "protein_id": "ENSP00000404567",
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "3_prime_UTR_variant",
+                "NMD_transcript_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000456369",
+            "hgvsc": "ENST00000456369.1:c.263+3985_263+3986inv",
+            "variant_allele": "CA",
+            "protein_id": "ENSP00000394430",
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "intron_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000464581",
+            "variant_allele": "CA",
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000491919",
+            "variant_allele": "CA",
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "hgnc_id": 16627,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000544772",
+            "hgvsp": "ENSP00000442458.1:p.Lys152Glu",
+            "hgvsc": "ENST00000544772.1:c.453_454inv",
+            "variant_allele": "CA",
+            "codons": "tcCAag/tcTGag",
+            "protein_id": "ENSP00000442458",
+            "protein_start": 151,
+            "protein_end": 152,
+            "gene_symbol": "CHEK2",
+            "gene_id": "ENSG00000183765",
+            "amino_acids": "SK/SE",
+            "hgnc_id": 16627,
+            "refseq_transcript_ids": [
+                "NM_001257387.1"
+            ],
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/22_g.36689419_36689421delCCT.json
+++ b/service/src/test/resources/variant/22_g.36689419_36689421delCCT.json
@@ -1,0 +1,44 @@
+{
+    "variant": "22:g.36689419_36689421delCCT",
+    "id": "22:g.36689419_36689421delCCT",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "22",
+    "start": 36689419,
+    "end": 36689421,
+    "allele_string": "CCT/-",
+    "strand": 1,
+    "most_severe_consequence": "inframe_deletion",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000216181",
+            "hgvsp": "ENSP00000216181.5:p.Glu1350del",
+            "hgvsc": "ENST00000216181.5:c.4049_4051del",
+            "variant_allele": "-",
+            "codons": "gAGGcc/gcc",
+            "protein_id": "ENSP00000216181",
+            "protein_start": 1350,
+            "protein_end": 1351,
+            "gene_symbol": "MYH9",
+            "gene_id": "ENSG00000100345",
+            "amino_acids": "EA/A",
+            "hgnc_id": 7579,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_002473.4"
+            ],
+            "consequence_terms": [
+                "inframe_deletion"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000459960",
+            "variant_allele": "-",
+            "gene_symbol": "MYH9",
+            "gene_id": "ENSG00000100345",
+            "hgnc_id": 7579,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/3_g.114058003_114058003delG.json
+++ b/service/src/test/resources/variant/3_g.114058003_114058003delG.json
@@ -1,0 +1,164 @@
+{
+    "variant": "3:g.114058003_114058003delG",
+    "id": "3:g.114058003_114058003delG",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "3",
+    "start": 114058003,
+    "end": 114058003,
+    "allele_string": "G/-",
+    "strand": 1,
+    "most_severe_consequence": "frameshift_variant",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000357258",
+            "hgvsp": "ENSP00000349803.3:p.Pro619LeufsTer43",
+            "hgvsc": "ENST00000357258.3:c.1856del",
+            "variant_allele": "-",
+            "codons": "cCt/ct",
+            "protein_id": "ENSP00000349803",
+            "protein_start": 619,
+            "protein_end": 619,
+            "gene_symbol": "ZBTB20",
+            "gene_id": "ENSG00000181722",
+            "amino_acids": "P/X",
+            "hgnc_id": 13503,
+            "refseq_transcript_ids": [
+                "NM_015642.4"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000393785",
+            "hgvsp": "ENSP00000377375.2:p.Pro619LeufsTer43",
+            "hgvsc": "ENST00000393785.2:c.1856del",
+            "variant_allele": "-",
+            "codons": "cCt/ct",
+            "protein_id": "ENSP00000377375",
+            "protein_start": 619,
+            "protein_end": 619,
+            "gene_symbol": "ZBTB20",
+            "gene_id": "ENSG00000181722",
+            "amino_acids": "P/X",
+            "hgnc_id": 13503,
+            "refseq_transcript_ids": [
+                "NM_001164346.1"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000462705",
+            "hgvsp": "ENSP00000420324.1:p.Pro619LeufsTer43",
+            "hgvsc": "ENST00000462705.1:c.1856del",
+            "variant_allele": "-",
+            "codons": "cCt/ct",
+            "protein_id": "ENSP00000420324",
+            "protein_start": 619,
+            "protein_end": 619,
+            "gene_symbol": "ZBTB20",
+            "gene_id": "ENSG00000181722",
+            "amino_acids": "P/X",
+            "hgnc_id": 13503,
+            "refseq_transcript_ids": [
+                "NM_001164343.1"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000464560",
+            "hgvsp": "ENSP00000417307.1:p.Pro619LeufsTer43",
+            "hgvsc": "ENST00000464560.1:c.1856del",
+            "variant_allele": "-",
+            "codons": "cCt/ct",
+            "protein_id": "ENSP00000417307",
+            "protein_start": 619,
+            "protein_end": 619,
+            "gene_symbol": "ZBTB20",
+            "gene_id": "ENSG00000181722",
+            "amino_acids": "P/X",
+            "hgnc_id": 13503,
+            "refseq_transcript_ids": [
+                "NM_001164344.1"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000471418",
+            "hgvsp": "ENSP00000419902.1:p.Pro619LeufsTer43",
+            "hgvsc": "ENST00000471418.1:c.1856del",
+            "variant_allele": "-",
+            "codons": "cCt/ct",
+            "protein_id": "ENSP00000419902",
+            "protein_start": 619,
+            "protein_end": 619,
+            "gene_symbol": "ZBTB20",
+            "gene_id": "ENSG00000181722",
+            "amino_acids": "P/X",
+            "hgnc_id": 13503,
+            "refseq_transcript_ids": [
+                "NM_001164345.1"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000474710",
+            "hgvsp": "ENSP00000419153.1:p.Pro692LeufsTer43",
+            "hgvsc": "ENST00000474710.1:c.2075del",
+            "variant_allele": "-",
+            "codons": "cCt/ct",
+            "protein_id": "ENSP00000419153",
+            "protein_start": 692,
+            "protein_end": 692,
+            "gene_symbol": "ZBTB20",
+            "gene_id": "ENSG00000181722",
+            "amino_acids": "P/X",
+            "hgnc_id": 13503,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_001164342.1"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000479879",
+            "variant_allele": "-",
+            "gene_symbol": "ZBTB20",
+            "gene_id": "ENSG00000181722",
+            "hgnc_id": 13503,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000481632",
+            "hgvsp": "ENSP00000418092.1:p.Pro619LeufsTer43",
+            "hgvsc": "ENST00000481632.1:c.1856del",
+            "variant_allele": "-",
+            "codons": "cCt/ct",
+            "protein_id": "ENSP00000418092",
+            "protein_start": 619,
+            "protein_end": 619,
+            "gene_symbol": "ZBTB20",
+            "gene_id": "ENSG00000181722",
+            "amino_acids": "P/X",
+            "hgnc_id": 13503,
+            "refseq_transcript_ids": [
+                "NM_001164347.1"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/3_g.14106026_14106037delCCAGCAGTAGCT.json
+++ b/service/src/test/resources/variant/3_g.14106026_14106037delCCAGCAGTAGCT.json
@@ -1,0 +1,171 @@
+{
+    "variant": "3:g.14106026_14106037delCCAGCAGTAGCT",
+    "id": "3:g.14106026_14106037delCCAGCAGTAGCT",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "3",
+    "start": 14106026,
+    "end": 14106037,
+    "allele_string": "CCAGCAGTAGCT/-",
+    "strand": 1,
+    "most_severe_consequence": "inframe_deletion",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000326972",
+            "hgvsp": "ENSP00000322097.8:p.Ser124_Ser127del",
+            "hgvsc": "ENST00000326972.8:c.357_368del",
+            "variant_allele": "-",
+            "codons": "cCCAGCAGTAGCTcc/ccc",
+            "protein_id": "ENSP00000322097",
+            "protein_start": 117,
+            "protein_end": 121,
+            "gene_symbol": "TPRXL",
+            "gene_id": "ENSG00000180438",
+            "amino_acids": "PSSSS/P",
+            "hgnc_id": 32178,
+            "consequence_terms": [
+                "inframe_deletion"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000424053",
+            "hgvsp": "ENSP00000400448.1:p.Ser124_Ser127del",
+            "hgvsc": "ENST00000424053.1:c.357_368del",
+            "variant_allele": "-",
+            "codons": "cCCAGCAGTAGCTcc/ccc",
+            "protein_id": "ENSP00000400448",
+            "protein_start": 117,
+            "protein_end": 121,
+            "gene_symbol": "TPRXL",
+            "gene_id": "ENSG00000180438",
+            "amino_acids": "PSSSS/P",
+            "hgnc_id": 32178,
+            "canonical": "1",
+            "consequence_terms": [
+                "inframe_deletion"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000429201",
+            "hgvsp": "ENSP00000400824.1:p.Ser124_Ser127del",
+            "hgvsc": "ENST00000429201.1:c.357_368del",
+            "variant_allele": "-",
+            "codons": "cCCAGCAGTAGCTcc/ccc",
+            "protein_id": "ENSP00000400824",
+            "protein_start": 117,
+            "protein_end": 121,
+            "gene_symbol": "TPRXL",
+            "gene_id": "ENSG00000180438",
+            "amino_acids": "PSSSS/P",
+            "hgnc_id": 32178,
+            "consequence_terms": [
+                "inframe_deletion"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000524375",
+            "variant_allele": "-",
+            "protein_id": "ENSP00000435219",
+            "gene_symbol": "TPRXL",
+            "gene_id": "ENSG00000180438",
+            "hgnc_id": 32178,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000528040",
+            "variant_allele": "-",
+            "protein_id": "ENSP00000435511",
+            "gene_symbol": "TPRXL",
+            "gene_id": "ENSG00000180438",
+            "hgnc_id": 32178,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000528067",
+            "variant_allele": "-",
+            "protein_id": "ENSP00000435438",
+            "gene_symbol": "TPRXL",
+            "gene_id": "ENSG00000180438",
+            "hgnc_id": 32178,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000528312",
+            "variant_allele": "-",
+            "protein_id": "ENSP00000435227",
+            "gene_symbol": "TPRXL",
+            "gene_id": "ENSG00000180438",
+            "hgnc_id": 32178,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000529129",
+            "variant_allele": "-",
+            "protein_id": "ENSP00000436919",
+            "gene_symbol": "TPRXL",
+            "gene_id": "ENSG00000180438",
+            "hgnc_id": 32178,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000530586",
+            "variant_allele": "-",
+            "protein_id": "ENSP00000435853",
+            "gene_symbol": "TPRXL",
+            "gene_id": "ENSG00000180438",
+            "hgnc_id": 32178,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000532753",
+            "hgvsc": "ENST00000532753.1:n.324+1025_324+1036del",
+            "variant_allele": "-",
+            "gene_symbol": "TPRXL",
+            "gene_id": "ENSG00000180438",
+            "hgnc_id": 32178,
+            "consequence_terms": [
+                "intron_variant",
+                "non_coding_transcript_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000532880",
+            "variant_allele": "-",
+            "protein_id": "ENSP00000437227",
+            "gene_symbol": "TPRXL",
+            "gene_id": "ENSG00000180438",
+            "hgnc_id": 32178,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000532924",
+            "hgvsp": "ENSP00000432662.1:p.Ser124_Ser127del",
+            "hgvsc": "ENST00000532924.1:c.357_368del",
+            "variant_allele": "-",
+            "codons": "cCCAGCAGTAGCTcc/ccc",
+            "protein_id": "ENSP00000432662",
+            "protein_start": 117,
+            "protein_end": 121,
+            "gene_symbol": "TPRXL",
+            "gene_id": "ENSG00000180438",
+            "amino_acids": "PSSSS/P",
+            "hgnc_id": 32178,
+            "consequence_terms": [
+                "inframe_deletion"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/3_g.14940279_14940280insCAT.json
+++ b/service/src/test/resources/variant/3_g.14940279_14940280insCAT.json
@@ -1,0 +1,90 @@
+{
+    "variant": "3:g.14940279_14940280insCAT",
+    "id": "3:g.14940279_14940280insCAT",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "3",
+    "start": 14940280,
+    "end": 14940279,
+    "allele_string": "-/CAT",
+    "strand": 1,
+    "most_severe_consequence": "protein_altering_variant",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000285046",
+            "hgvsp": "ENSP00000285046.5:p.His1034delinsProTyr",
+            "hgvsc": "ENST00000285046.5:c.3100_3101insCAT",
+            "variant_allele": "CAT",
+            "codons": "cat/cCATat",
+            "protein_id": "ENSP00000285046",
+            "protein_start": 1034,
+            "protein_end": 1034,
+            "gene_symbol": "FGD5",
+            "gene_id": "ENSG00000154783",
+            "amino_acids": "H/PY",
+            "hgnc_id": 19117,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_152536.3"
+            ],
+            "consequence_terms": [
+                "protein_altering_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000457774",
+            "hgvsp": "ENSP00000394827.1:p.His218delinsProTyr",
+            "hgvsc": "ENST00000457774.1:c.650_651insCAT",
+            "variant_allele": "CAT",
+            "codons": "cat/cCATat",
+            "protein_id": "ENSP00000394827",
+            "protein_start": 218,
+            "protein_end": 218,
+            "gene_symbol": "FGD5",
+            "gene_id": "ENSG00000154783",
+            "amino_acids": "H/PY",
+            "hgnc_id": 19117,
+            "consequence_terms": [
+                "protein_altering_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000468662",
+            "hgvsc": "ENST00000468662.1:n.402_403insCAT",
+            "variant_allele": "CAT",
+            "gene_symbol": "FGD5",
+            "gene_id": "ENSG00000154783",
+            "hgnc_id": 19117,
+            "consequence_terms": [
+                "non_coding_transcript_exon_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000476851",
+            "hgvsc": "ENST00000476851.1:n.637_638insCAT",
+            "variant_allele": "CAT",
+            "gene_symbol": "FGD5",
+            "gene_id": "ENSG00000154783",
+            "hgnc_id": 19117,
+            "consequence_terms": [
+                "non_coding_transcript_exon_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000543601",
+            "hgvsp": "ENSP00000445949.1:p.His793delinsProTyr",
+            "hgvsc": "ENST00000543601.1:c.2377_2378insCAT",
+            "variant_allele": "CAT",
+            "codons": "cat/cCATat",
+            "protein_id": "ENSP00000445949",
+            "protein_start": 793,
+            "protein_end": 793,
+            "gene_symbol": "FGD5",
+            "gene_id": "ENSG00000154783",
+            "amino_acids": "H/PY",
+            "hgnc_id": 19117,
+            "consequence_terms": [
+                "protein_altering_variant"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/4_g.77675978_77675979insC.json
+++ b/service/src/test/resources/variant/4_g.77675978_77675979insC.json
@@ -1,0 +1,64 @@
+{
+    "variant": "4:g.77675978_77675979insC",
+    "id": "4:g.77675978_77675979insC",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "4",
+    "start": 77675979,
+    "end": 77675978,
+    "allele_string": "-/C",
+    "strand": 1,
+    "most_severe_consequence": "frameshift_variant",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000296043",
+            "hgvsp": "ENSP00000296043.6:p.Asp1450Ter",
+            "hgvsc": "ENST00000296043.6:c.4346dup",
+            "variant_allele": "C",
+            "codons": "gcc/gCcc",
+            "protein_id": "ENSP00000296043",
+            "protein_start": 1448,
+            "protein_end": 1448,
+            "gene_symbol": "SHROOM3",
+            "gene_id": "ENSG00000138771",
+            "amino_acids": "A/AX",
+            "hgnc_id": 30422,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_020859.3"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000449007",
+            "variant_allele": "C",
+            "gene_symbol": "RP11-359D14.3",
+            "gene_id": "ENSG00000224218",
+            "canonical": "1",
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000452412",
+            "variant_allele": "C",
+            "gene_symbol": "RP11-359D14.2",
+            "gene_id": "ENSG00000233860",
+            "canonical": "1",
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000469923",
+            "variant_allele": "C",
+            "gene_symbol": "SHROOM3",
+            "gene_id": "ENSG00000138771",
+            "hgnc_id": 30422,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/4_g.9784947_9784948insAGA.json
+++ b/service/src/test/resources/variant/4_g.9784947_9784948insAGA.json
@@ -1,0 +1,58 @@
+{
+    "variant": "4:g.9784947_9784948insAGA",
+    "id": "4:g.9784947_9784948insAGA",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "4",
+    "start": 9784948,
+    "end": 9784947,
+    "allele_string": "-/AGA",
+    "strand": 1,
+    "most_severe_consequence": "protein_altering_variant",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000304374",
+            "hgvsp": "ENSP00000306129.2:p.Gly432delinsGluSer",
+            "hgvsc": "ENST00000304374.2:c.1294_1295insAGA",
+            "variant_allele": "AGA",
+            "codons": "ggt/gAGAgt",
+            "protein_id": "ENSP00000306129",
+            "protein_start": 432,
+            "protein_end": 432,
+            "gene_symbol": "DRD5",
+            "gene_id": "ENSG00000169676",
+            "amino_acids": "G/ES",
+            "hgnc_id": 3026,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_000798.4"
+            ],
+            "consequence_terms": [
+                "protein_altering_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000503803",
+            "hgvsc": "ENST00000503803.1:n.386-3259_386-3258insTCT",
+            "variant_allele": "AGA",
+            "gene_symbol": "SLC2A9",
+            "gene_id": "ENSG00000109667",
+            "hgnc_id": 13446,
+            "consequence_terms": [
+                "intron_variant",
+                "non_coding_transcript_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000508585",
+            "hgvsc": "ENST00000508585.1:n.182-11955_182-11954insTCT",
+            "variant_allele": "AGA",
+            "gene_symbol": "SLC2A9",
+            "gene_id": "ENSG00000109667",
+            "hgnc_id": 13446,
+            "consequence_terms": [
+                "intron_variant",
+                "non_coding_transcript_variant"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/6_g.137519505_137519506delCT.json
+++ b/service/src/test/resources/variant/6_g.137519505_137519506delCT.json
@@ -1,0 +1,51 @@
+{
+    "variant": "6:g.137519505_137519506delCT",
+    "id": "6:g.137519505_137519506delCT",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "6",
+    "start": 137519505,
+    "end": 137519506,
+    "allele_string": "CT/-",
+    "strand": 1,
+    "most_severe_consequence": "frameshift_variant",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000367739",
+            "hgvsp": "ENSP00000356713.4:p.Ser378PhefsTer6",
+            "hgvsc": "ENST00000367739.4:c.1132_1133del",
+            "variant_allele": "-",
+            "codons": "AGt/t",
+            "protein_id": "ENSP00000356713",
+            "protein_start": 378,
+            "protein_end": 378,
+            "gene_symbol": "IFNGR1",
+            "gene_id": "ENSG00000027697",
+            "amino_acids": "S/X",
+            "hgnc_id": 5439,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_000416.2"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000543628",
+            "hgvsp": "ENSP00000443282.1:p.Ser350PhefsTer6",
+            "hgvsc": "ENST00000543628.1:c.1048_1049del",
+            "variant_allele": "-",
+            "codons": "AGt/t",
+            "protein_id": "ENSP00000443282",
+            "protein_start": 350,
+            "protein_end": 350,
+            "gene_symbol": "IFNGR1",
+            "gene_id": "ENSG00000027697",
+            "amino_acids": "S/X",
+            "hgnc_id": 5439,
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/6_g.137519505_137519506delCTinsA.json
+++ b/service/src/test/resources/variant/6_g.137519505_137519506delCTinsA.json
@@ -1,0 +1,51 @@
+{
+    "variant": "6:g.137519505_137519506delCTinsA",
+    "id": "6:g.137519505_137519506delCTinsA",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "6",
+    "start": 137519505,
+    "end": 137519506,
+    "allele_string": "CT/A",
+    "strand": 1,
+    "most_severe_consequence": "frameshift_variant",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000367739",
+            "hgvsp": "ENSP00000356713.4:p.Ser378PhefsTer5",
+            "hgvsc": "ENST00000367739.4:c.1132_1133delinsT",
+            "variant_allele": "A",
+            "codons": "AGt/Tt",
+            "protein_id": "ENSP00000356713",
+            "protein_start": 378,
+            "protein_end": 378,
+            "gene_symbol": "IFNGR1",
+            "gene_id": "ENSG00000027697",
+            "amino_acids": "S/X",
+            "hgnc_id": 5439,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_000416.2"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000543628",
+            "hgvsp": "ENSP00000443282.1:p.Ser350PhefsTer5",
+            "hgvsc": "ENST00000543628.1:c.1048_1049delinsT",
+            "variant_allele": "A",
+            "codons": "AGt/Tt",
+            "protein_id": "ENSP00000443282",
+            "protein_start": 350,
+            "protein_end": 350,
+            "gene_symbol": "IFNGR1",
+            "gene_id": "ENSG00000027697",
+            "amino_acids": "S/X",
+            "hgnc_id": 5439,
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/7_g.140453136A_T.json
+++ b/service/src/test/resources/variant/7_g.140453136A_T.json
@@ -1,0 +1,94 @@
+{
+    "variant": "7:g.140453136A>T",
+    "id": "7:g.140453136A>T",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "7",
+    "start": 140453136,
+    "end": 140453136,
+    "allele_string": "A/T",
+    "strand": 1,
+    "most_severe_consequence": "missense_variant",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000288602",
+            "hgvsp": "ENSP00000288602.6:p.Val600Glu",
+            "hgvsc": "ENST00000288602.6:c.1799T>A",
+            "variant_allele": "T",
+            "codons": "gTg/gAg",
+            "protein_id": "ENSP00000288602",
+            "protein_start": 600,
+            "protein_end": 600,
+            "gene_symbol": "BRAF",
+            "gene_id": "ENSG00000157764",
+            "amino_acids": "V/E",
+            "hgnc_id": 1097,
+            "canonical": "1",
+            "polyphen_score": 0.963,
+            "polyphen_prediction": "probably_damaging",
+            "sift_score": 0,
+            "sift_prediction": "deleterious",
+            "refseq_transcript_ids": [
+                "NM_004333.4"
+            ],
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000479537",
+            "hgvsp": "ENSP00000418033.1:p.Val28Glu",
+            "hgvsc": "ENST00000479537.1:c.83T>A",
+            "variant_allele": "T",
+            "codons": "gTg/gAg",
+            "protein_id": "ENSP00000418033",
+            "protein_start": 28,
+            "protein_end": 28,
+            "gene_symbol": "BRAF",
+            "gene_id": "ENSG00000157764",
+            "amino_acids": "V/E",
+            "hgnc_id": 1097,
+            "polyphen_score": 0.991,
+            "polyphen_prediction": "probably_damaging",
+            "sift_score": 0.01,
+            "sift_prediction": "deleterious",
+            "consequence_terms": [
+                "missense_variant",
+                "NMD_transcript_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000496384",
+            "hgvsp": "ENSP00000419060.1:p.Val208Glu",
+            "hgvsc": "ENST00000496384.2:c.622T>A",
+            "variant_allele": "T",
+            "codons": "gTg/gAg",
+            "protein_id": "ENSP00000419060",
+            "protein_start": 208,
+            "protein_end": 208,
+            "gene_symbol": "BRAF",
+            "gene_id": "ENSG00000157764",
+            "amino_acids": "V/E",
+            "hgnc_id": 1097,
+            "polyphen_score": 0.817,
+            "polyphen_prediction": "possibly_damaging",
+            "sift_score": 0,
+            "sift_prediction": "deleterious",
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000497784",
+            "hgvsc": "ENST00000497784.1:c.*1249T>A",
+            "variant_allele": "T",
+            "protein_id": "ENSP00000420119",
+            "gene_symbol": "BRAF",
+            "gene_id": "ENSG00000157764",
+            "hgnc_id": 1097,
+            "consequence_terms": [
+                "3_prime_UTR_variant",
+                "NMD_transcript_variant"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/8_g.37696499_37696500insG.json
+++ b/service/src/test/resources/variant/8_g.37696499_37696500insG.json
@@ -1,0 +1,66 @@
+{
+    "variant": "8:g.37696499_37696500insG",
+    "id": "8:g.37696499_37696500insG",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "8",
+    "start": 37696500,
+    "end": 37696499,
+    "allele_string": "-/G",
+    "strand": 1,
+    "most_severe_consequence": "frameshift_variant",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000220659",
+            "variant_allele": "G",
+            "protein_id": "ENSP00000220659",
+            "gene_symbol": "BRF2",
+            "gene_id": "ENSG00000104221",
+            "hgnc_id": 17298,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_018310.3"
+            ],
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000315215",
+            "hgvsp": "ENSP00000323508.7:p.Ala548ArgfsTer98",
+            "hgvsc": "ENST00000315215.7:c.1640dup",
+            "variant_allele": "G",
+            "codons": "gtg/gtGg",
+            "protein_id": "ENSP00000323508",
+            "protein_start": 545,
+            "protein_end": 545,
+            "gene_symbol": "GPR124",
+            "gene_id": "ENSG00000020181",
+            "amino_acids": "V/VX",
+            "hgnc_id": 17849,
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000412232",
+            "hgvsp": "ENSP00000406367.2:p.Ala765ArgfsTer98",
+            "hgvsc": "ENST00000412232.2:c.2291dup",
+            "variant_allele": "G",
+            "codons": "gtg/gtGg",
+            "protein_id": "ENSP00000406367",
+            "protein_start": 762,
+            "protein_end": 762,
+            "gene_symbol": "GPR124",
+            "gene_id": "ENSG00000020181",
+            "amino_acids": "V/VX",
+            "hgnc_id": 17849,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_032777.9"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/variant/9_g.135797242_135797242delCinsAT.json
+++ b/service/src/test/resources/variant/9_g.135797242_135797242delCinsAT.json
@@ -1,0 +1,130 @@
+{
+    "variant": "9:g.135797242_135797242delCinsAT",
+    "id": "9:g.135797242_135797242delCinsAT",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "9",
+    "start": 135797242,
+    "end": 135797242,
+    "allele_string": "C/AT",
+    "strand": 1,
+    "most_severe_consequence": "frameshift_variant",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000298552",
+            "hgvsp": "ENSP00000298552.3:p.Met209IlefsTer2",
+            "hgvsc": "ENST00000298552.3:c.627delinsAT",
+            "variant_allele": "AT",
+            "codons": "atG/atAT",
+            "protein_id": "ENSP00000298552",
+            "protein_start": 209,
+            "protein_end": 209,
+            "gene_symbol": "TSC1",
+            "gene_id": "ENSG00000165699",
+            "amino_acids": "M/IX",
+            "hgnc_id": 12362,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_001162426.1",
+                "NM_001162427.1",
+                "NM_000368.4"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000403810",
+            "hgvsp": "ENSP00000386093.1:p.Met209IlefsTer2",
+            "hgvsc": "ENST00000403810.1:c.627delinsAT",
+            "variant_allele": "AT",
+            "codons": "atG/atAT",
+            "protein_id": "ENSP00000386093",
+            "protein_start": 209,
+            "protein_end": 209,
+            "gene_symbol": "TSC1",
+            "gene_id": "ENSG00000165699",
+            "amino_acids": "M/IX",
+            "hgnc_id": 12362,
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000440111",
+            "hgvsp": "ENSP00000394524.2:p.Met209IlefsTer2",
+            "hgvsc": "ENST00000440111.2:c.627delinsAT",
+            "variant_allele": "AT",
+            "codons": "atG/atAT",
+            "protein_id": "ENSP00000394524",
+            "protein_start": 209,
+            "protein_end": 209,
+            "gene_symbol": "TSC1",
+            "gene_id": "ENSG00000165699",
+            "amino_acids": "M/IX",
+            "hgnc_id": 12362,
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000461879",
+            "hgvsc": "ENST00000461879.1:n.456delinsAT",
+            "variant_allele": "AT",
+            "gene_symbol": "TSC1",
+            "gene_id": "ENSG00000165699",
+            "hgnc_id": 12362,
+            "consequence_terms": [
+                "non_coding_transcript_exon_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000475903",
+            "hgvsc": "ENST00000475903.1:n.784delinsAT",
+            "variant_allele": "AT",
+            "gene_symbol": "TSC1",
+            "gene_id": "ENSG00000165699",
+            "hgnc_id": 12362,
+            "consequence_terms": [
+                "non_coding_transcript_exon_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000490179",
+            "variant_allele": "AT",
+            "gene_symbol": "TSC1",
+            "gene_id": "ENSG00000165699",
+            "hgnc_id": 12362,
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000493467",
+            "hgvsc": "ENST00000493467.1:n.823delinsAT",
+            "variant_allele": "AT",
+            "gene_symbol": "TSC1",
+            "gene_id": "ENSG00000165699",
+            "hgnc_id": 12362,
+            "consequence_terms": [
+                "non_coding_transcript_exon_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000545250",
+            "hgvsp": "ENSP00000444017.1:p.Met158IlefsTer2",
+            "hgvsc": "ENST00000545250.1:c.474delinsAT",
+            "variant_allele": "AT",
+            "codons": "atG/atAT",
+            "protein_id": "ENSP00000444017",
+            "protein_start": 158,
+            "protein_end": 158,
+            "gene_symbol": "TSC1",
+            "gene_id": "ENSG00000165699",
+            "amino_acids": "M/IX",
+            "hgnc_id": 12362,
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        }
+    ]
+}

--- a/service/src/test/resources/xref/ENSG00000020181.json
+++ b/service/src/test/resources/xref/ENSG00000020181.json
@@ -1,0 +1,120 @@
+[
+    {
+        "display_id": "GPR124",
+        "primary_id": "GPR124",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+            "KIAA1531",
+            "TEM5"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    },
+    {
+        "display_id": "OTTHUMG00000156182",
+        "primary_id": "OTTHUMG00000156182",
+        "version": "4",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "primary_id": "Hs.274136",
+        "dbname": "UniGene",
+        "ensembl_identity": 100,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1,
+        "xref_start": 374,
+        "xref_end": 6024,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.274136",
+        "ensembl_end": 5651,
+        "version": "0",
+        "cigar_line": "5651M",
+        "score": 28255,
+        "description": "G protein-coupled receptor 124",
+        "xref_identity": 93,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "display_id": " G PROTEIN-COUPLED RECEPTOR 124 [*606823]",
+        "primary_id": "606823",
+        "version": "0",
+        "description": " G PROTEIN-COUPLED RECEPTOR 124; GPR124",
+        "dbname": "MIM_GENE",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM gene"
+    },
+    {
+        "display_id": "GPR124",
+        "primary_id": "17849",
+        "version": "0",
+        "description": "G protein-coupled receptor 124",
+        "dbname": "HGNC",
+        "synonyms": [
+            "DKFZp434C211",
+            "DKFZp434J0911",
+            "FLJ14390",
+            "KIAA1531",
+            "TEM5"
+        ],
+        "info_text": "Generated via ensembl_manual",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "GPR124",
+        "primary_id": "25960",
+        "version": "0",
+        "description": "G protein-coupled receptor 124",
+        "dbname": "EntrezGene",
+        "synonyms": [
+            "TEM5"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "ENSG00000020181",
+        "primary_id": "ENSG00000020181",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    },
+    {
+        "display_id": "GPR124",
+        "primary_id": "25960",
+        "version": "0",
+        "description": "G protein-coupled receptor 124",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    }
+]

--- a/service/src/test/resources/xref/ENSG00000027697.json
+++ b/service/src/test/resources/xref/ENSG00000027697.json
@@ -1,0 +1,147 @@
+[
+    {
+        "display_id": "OTTHUMG00000015656",
+        "primary_id": "OTTHUMG00000015656",
+        "version": "2",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "display_id": "IFNGR1",
+        "primary_id": "IFNGR1",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    },
+    {
+        "display_id": "LRG_66",
+        "primary_id": "LRG_66",
+        "version": "0",
+        "description": "Locus Reference Genomic record for IFNGR1",
+        "dbname": "LRG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "Locus Reference Genomic"
+    },
+    {
+        "display_id": "LRG_66",
+        "primary_id": "LRG_66",
+        "version": "0",
+        "description": null,
+        "dbname": "ENS_LRG_gene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "LRG display in Ensembl gene"
+    },
+    {
+        "display_id": " HELICOBACTER PYLORI INFECTION, SUS [#600263]",
+        "primary_id": "600263",
+        "version": "0",
+        "description": " HELICOBACTER PYLORI INFECTION, SUSCEPTIBILITY TO",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " ATYPICAL MYCOBACTERIOSIS, FAMILIAL [#209950]",
+        "primary_id": "209950",
+        "version": "0",
+        "description": " ATYPICAL MYCOBACTERIOSIS, FAMILIAL",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+            "209750"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " INTERFERON-GAMMA RECEPTOR 1 [*107470]",
+        "primary_id": "107470",
+        "version": "0",
+        "description": " INTERFERON-GAMMA RECEPTOR 1; IFNGR1",
+        "dbname": "MIM_GENE",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM gene"
+    },
+    {
+        "display_id": "IFNGR1",
+        "primary_id": "5439",
+        "version": "0",
+        "description": "interferon gamma receptor 1",
+        "dbname": "HGNC",
+        "synonyms": [
+            "CD119",
+            "IFNGR"
+        ],
+        "info_text": "Generated via ensembl_manual",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "IFNGR1",
+        "primary_id": "3459",
+        "version": "0",
+        "description": "interferon gamma receptor 1",
+        "dbname": "EntrezGene",
+        "synonyms": [
+            "CD119",
+            "IFNGR"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "ENSG00000027697",
+        "primary_id": "ENSG00000027697",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    },
+    {
+        "display_id": "IFNGR1",
+        "primary_id": "3459",
+        "version": "0",
+        "description": "interferon gamma receptor 1",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    }
+]

--- a/service/src/test/resources/xref/ENSG00000089597.json
+++ b/service/src/test/resources/xref/ENSG00000089597.json
@@ -1,0 +1,141 @@
+[
+    {
+        "display_id": "OTTHUMG00000167696",
+        "primary_id": "OTTHUMG00000167696",
+        "version": "3",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "primary_id": "Hs.706921",
+        "dbname": "UniGene",
+        "ensembl_identity": 11,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 3181,
+        "xref_start": 4,
+        "xref_end": 421,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.706921",
+        "ensembl_end": 3598,
+        "version": "0",
+        "cigar_line": "418M",
+        "score": 2047,
+        "description": "Transcribed locus",
+        "xref_identity": 98,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.595071",
+        "dbname": "UniGene",
+        "ensembl_identity": 99,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1,
+        "xref_start": 18,
+        "xref_end": 3921,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.595071",
+        "ensembl_end": 3904,
+        "version": "0",
+        "cigar_line": "3904M",
+        "score": 19520,
+        "description": "Glucosidase, alpha; neutral AB",
+        "xref_identity": 99,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "display_id": " GLUCOSIDASE, ALPHA, NEUTRAL AB [*104160]",
+        "primary_id": "104160",
+        "version": "0",
+        "description": " GLUCOSIDASE, ALPHA, NEUTRAL AB; GANAB",
+        "dbname": "MIM_GENE",
+        "synonyms": [
+            "601862"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM gene"
+    },
+    {
+        "display_id": "GANAB",
+        "primary_id": "4138",
+        "version": "0",
+        "description": "glucosidase, alpha; neutral AB",
+        "dbname": "HGNC",
+        "synonyms": [
+            "G2AN",
+            "GluII",
+            "KIAA0088"
+        ],
+        "info_text": "Generated via ensembl_manual",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "GANAB",
+        "primary_id": "23193",
+        "version": "0",
+        "description": "glucosidase, alpha; neutral AB",
+        "dbname": "EntrezGene",
+        "synonyms": [
+            "G2AN",
+            "GLUII"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "ENSG00000089597",
+        "primary_id": "ENSG00000089597",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    },
+    {
+        "display_id": "GANAB",
+        "primary_id": "23193",
+        "version": "0",
+        "description": "glucosidase, alpha; neutral AB",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    },
+    {
+        "display_id": "GANAB",
+        "primary_id": "GANAB",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+            "G2AN",
+            "KIAA0088"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    }
+]

--- a/service/src/test/resources/xref/ENSG00000100345.json
+++ b/service/src/test/resources/xref/ENSG00000100345.json
@@ -1,0 +1,249 @@
+[
+    {
+        "display_id": "OTTHUMG00000030429",
+        "primary_id": "OTTHUMG00000030429",
+        "version": "5",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "primary_id": "Hs.735360",
+        "dbname": "UniGene",
+        "ensembl_identity": 1,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1899,
+        "xref_start": 1,
+        "xref_end": 149,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.735360",
+        "ensembl_end": 1752,
+        "version": "0",
+        "cigar_line": "50M1I26M1I22M1I48M",
+        "score": 658,
+        "description": "Transcribed locus",
+        "xref_identity": 95,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.713174",
+        "dbname": "UniGene",
+        "ensembl_identity": 3,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 7490,
+        "xref_start": 4,
+        "xref_end": 235,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.713174",
+        "ensembl_end": 7258,
+        "version": "0",
+        "cigar_line": "97M1I134M",
+        "score": 1125,
+        "description": "Transcribed locus",
+        "xref_identity": 90,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.474751",
+        "dbname": "UniGene",
+        "ensembl_identity": 100,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1,
+        "xref_start": 1,
+        "xref_end": 7501,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.474751",
+        "ensembl_end": 7501,
+        "version": "0",
+        "cigar_line": "7501M",
+        "score": 37505,
+        "description": "Myosin, heavy chain 9, non-muscle",
+        "xref_identity": 99,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "display_id": " SEBASTIAN SYNDROME [#605249]",
+        "primary_id": "605249",
+        "version": "0",
+        "description": " SEBASTIAN SYNDROME; SBS",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " DEAFNESS, AUTOSOMAL DOMINANT 17 [#603622]",
+        "primary_id": "603622",
+        "version": "0",
+        "description": " DEAFNESS, AUTOSOMAL DOMINANT 17; DFNA17",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " MACROTHROMBOCYTOPENIA AND PROGRESS [#600208]",
+        "primary_id": "600208",
+        "version": "0",
+        "description": " MACROTHROMBOCYTOPENIA AND PROGRESSIVE SENSORINEURAL DEAFNESS",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " MAY-HEGGLIN ANOMALY [#155100]",
+        "primary_id": "155100",
+        "version": "0",
+        "description": " MAY-HEGGLIN ANOMALY; MHA",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " EPSTEIN SYNDROME [#153650]",
+        "primary_id": "153650",
+        "version": "0",
+        "description": " EPSTEIN SYNDROME",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " FECHTNER SYNDROME [#153640]",
+        "primary_id": "153640",
+        "version": "0",
+        "description": " FECHTNER SYNDROME; FTNS",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " MYOSIN, HEAVY CHAIN 9, NONMUSCLE [*160775]",
+        "primary_id": "160775",
+        "version": "0",
+        "description": " MYOSIN, HEAVY CHAIN 9, NONMUSCLE; MYH9",
+        "dbname": "MIM_GENE",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM gene"
+    },
+    {
+        "display_id": "MYH9",
+        "primary_id": "7579",
+        "version": "0",
+        "description": "myosin, heavy chain 9, non-muscle",
+        "dbname": "HGNC",
+        "synonyms": [
+            "DFNA17",
+            "EPSTS",
+            "FTNS",
+            "MHA",
+            "NMHC-II-A",
+            "NMMHCA"
+        ],
+        "info_text": "Generated via ensembl_manual",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "MYH9",
+        "primary_id": "4627",
+        "version": "0",
+        "description": "myosin, heavy chain 9, non-muscle",
+        "dbname": "EntrezGene",
+        "synonyms": [
+            "BDPLT6",
+            "DFNA17",
+            "EPSTS",
+            "FTNS",
+            "MHA",
+            "NMHC-II-A",
+            "NMMHC-IIA",
+            "NMMHCA"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "ENSG00000100345",
+        "primary_id": "ENSG00000100345",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    },
+    {
+        "display_id": "MYH9",
+        "primary_id": "4627",
+        "version": "0",
+        "description": "myosin, heavy chain 9, non-muscle",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    },
+    {
+        "display_id": "MYH9",
+        "primary_id": "MYH9",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    }
+]

--- a/service/src/test/resources/xref/ENSG00000122025.json
+++ b/service/src/test/resources/xref/ENSG00000122025.json
@@ -1,0 +1,183 @@
+[
+    {
+        "display_id": "OTTHUMG00000016646",
+        "primary_id": "OTTHUMG00000016646",
+        "version": "3",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "display_id": "LRG_457",
+        "primary_id": "LRG_457",
+        "version": "0",
+        "description": "Locus Reference Genomic record for FLT3",
+        "dbname": "LRG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "Locus Reference Genomic"
+    },
+    {
+        "display_id": "LRG_457",
+        "primary_id": "LRG_457",
+        "version": "0",
+        "description": null,
+        "dbname": "ENS_LRG_gene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "LRG display in Ensembl gene"
+    },
+    {
+        "primary_id": "Hs.717775",
+        "dbname": "UniGene",
+        "ensembl_identity": 3,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 248,
+        "xref_start": 1,
+        "xref_end": 121,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.717775",
+        "ensembl_end": 126,
+        "version": "0",
+        "cigar_line": "121M",
+        "score": 578,
+        "description": "Transcribed locus",
+        "xref_identity": 97,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.507590",
+        "dbname": "UniGene",
+        "ensembl_identity": 100,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1,
+        "xref_start": 1,
+        "xref_end": 3842,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.507590",
+        "ensembl_end": 3842,
+        "version": "0",
+        "cigar_line": "3842M",
+        "score": 19210,
+        "description": "Fms-related tyrosine kinase 3",
+        "xref_identity": 99,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "display_id": " LEUKEMIA, ACUTE MYELOID [#601626]",
+        "primary_id": "601626",
+        "version": "0",
+        "description": " LEUKEMIA, ACUTE MYELOID; AML",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+            "602439"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " FMS-RELATED TYROSINE KINASE 3 [*136351]",
+        "primary_id": "136351",
+        "version": "0",
+        "description": " FMS-RELATED TYROSINE KINASE 3; FLT3",
+        "dbname": "MIM_GENE",
+        "synonyms": [
+            "184747"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM gene"
+    },
+    {
+        "display_id": "FLT3",
+        "primary_id": "3765",
+        "version": "0",
+        "description": "fms-related tyrosine kinase 3",
+        "dbname": "HGNC",
+        "synonyms": [
+            "CD135",
+            "FLK2",
+            "STK1"
+        ],
+        "info_text": "Generated via ensembl_manual",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "FLT3",
+        "primary_id": "2322",
+        "version": "0",
+        "description": "fms-related tyrosine kinase 3",
+        "dbname": "EntrezGene",
+        "synonyms": [
+            "CD135",
+            "FLK-2",
+            "FLK2",
+            "STK1"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "ENSG00000122025",
+        "primary_id": "ENSG00000122025",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    },
+    {
+        "display_id": "FLT3",
+        "primary_id": "2322",
+        "version": "0",
+        "description": "fms-related tyrosine kinase 3",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    },
+    {
+        "display_id": "FLT3",
+        "primary_id": "FLT3",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+            "CD135",
+            "FLK2",
+            "STK1"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    }
+]

--- a/service/src/test/resources/xref/ENSG00000125746.json
+++ b/service/src/test/resources/xref/ENSG00000125746.json
@@ -1,0 +1,120 @@
+[
+    {
+        "display_id": "OTTHUMG00000182127",
+        "primary_id": "OTTHUMG00000182127",
+        "version": "1",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "primary_id": "Hs.24178",
+        "dbname": "UniGene",
+        "ensembl_identity": 95,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 113,
+        "xref_start": 1,
+        "xref_end": 2651,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.24178",
+        "ensembl_end": 2763,
+        "version": "0",
+        "cigar_line": "2651M",
+        "score": 13255,
+        "description": "Echinoderm microtubule associated protein like 2",
+        "xref_identity": 91,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "display_id": "hsa-mir-330",
+        "primary_id": "MI0000803",
+        "version": "0",
+        "description": "hsa-mir-330",
+        "dbname": "miRBase",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "MISC",
+        "db_display_name": "miRBase"
+    },
+    {
+        "display_id": "EML2",
+        "primary_id": "18035",
+        "version": "0",
+        "description": "echinoderm microtubule associated protein like 2",
+        "dbname": "HGNC",
+        "synonyms": [
+            "ELP70",
+            "EMAP-2",
+            "EMAP2"
+        ],
+        "info_text": "Generated via ccds",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "EML2",
+        "primary_id": "24139",
+        "version": "0",
+        "description": "echinoderm microtubule associated protein like 2",
+        "dbname": "EntrezGene",
+        "synonyms": [
+            "ELP70",
+            "EMAP-2",
+            "EMAP2"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "ENSG00000125746",
+        "primary_id": "ENSG00000125746",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    },
+    {
+        "display_id": "EML2",
+        "primary_id": "24139",
+        "version": "0",
+        "description": "echinoderm microtubule associated protein like 2",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    },
+    {
+        "display_id": "EML2",
+        "primary_id": "EML2",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+            "EMAP2",
+            "EMAPL2"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    }
+]

--- a/service/src/test/resources/xref/ENSG00000133703.json
+++ b/service/src/test/resources/xref/ENSG00000133703.json
@@ -1,0 +1,329 @@
+[
+    {
+        "display_id": "KRAS",
+        "primary_id": "KRAS",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+            "KRAS2",
+            "RASK2"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    },
+    {
+        "display_id": "OTTHUMG00000171193",
+        "primary_id": "OTTHUMG00000171193",
+        "version": "1",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "primary_id": "Hs.734869",
+        "dbname": "UniGene",
+        "ensembl_identity": 26,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1222,
+        "xref_start": 1,
+        "xref_end": 459,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.734869",
+        "ensembl_end": 1680,
+        "version": "0",
+        "cigar_line": "459M",
+        "score": 2277,
+        "description": "Transcribed locus",
+        "xref_identity": 99,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.732231",
+        "dbname": "UniGene",
+        "ensembl_identity": 9,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 5052,
+        "xref_start": 20,
+        "xref_end": 585,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.732231",
+        "ensembl_end": 4485,
+        "version": "0",
+        "cigar_line": "78M1D476M1I11M",
+        "score": 2747,
+        "description": "Transcribed locus",
+        "xref_identity": 95,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.691064",
+        "dbname": "UniGene",
+        "ensembl_identity": 9,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 3028,
+        "xref_start": 2,
+        "xref_end": 567,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.691064",
+        "ensembl_end": 3591,
+        "version": "0",
+        "cigar_line": "148M1I10M1I406M",
+        "score": 2778,
+        "description": "Transcribed locus",
+        "xref_identity": 99,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.690627",
+        "dbname": "UniGene",
+        "ensembl_identity": 10,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 2371,
+        "xref_start": 10,
+        "xref_end": 592,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.690627",
+        "ensembl_end": 2955,
+        "version": "0",
+        "cigar_line": "446M1D133M1D4M",
+        "score": 2855,
+        "description": "Transcribed locus",
+        "xref_identity": 97,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.675166",
+        "dbname": "UniGene",
+        "ensembl_identity": 7,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 3606,
+        "xref_start": 1,
+        "xref_end": 457,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.675166",
+        "ensembl_end": 4062,
+        "version": "0",
+        "cigar_line": "457M",
+        "score": 2285,
+        "description": "Transcribed locus",
+        "xref_identity": 100,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.594741",
+        "dbname": "UniGene",
+        "ensembl_identity": 5,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 4952,
+        "xref_start": 3,
+        "xref_end": 358,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.594741",
+        "ensembl_end": 5308,
+        "version": "0",
+        "cigar_line": "174M1D182M",
+        "score": 1570,
+        "description": "Transcribed locus",
+        "xref_identity": 93,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "display_id": " CARDIOFACIOCUTANEOUS SYNDROME 2 [#615278]",
+        "primary_id": "615278",
+        "version": "0",
+        "description": " CARDIOFACIOCUTANEOUS SYNDROME 2; CFC2",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " GASTRIC CANCER [#613659]",
+        "primary_id": "613659",
+        "version": "0",
+        "description": " GASTRIC CANCER",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " NOONAN SYNDROME 3 [#609942]",
+        "primary_id": "609942",
+        "version": "0",
+        "description": " NOONAN SYNDROME 3; NS3",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " JUVENILE MYELOMONOCYTIC LEUKEMIA [#607785]",
+        "primary_id": "607785",
+        "version": "0",
+        "description": " JUVENILE MYELOMONOCYTIC LEUKEMIA; JMML",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " LEUKEMIA, ACUTE MYELOID [#601626]",
+        "primary_id": "601626",
+        "version": "0",
+        "description": " LEUKEMIA, ACUTE MYELOID; AML",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+            "602439"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " V-KI-RAS2 KIRSTEN RAT SARCOMA VIRA [*190070]",
+        "primary_id": "190070",
+        "version": "0",
+        "description": " V-KI-RAS2 KIRSTEN RAT SARCOMA VIRAL ONCOGENE HOMOLOG; KRAS",
+        "dbname": "MIM_GENE",
+        "synonyms": [
+            "190110"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM gene"
+    },
+    {
+        "display_id": "KRAS",
+        "primary_id": "6407",
+        "version": "0",
+        "description": "Kirsten rat sarcoma viral oncogene homolog",
+        "dbname": "HGNC",
+        "synonyms": [
+            "KRAS1",
+            "KRAS2"
+        ],
+        "info_text": "Generated via ensembl_manual",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "KRAS",
+        "primary_id": "3845",
+        "version": "0",
+        "description": "Kirsten rat sarcoma viral oncogene homolog",
+        "dbname": "EntrezGene",
+        "synonyms": [
+            "C-K-RAS",
+            "CFC2",
+            "K-RAS2A",
+            "K-RAS2B",
+            "K-RAS4A",
+            "K-RAS4B",
+            "KI-RAS",
+            "KRAS1",
+            "KRAS2",
+            "NS",
+            "NS3",
+            "RASK2"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "ENSG00000133703",
+        "primary_id": "ENSG00000133703",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    },
+    {
+        "display_id": "KRAS",
+        "primary_id": "3845",
+        "version": "0",
+        "description": "Kirsten rat sarcoma viral oncogene homolog",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    },
+    {
+        "display_id": "N-RAS",
+        "primary_id": "N-RAS",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    },
+    {
+        "display_id": "HRAS",
+        "primary_id": "HRAS",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+            "HRAS1"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    }
+]

--- a/service/src/test/resources/xref/ENSG00000138771.json
+++ b/service/src/test/resources/xref/ENSG00000138771.json
@@ -1,0 +1,235 @@
+[
+    {
+        "display_id": "OTTHUMG00000157075",
+        "primary_id": "OTTHUMG00000157075",
+        "version": "2",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "primary_id": "Hs.702168",
+        "dbname": "UniGene",
+        "ensembl_identity": 100,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1,
+        "xref_start": 1,
+        "xref_end": 11020,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.702168",
+        "ensembl_end": 11020,
+        "version": "0",
+        "cigar_line": "11020M",
+        "score": 55100,
+        "description": "Shroom family member 3",
+        "xref_identity": 99,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.689676",
+        "dbname": "UniGene",
+        "ensembl_identity": 76,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 112,
+        "xref_start": 5,
+        "xref_end": 368,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.689676",
+        "ensembl_end": 475,
+        "version": "0",
+        "cigar_line": "364M",
+        "score": 1811,
+        "description": "Transcribed locus",
+        "xref_identity": 91,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.683808",
+        "dbname": "UniGene",
+        "ensembl_identity": 99,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1,
+        "xref_start": 1,
+        "xref_end": 504,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.683808",
+        "ensembl_end": 504,
+        "version": "0",
+        "cigar_line": "504M",
+        "score": 2502,
+        "description": "CDNA FLJ40481 fis, clone TESTI2043477",
+        "xref_identity": 30,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.606207",
+        "dbname": "UniGene",
+        "ensembl_identity": 5,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 7558,
+        "xref_start": 2,
+        "xref_end": 578,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.606207",
+        "ensembl_end": 6980,
+        "version": "0",
+        "cigar_line": "577M",
+        "score": 2885,
+        "description": "Transcribed locus",
+        "xref_identity": 99,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.432504",
+        "dbname": "UniGene",
+        "ensembl_identity": 5,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 11014,
+        "xref_start": 1,
+        "xref_end": 580,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.432504",
+        "ensembl_end": 10433,
+        "version": "0",
+        "cigar_line": "580M",
+        "score": 2900,
+        "description": "Transcribed locus",
+        "xref_identity": 100,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "display_id": " SHROOM FAMILY MEMBER 3 [*604570]",
+        "primary_id": "604570",
+        "version": "0",
+        "description": " SHROOM FAMILY MEMBER 3; SHROOM3",
+        "dbname": "MIM_GENE",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM gene"
+    },
+    {
+        "display_id": "SHROOM3",
+        "primary_id": "30422",
+        "version": "0",
+        "description": "shroom family member 3",
+        "dbname": "HGNC",
+        "synonyms": [
+            "APXL3",
+            "KIAA1481",
+            "SHRM",
+            "ShrmL"
+        ],
+        "info_text": "Generated via ensembl_manual",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "LOC100996628",
+        "primary_id": "100996628",
+        "version": "0",
+        "description": "uncharacterized LOC100996628",
+        "dbname": "EntrezGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "SHROOM3",
+        "primary_id": "57619",
+        "version": "0",
+        "description": "shroom family member 3",
+        "dbname": "EntrezGene",
+        "synonyms": [
+            "APXL3",
+            "SHRM",
+            "ShrmL"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "ENSG00000138771",
+        "primary_id": "ENSG00000138771",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    },
+    {
+        "display_id": "LOC100996628",
+        "primary_id": "100996628",
+        "version": "0",
+        "description": "uncharacterized LOC100996628",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    },
+    {
+        "display_id": "SHROOM3",
+        "primary_id": "57619",
+        "version": "0",
+        "description": "shroom family member 3",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    },
+    {
+        "display_id": "SHROOM3",
+        "primary_id": "SHROOM3",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+            "KIAA1481",
+            "SHRML"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    }
+]

--- a/service/src/test/resources/xref/ENSG00000154783.json
+++ b/service/src/test/resources/xref/ENSG00000154783.json
@@ -1,0 +1,117 @@
+[
+    {
+        "display_id": "FGD5",
+        "primary_id": "FGD5",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+            "ZFYVE23"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    },
+    {
+        "display_id": "OTTHUMG00000155556",
+        "primary_id": "OTTHUMG00000155556",
+        "version": "5",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "primary_id": "Hs.412406",
+        "dbname": "UniGene",
+        "ensembl_identity": 100,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1,
+        "xref_start": 1,
+        "xref_end": 5720,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.412406",
+        "ensembl_end": 5720,
+        "version": "0",
+        "cigar_line": "5720M",
+        "score": 28600,
+        "description": "FYVE, RhoGEF and PH domain containing 5",
+        "xref_identity": 96,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "display_id": " FYVE, RhoGEF, AND PH DOMAIN-CONTAI [*614788]",
+        "primary_id": "614788",
+        "version": "0",
+        "description": " FYVE, RhoGEF, AND PH DOMAIN-CONTAINING PROTEIN 5; FGD5",
+        "dbname": "MIM_GENE",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM gene"
+    },
+    {
+        "display_id": "FGD5",
+        "primary_id": "19117",
+        "version": "0",
+        "description": "FYVE, RhoGEF and PH domain containing 5",
+        "dbname": "HGNC",
+        "synonyms": [
+            "FLJ00274",
+            "FLJ39957",
+            "ZFYVE23"
+        ],
+        "info_text": "Generated via ensembl_manual",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "FGD5",
+        "primary_id": "152273",
+        "version": "0",
+        "description": "FYVE, RhoGEF and PH domain containing 5",
+        "dbname": "EntrezGene",
+        "synonyms": [
+            "ZFYVE23"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "ENSG00000154783",
+        "primary_id": "ENSG00000154783",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    },
+    {
+        "display_id": "FGD5",
+        "primary_id": "152273",
+        "version": "0",
+        "description": "FYVE, RhoGEF and PH domain containing 5",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    }
+]

--- a/service/src/test/resources/xref/ENSG00000157764.json
+++ b/service/src/test/resources/xref/ENSG00000157764.json
@@ -1,0 +1,373 @@
+[
+    {
+        "display_id": "BRAF",
+        "primary_id": "BRAF",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+            "BRAF1",
+            "RAFB1"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    },
+    {
+        "display_id": "OTTHUMG00000157457",
+        "primary_id": "OTTHUMG00000157457",
+        "version": "2",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "primary_id": "Hs.737412",
+        "dbname": "UniGene",
+        "ensembl_identity": 5,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 4558,
+        "xref_start": 18,
+        "xref_end": 505,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.737412",
+        "ensembl_end": 5045,
+        "version": "0",
+        "cigar_line": "488M",
+        "score": 2413,
+        "description": "Transcribed locus",
+        "xref_identity": 95,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.659507",
+        "dbname": "UniGene",
+        "ensembl_identity": 31,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 5534,
+        "xref_start": 1,
+        "xref_end": 2606,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.659507",
+        "ensembl_end": 8139,
+        "version": "0",
+        "cigar_line": "2606M",
+        "score": 13021,
+        "description": "CDNA FLJ36704 fis, clone UTERU2009335",
+        "xref_identity": 99,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.614551",
+        "dbname": "UniGene",
+        "ensembl_identity": 6,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 3515,
+        "xref_start": 3,
+        "xref_end": 559,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.614551",
+        "ensembl_end": 4070,
+        "version": "0",
+        "cigar_line": "70M1D165M1I34M1I24M1I36M1I19M1I36M2D3M1D44M1D21M1I13M1I48M1I20M1D4M1D12M",
+        "score": 2348,
+        "description": "Transcribed locus",
+        "xref_identity": 91,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.613773",
+        "dbname": "UniGene",
+        "ensembl_identity": 2,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1867,
+        "xref_start": 3,
+        "xref_end": 196,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.613773",
+        "ensembl_end": 1672,
+        "version": "0",
+        "cigar_line": "194M",
+        "score": 970,
+        "description": "Transcribed locus",
+        "xref_identity": 98,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.604885",
+        "dbname": "UniGene",
+        "ensembl_identity": 6,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 6326,
+        "xref_start": 8,
+        "xref_end": 506,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.604885",
+        "ensembl_end": 5826,
+        "version": "0",
+        "cigar_line": "499M",
+        "score": 2495,
+        "description": "Transcribed locus",
+        "xref_identity": 98,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.601041",
+        "dbname": "UniGene",
+        "ensembl_identity": 7,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 3482,
+        "xref_start": 1,
+        "xref_end": 621,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.601041",
+        "ensembl_end": 4102,
+        "version": "0",
+        "cigar_line": "621M",
+        "score": 3105,
+        "description": "Transcribed locus",
+        "xref_identity": 100,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.600998",
+        "dbname": "UniGene",
+        "ensembl_identity": 28,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1246,
+        "xref_start": 1,
+        "xref_end": 2362,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.600998",
+        "ensembl_end": 3606,
+        "version": "0",
+        "cigar_line": "664M1I1697M",
+        "score": 11775,
+        "description": "CDNA FLJ42263 fis, clone TKIDN2014570",
+        "xref_identity": 99,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.550061",
+        "dbname": "UniGene",
+        "ensembl_identity": 100,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1,
+        "xref_start": 1,
+        "xref_end": 2480,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.550061",
+        "ensembl_end": 2480,
+        "version": "0",
+        "cigar_line": "2480M",
+        "score": 12400,
+        "description": "V-raf murine sarcoma viral oncogene homolog B1",
+        "xref_identity": 84,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.324250",
+        "dbname": "UniGene",
+        "ensembl_identity": 4,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 8295,
+        "xref_start": 7,
+        "xref_end": 412,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.324250",
+        "ensembl_end": 7888,
+        "version": "0",
+        "cigar_line": "406M",
+        "score": 2030,
+        "description": "Transcribed locus",
+        "xref_identity": 98,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "display_id": " LEOPARD SYNDROME 3 [#613707]",
+        "primary_id": "613707",
+        "version": "0",
+        "description": " LEOPARD SYNDROME 3",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " NOONAN SYNDROME 7 [#613706]",
+        "primary_id": "613706",
+        "version": "0",
+        "description": " NOONAN SYNDROME 7; NS7",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " LYMPHOMA, NON-HODGKIN, FAMILIAL [#605027]",
+        "primary_id": "605027",
+        "version": "0",
+        "description": " LYMPHOMA, NON-HODGKIN, FAMILIAL",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " LUNG CANCER [#211980]",
+        "primary_id": "211980",
+        "version": "0",
+        "description": " LUNG CANCER",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " CARDIOFACIOCUTANEOUS SYNDROME 1 [#115150]",
+        "primary_id": "115150",
+        "version": "0",
+        "description": " CARDIOFACIOCUTANEOUS SYNDROME 1; CFC1",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " COLORECTAL CANCER [#114500]",
+        "primary_id": "114500",
+        "version": "0",
+        "description": " COLORECTAL CANCER; CRC",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " V-RAF MURINE SARCOMA VIRAL ONCOGEN [*164757]",
+        "primary_id": "164757",
+        "version": "0",
+        "description": " V-RAF MURINE SARCOMA VIRAL ONCOGENE HOMOLOG B1; BRAF",
+        "dbname": "MIM_GENE",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM gene"
+    },
+    {
+        "display_id": "BRAF",
+        "primary_id": "1097",
+        "version": "0",
+        "description": "v-raf murine sarcoma viral oncogene homolog B",
+        "dbname": "HGNC",
+        "synonyms": [
+            "BRAF1"
+        ],
+        "info_text": "Generated via ensembl_manual",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "BRAF",
+        "primary_id": "673",
+        "version": "0",
+        "description": "v-raf murine sarcoma viral oncogene homolog B",
+        "dbname": "EntrezGene",
+        "synonyms": [
+            "B-RAF1",
+            "BRAF1",
+            "NS7",
+            "RAFB1"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "ENSG00000157764",
+        "primary_id": "ENSG00000157764",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    },
+    {
+        "display_id": "BRAF",
+        "primary_id": "673",
+        "version": "0",
+        "description": "v-raf murine sarcoma viral oncogene homolog B",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    }
+]

--- a/service/src/test/resources/xref/ENSG00000162434.json
+++ b/service/src/test/resources/xref/ENSG00000162434.json
@@ -1,0 +1,120 @@
+[
+    {
+        "display_id": "OTTHUMG00000009310",
+        "primary_id": "OTTHUMG00000009310",
+        "version": "1",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "primary_id": "Hs.610395",
+        "dbname": "UniGene",
+        "ensembl_identity": 11,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1658,
+        "xref_start": 8,
+        "xref_end": 574,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.610395",
+        "ensembl_end": 2227,
+        "version": "0",
+        "cigar_line": "48M3D519M",
+        "score": 2806,
+        "description": "Transcribed locus, strongly similar to NP_002218.2 JAK1 gene product [Homo sapiens]",
+        "xref_identity": 98,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "display_id": " JANUS KINASE 1 [*147795]",
+        "primary_id": "147795",
+        "version": "0",
+        "description": " JANUS KINASE 1; JAK1",
+        "dbname": "MIM_GENE",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM gene"
+    },
+    {
+        "display_id": "JAK1",
+        "primary_id": "6190",
+        "version": "0",
+        "description": "Janus kinase 1",
+        "dbname": "HGNC",
+        "synonyms": [
+            "JAK1A",
+            "JAK1B",
+            "JTK3"
+        ],
+        "info_text": "Generated via ensembl_manual",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "JAK1",
+        "primary_id": "3716",
+        "version": "0",
+        "description": "Janus kinase 1",
+        "dbname": "EntrezGene",
+        "synonyms": [
+            "JAK1A",
+            "JAK1B",
+            "JTK3"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "ENSG00000162434",
+        "primary_id": "ENSG00000162434",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    },
+    {
+        "display_id": "JAK1",
+        "primary_id": "3716",
+        "version": "0",
+        "description": "Janus kinase 1",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    },
+    {
+        "display_id": "JAK1",
+        "primary_id": "JAK1",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+            "JAK1A",
+            "JAK1B"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    }
+]

--- a/service/src/test/resources/xref/ENSG00000165699.json
+++ b/service/src/test/resources/xref/ENSG00000165699.json
@@ -1,0 +1,182 @@
+[
+    {
+        "display_id": "TSC1",
+        "primary_id": "TSC1",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+            "KIAA0243",
+            "TSC"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    },
+    {
+        "display_id": "OTTHUMG00000020844",
+        "primary_id": "OTTHUMG00000020844",
+        "version": "3",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "primary_id": "Hs.713977",
+        "dbname": "UniGene",
+        "ensembl_identity": 6,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 5235,
+        "xref_start": 16,
+        "xref_end": 599,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.713977",
+        "ensembl_end": 5818,
+        "version": "0",
+        "cigar_line": "584M",
+        "score": 2902,
+        "description": "Transcribed locus",
+        "xref_identity": 97,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.370854",
+        "dbname": "UniGene",
+        "ensembl_identity": 100,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1,
+        "xref_start": 13,
+        "xref_end": 8616,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.370854",
+        "ensembl_end": 8604,
+        "version": "0",
+        "cigar_line": "8604M",
+        "score": 43020,
+        "description": "Tuberous sclerosis 1",
+        "xref_identity": 99,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "display_id": " FOCAL CORTICAL DYSPLASIA OF TAYLOR [#607341]",
+        "primary_id": "607341",
+        "version": "0",
+        "description": " FOCAL CORTICAL DYSPLASIA OF TAYLOR; FCDT",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " TUBEROUS SCLEROSIS 1 [#191100]",
+        "primary_id": "191100",
+        "version": "0",
+        "description": " TUBEROUS SCLEROSIS 1; TSC1",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+            "191090",
+            "191091"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " TSC1 GENE [*605284]",
+        "primary_id": "605284",
+        "version": "0",
+        "description": " TSC1 GENE; TSC1",
+        "dbname": "MIM_GENE",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM gene"
+    },
+    {
+        "display_id": "TSC1",
+        "primary_id": "12362",
+        "version": "0",
+        "description": "tuberous sclerosis 1",
+        "dbname": "HGNC",
+        "synonyms": [
+            "hamartin",
+            "KIAA0243",
+            "LAM",
+            "TSC"
+        ],
+        "info_text": "Generated via ensembl_manual",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "TSC1",
+        "primary_id": "7248",
+        "version": "0",
+        "description": "tuberous sclerosis 1",
+        "dbname": "EntrezGene",
+        "synonyms": [
+            "LAM",
+            "TSC"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "TSC1",
+        "primary_id": "161",
+        "version": "1",
+        "description": "",
+        "dbname": "DBASS3",
+        "synonyms": [
+
+        ],
+        "info_text": "Generated via Database of aberrant 3' splice sites.",
+        "info_type": "DIRECT",
+        "db_display_name": "DataBase of Aberrant 3' Splice Sites"
+    },
+    {
+        "display_id": "ENSG00000165699",
+        "primary_id": "ENSG00000165699",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    },
+    {
+        "display_id": "TSC1",
+        "primary_id": "7248",
+        "version": "0",
+        "description": "tuberous sclerosis 1",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    }
+]

--- a/service/src/test/resources/xref/ENSG00000169676.json
+++ b/service/src/test/resources/xref/ENSG00000169676.json
@@ -1,0 +1,189 @@
+[
+    {
+        "display_id": "OTTHUMG00000128489",
+        "primary_id": "OTTHUMG00000128489",
+        "version": "1",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "primary_id": "Hs.568236",
+        "dbname": "UniGene",
+        "ensembl_identity": 84,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1,
+        "xref_start": 102,
+        "xref_end": 2219,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.568236",
+        "ensembl_end": 2108,
+        "version": "0",
+        "cigar_line": "792M8I676M1D215M3I424M",
+        "score": 9563,
+        "description": "D(1B) dopamine receptor-like",
+        "xref_identity": 90,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.457002",
+        "dbname": "UniGene",
+        "ensembl_identity": 26,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 2109,
+        "xref_start": 8,
+        "xref_end": 676,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.457002",
+        "ensembl_end": 1441,
+        "version": "0",
+        "cigar_line": "418M3I220M1D28M",
+        "score": 3021,
+        "description": "Transcribed locus, strongly similar to NP_000789.1 DRD5 gene product [Homo sapiens]",
+        "xref_identity": 93,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.380681",
+        "dbname": "UniGene",
+        "ensembl_identity": 100,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1,
+        "xref_start": 1,
+        "xref_end": 2375,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.380681",
+        "ensembl_end": 2375,
+        "version": "0",
+        "cigar_line": "2375M",
+        "score": 11875,
+        "description": "Dopamine receptor D5",
+        "xref_identity": 99,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "display_id": " BLEPHAROSPASM, BENIGN ESSENTIAL [#606798]",
+        "primary_id": "606798",
+        "version": "0",
+        "description": " BLEPHAROSPASM, BENIGN ESSENTIAL",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " DOPAMINE RECEPTOR D5 [+126453]",
+        "primary_id": "126453",
+        "version": "0",
+        "description": " DOPAMINE RECEPTOR D5; DRD5",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+            "126448"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " DOPAMINE RECEPTOR D5 [+126453]",
+        "primary_id": "126453",
+        "version": "0",
+        "description": " DOPAMINE RECEPTOR D5; DRD5",
+        "dbname": "MIM_GENE",
+        "synonyms": [
+            "126448"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM gene"
+    },
+    {
+        "display_id": "DRD5",
+        "primary_id": "3026",
+        "version": "0",
+        "description": "dopamine receptor D5",
+        "dbname": "HGNC",
+        "synonyms": [
+            "DRD1B",
+            "DRD1L2"
+        ],
+        "info_text": "Generated via ensembl_manual",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "DRD5",
+        "primary_id": "1816",
+        "version": "0",
+        "description": "dopamine receptor D5",
+        "dbname": "EntrezGene",
+        "synonyms": [
+            "DBDR",
+            "DRD1B",
+            "DRD1L2"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "ENSG00000169676",
+        "primary_id": "ENSG00000169676",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    },
+    {
+        "display_id": "DRD5",
+        "primary_id": "1816",
+        "version": "0",
+        "description": "dopamine receptor D5",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    },
+    {
+        "display_id": "DRD5",
+        "primary_id": "DRD5",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+            "DRD1B",
+            "DRD1L2"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    }
+]

--- a/service/src/test/resources/xref/ENSG00000180438.json
+++ b/service/src/test/resources/xref/ENSG00000180438.json
@@ -1,0 +1,98 @@
+[
+    {
+        "display_id": "TPRXL",
+        "primary_id": "TPRXL",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    },
+    {
+        "display_id": "OTTHUMG00000155509",
+        "primary_id": "OTTHUMG00000155509",
+        "version": "2",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "primary_id": "Hs.739211",
+        "dbname": "UniGene",
+        "ensembl_identity": 100,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1,
+        "xref_start": 3,
+        "xref_end": 510,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.739211",
+        "ensembl_end": 508,
+        "version": "0",
+        "cigar_line": "508M",
+        "score": 2540,
+        "description": "Transcribed locus",
+        "xref_identity": 99,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.529180",
+        "dbname": "UniGene",
+        "ensembl_identity": 100,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1,
+        "xref_start": 95,
+        "xref_end": 2258,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.529180",
+        "ensembl_end": 2164,
+        "version": "0",
+        "cigar_line": "2164M",
+        "score": 10820,
+        "description": "Tetra-peptide repeat homeobox-like",
+        "xref_identity": 95,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "display_id": "TPRXL",
+        "primary_id": "32178",
+        "version": "0",
+        "description": "tetra-peptide repeat homeobox-like",
+        "dbname": "HGNC",
+        "synonyms": [
+            "FLJ35107"
+        ],
+        "info_text": "Generated via ensembl_manual",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "ENSG00000180438",
+        "primary_id": "ENSG00000180438",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    }
+]

--- a/service/src/test/resources/xref/ENSG00000181722.json
+++ b/service/src/test/resources/xref/ENSG00000181722.json
@@ -1,0 +1,101 @@
+[
+    {
+        "display_id": "OTTHUMG00000159366",
+        "primary_id": "OTTHUMG00000159366",
+        "version": "1",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "display_id": " ZINC FINGER- AND BTB DOMAIN-CONTAI [*606025]",
+        "primary_id": "606025",
+        "version": "0",
+        "description": " ZINC FINGER- AND BTB DOMAIN-CONTAINING PROTEIN 20; ZBTB20",
+        "dbname": "MIM_GENE",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM gene"
+    },
+    {
+        "display_id": "ZBTB20",
+        "primary_id": "13503",
+        "version": "0",
+        "description": "zinc finger and BTB domain containing 20",
+        "dbname": "HGNC",
+        "synonyms": [
+            "DKFZp566F123",
+            "DPZF",
+            "ODA-8S",
+            "ZNF288"
+        ],
+        "info_text": "Generated via ensembl_manual",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "ZBTB20",
+        "primary_id": "26137",
+        "version": "0",
+        "description": "zinc finger and BTB domain containing 20",
+        "dbname": "EntrezGene",
+        "synonyms": [
+            "DPZF",
+            "HOF",
+            "ODA-8S",
+            "RP11-553L6.5",
+            "ZNF288"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "ENSG00000181722",
+        "primary_id": "ENSG00000181722",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    },
+    {
+        "display_id": "ZBTB20",
+        "primary_id": "26137",
+        "version": "0",
+        "description": "zinc finger and BTB domain containing 20",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    },
+    {
+        "display_id": "ZBTB20",
+        "primary_id": "ZBTB20",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+            "DPZF",
+            "ZNF288"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    }
+]

--- a/service/src/test/resources/xref/ENSG00000183765.json
+++ b/service/src/test/resources/xref/ENSG00000183765.json
@@ -1,0 +1,215 @@
+[
+    {
+        "display_id": "OTTHUMG00000151023",
+        "primary_id": "OTTHUMG00000151023",
+        "version": "21",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "primary_id": "Hs.505297",
+        "dbname": "UniGene",
+        "ensembl_identity": 19,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 2058,
+        "xref_start": 1,
+        "xref_end": 504,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.505297",
+        "ensembl_end": 2560,
+        "version": "0",
+        "cigar_line": "136M1I367M",
+        "score": 2503,
+        "description": "Transcribed locus, strongly similar to NP_001244316.1 CHEK2 gene product [Homo sapiens]",
+        "xref_identity": 99,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.291363",
+        "dbname": "UniGene",
+        "ensembl_identity": 99,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1,
+        "xref_start": 12,
+        "xref_end": 2571,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.291363",
+        "ensembl_end": 2560,
+        "version": "0",
+        "cigar_line": "2560M",
+        "score": 12791,
+        "description": "Checkpoint kinase 2",
+        "xref_identity": 98,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "display_id": " LI-FRAUMENI SYNDROME 2 [#609265]",
+        "primary_id": "609265",
+        "version": "0",
+        "description": " LI-FRAUMENI SYNDROME 2; LFS2",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " CHECKPOINT KINASE 2, S. POMBE, HOM [+604373]",
+        "primary_id": "604373",
+        "version": "0",
+        "description": " CHECKPOINT KINASE 2, S. POMBE, HOMOLOG OF; CHEK2",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " OSTEOGENIC SARCOMA [#259500]",
+        "primary_id": "259500",
+        "version": "0",
+        "description": " OSTEOGENIC SARCOMA",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " PROSTATE CANCER [#176807]",
+        "primary_id": "176807",
+        "version": "0",
+        "description": " PROSTATE CANCER",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " BREAST CANCER [#114480]",
+        "primary_id": "114480",
+        "version": "0",
+        "description": " BREAST CANCER",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " CHECKPOINT KINASE 2, S. POMBE, HOM [+604373]",
+        "primary_id": "604373",
+        "version": "0",
+        "description": " CHECKPOINT KINASE 2, S. POMBE, HOMOLOG OF; CHEK2",
+        "dbname": "MIM_GENE",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM gene"
+    },
+    {
+        "display_id": "CHEK2",
+        "primary_id": "16627",
+        "version": "0",
+        "description": "checkpoint kinase 2",
+        "dbname": "HGNC",
+        "synonyms": [
+            "bA444G7",
+            "CDS1",
+            "CHK2",
+            "HuCds1",
+            "PP1425",
+            "RAD53"
+        ],
+        "info_text": "Generated via ensembl_manual",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "CHEK2",
+        "primary_id": "11200",
+        "version": "0",
+        "description": "checkpoint kinase 2",
+        "dbname": "EntrezGene",
+        "synonyms": [
+            "CDS1",
+            "CHK2",
+            "hCds1",
+            "HuCds1",
+            "LFS2",
+            "PP1425",
+            "RAD53"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "ENSG00000183765",
+        "primary_id": "ENSG00000183765",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    },
+    {
+        "display_id": "CHEK2",
+        "primary_id": "11200",
+        "version": "0",
+        "description": "checkpoint kinase 2",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    },
+    {
+        "display_id": "CHEK2",
+        "primary_id": "CHEK2",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+            "CDS1",
+            "CHK2",
+            "RAD53"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    }
+]

--- a/service/src/test/resources/xref/ENSG00000187555.json
+++ b/service/src/test/resources/xref/ENSG00000187555.json
@@ -1,0 +1,182 @@
+[
+    {
+        "display_id": "USP7",
+        "primary_id": "USP7",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+            "HAUSP"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    },
+    {
+        "display_id": "OTTHUMG00000176903",
+        "primary_id": "OTTHUMG00000176903",
+        "version": "3",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "primary_id": "Hs.744146",
+        "dbname": "UniGene",
+        "ensembl_identity": 14,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 4394,
+        "xref_start": 3,
+        "xref_end": 793,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.744146",
+        "ensembl_end": 3600,
+        "version": "0",
+        "cigar_line": "735M1D30M1D26M",
+        "score": 3876,
+        "description": "Transcribed locus",
+        "xref_identity": 98,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.743739",
+        "dbname": "UniGene",
+        "ensembl_identity": 9,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 5413,
+        "xref_start": 1,
+        "xref_end": 529,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.743739",
+        "ensembl_end": 4882,
+        "version": "0",
+        "cigar_line": "8M1D521M",
+        "score": 2597,
+        "description": "Transcribed locus",
+        "xref_identity": 99,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.606360",
+        "dbname": "UniGene",
+        "ensembl_identity": 4,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 4732,
+        "xref_start": 2,
+        "xref_end": 243,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.606360",
+        "ensembl_end": 4489,
+        "version": "0",
+        "cigar_line": "242M",
+        "score": 1210,
+        "description": "Transcribed locus",
+        "xref_identity": 99,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "primary_id": "Hs.386939",
+        "dbname": "UniGene",
+        "ensembl_identity": 100,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 1,
+        "xref_start": 1,
+        "xref_end": 5412,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.386939",
+        "ensembl_end": 5412,
+        "version": "0",
+        "cigar_line": "5412M",
+        "score": 27060,
+        "description": "Ubiquitin specific peptidase 7 (herpes virus-associated)",
+        "xref_identity": 100,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "display_id": " UBIQUITIN-SPECIFIC PROTEASE 7 [*602519]",
+        "primary_id": "602519",
+        "version": "0",
+        "description": " UBIQUITIN-SPECIFIC PROTEASE 7; USP7",
+        "dbname": "MIM_GENE",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM gene"
+    },
+    {
+        "display_id": "USP7",
+        "primary_id": "12630",
+        "version": "0",
+        "description": "ubiquitin specific peptidase 7 (herpes virus-associated)",
+        "dbname": "HGNC",
+        "synonyms": [
+            "HAUSP"
+        ],
+        "info_text": "Generated via ccds",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "USP7",
+        "primary_id": "7874",
+        "version": "0",
+        "description": "ubiquitin specific peptidase 7 (herpes virus-associated)",
+        "dbname": "EntrezGene",
+        "synonyms": [
+            "HAUSP",
+            "TEF1"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "ENSG00000187555",
+        "primary_id": "ENSG00000187555",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    },
+    {
+        "display_id": "USP7",
+        "primary_id": "7874",
+        "version": "0",
+        "description": "ubiquitin specific peptidase 7 (herpes virus-associated)",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    }
+]

--- a/service/src/test/resources/xref/ENSG00000213341.json
+++ b/service/src/test/resources/xref/ENSG00000213341.json
@@ -1,0 +1,139 @@
+[
+    {
+        "display_id": "OTTHUMG00000018899",
+        "primary_id": "OTTHUMG00000018899",
+        "version": "1",
+        "description": null,
+        "dbname": "OTTG",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "NONE",
+        "db_display_name": "Havana gene"
+    },
+    {
+        "primary_id": "Hs.594380",
+        "dbname": "UniGene",
+        "ensembl_identity": 6,
+        "synonyms": [
+
+        ],
+        "ensembl_start": 2998,
+        "xref_start": 1,
+        "xref_end": 247,
+        "db_display_name": "UniGene",
+        "display_id": "Hs.594380",
+        "ensembl_end": 3242,
+        "version": "0",
+        "cigar_line": "25M1I185M1I35M",
+        "score": 1178,
+        "description": "Transcribed locus",
+        "xref_identity": 97,
+        "evalue": null,
+        "info_type": "SEQUENCE_MATCH",
+        "info_text": ""
+    },
+    {
+        "display_id": " COCOON SYNDROME [#613630]",
+        "primary_id": "613630",
+        "version": "0",
+        "description": " COCOON SYNDROME",
+        "dbname": "MIM_MORBID",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM disease"
+    },
+    {
+        "display_id": " CONSERVED HELIX-LOOP-HELIX UBIQUIT [*600664]",
+        "primary_id": "600664",
+        "version": "0",
+        "description": " CONSERVED HELIX-LOOP-HELIX UBIQUITOUS KINASE; CHUK",
+        "dbname": "MIM_GENE",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "MIM gene"
+    },
+    {
+        "display_id": "CHUK",
+        "primary_id": "1974",
+        "version": "0",
+        "description": "conserved helix-loop-helix ubiquitous kinase",
+        "dbname": "HGNC",
+        "synonyms": [
+            "IkBKA",
+            "IKK-alpha",
+            "IKK1",
+            "IKKA",
+            "NFKBIKA",
+            "TCF16"
+        ],
+        "info_text": "Generated via ensembl_manual",
+        "info_type": "DIRECT",
+        "db_display_name": "HGNC Symbol"
+    },
+    {
+        "display_id": "CHUK",
+        "primary_id": "1147",
+        "version": "0",
+        "description": "conserved helix-loop-helix ubiquitous kinase",
+        "dbname": "EntrezGene",
+        "synonyms": [
+            "IKBKA",
+            "IKK-alpha",
+            "IKK1",
+            "IKKA",
+            "NFKBIKA",
+            "TCF16"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "EntrezGene"
+    },
+    {
+        "display_id": "ENSG00000213341",
+        "primary_id": "ENSG00000213341",
+        "version": "0",
+        "description": "",
+        "dbname": "ArrayExpress",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DIRECT",
+        "db_display_name": "ArrayExpress"
+    },
+    {
+        "display_id": "CHUK",
+        "primary_id": "1147",
+        "version": "0",
+        "description": "conserved helix-loop-helix ubiquitous kinase",
+        "dbname": "WikiGene",
+        "synonyms": [
+
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "WikiGene"
+    },
+    {
+        "display_id": "CHUK",
+        "primary_id": "CHUK",
+        "version": "0",
+        "description": "",
+        "dbname": "Uniprot_gn",
+        "synonyms": [
+            "IKKA",
+            "TCF16"
+        ],
+        "info_text": "",
+        "info_type": "DEPENDENT",
+        "db_display_name": "UniProtKB Gene Name"
+    }
+]

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationController.java
@@ -151,4 +151,44 @@ public class AnnotationController
     {
         return this.variantAnnotationService.getAnnotation(variant, isoformOverrideSource, fields);
     }
+
+    @ApiOperation(value = "Retrieves VEP annotation for the provided list of genomic locations",
+        nickname = "fetchVariantAnnotationByGenomicLocationPOST")
+    @RequestMapping(value = "/annotation/genomic",
+        method = RequestMethod.POST,
+        produces = "application/json")
+    public List<VariantAnnotation> fetchVariantAnnotationByGenomicLocationPOST(
+        @ApiParam(value="List of Genomic Locations",
+            required = true)
+        @RequestBody List<GenomicLocation> genomicLocations,
+        @ApiParam(value="Isoform override source. For example uniprot",
+            required = false)
+        @RequestParam(required = false) String isoformOverrideSource,
+        @ApiParam(value="Comma separated list of fields to include (case-sensitive!). " +
+            "For example: hotspots,mutation_assessor", required = false, defaultValue = "hotspots,mutation_assessor")
+        @RequestParam(required = false) List<String> fields)
+    {
+        return this.variantAnnotationService.getAnnotationsByGenomicLocations(
+            genomicLocations, isoformOverrideSource, fields);
+    }
+
+    @ApiOperation(value = "Retrieves VEP annotation for the provided genomic location",
+        nickname = "fetchVariantAnnotationByGenomicLocationGET")
+    @RequestMapping(value = "/annotation/genomic/{genomicLocation:.+}",
+        method = RequestMethod.GET,
+        produces = "application/json")
+    public VariantAnnotation fetchVariantAnnotationByGenomicLocationGET(
+        @ApiParam(value="A genomic location. For example 7,140453136,140453136,A,T",
+            required = true)
+        @PathVariable String genomicLocation,
+        @ApiParam(value="Isoform override source. For example uniprot",
+            required = false)
+        @RequestParam(required = false) String isoformOverrideSource,
+        @ApiParam(value="Comma separated list of fields to include (case-sensitive!). " +
+            "For example: hotspots,mutation_assessor", required = false, defaultValue = "hotspots,mutation_assessor")
+        @RequestParam(required = false) List<String> fields)
+        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException
+    {
+        return this.variantAnnotationService.getAnnotationByGenomicLocation(genomicLocation, isoformOverrideSource, fields);
+    }
 }

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationSummaryController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationSummaryController.java
@@ -1,0 +1,75 @@
+package org.cbioportal.genome_nexus.web;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.cbioportal.genome_nexus.model.VariantAnnotationSummary;
+import org.cbioportal.genome_nexus.service.VariantAnnotationSummaryService;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
+import org.cbioportal.genome_nexus.web.config.InternalApi;
+import org.cbioportal.genome_nexus.web.param.TranscriptSummaryProjection;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@InternalApi
+@RestController // shorthand for @Controller, @ResponseBody
+@CrossOrigin(origins="*") // allow all cross-domain requests
+@RequestMapping(value= "/")
+public class AnnotationSummaryController
+{
+    private final VariantAnnotationSummaryService variantAnnotationSummaryService;
+
+    @Autowired
+    public AnnotationSummaryController(VariantAnnotationSummaryService variantAnnotationSummaryService)
+    {
+        this.variantAnnotationSummaryService = variantAnnotationSummaryService;
+    }
+
+    @ApiOperation(value = "Retrieves VEP annotation summary for the provided list of variants",
+        nickname = "fetchVariantAnnotationPOST")
+    @RequestMapping(value = "/annotation/summary",
+        method = RequestMethod.POST,
+        produces = "application/json")
+    public List<VariantAnnotationSummary> fetchVariantAnnotationSummaryPOST(
+        @ApiParam(value="List of variants. For example [\"X:g.66937331T>A\",\"17:g.41242962_41242963insGA\"]",
+            required = true)
+        @RequestBody List<String> variants,
+        @ApiParam(value="Isoform override source. For example uniprot")
+        @RequestParam(required = false) String isoformOverrideSource,
+        @ApiParam(value="Indicates whether to return summary for all transcripts or only for canonical transcript")
+        @RequestParam(defaultValue = "ALL") TranscriptSummaryProjection projection)
+    {
+        if (projection == TranscriptSummaryProjection.CANONICAL) {
+            return this.variantAnnotationSummaryService.getAnnotationSummaryForCanonical(variants, isoformOverrideSource);
+        }
+        else {
+            return this.variantAnnotationSummaryService.getAnnotationSummary(variants, isoformOverrideSource);
+        }
+    }
+
+    @ApiOperation(value = "Retrieves VEP annotation summary for the provided variant",
+        nickname = "fetchVariantAnnotationSummaryGET")
+    @RequestMapping(value = "/annotation/summary/{variant:.+}",
+        method = RequestMethod.GET,
+        produces = "application/json")
+    public VariantAnnotationSummary fetchVariantAnnotationSummaryGET(
+        @ApiParam(value="Variant. For example 17:g.41242962_41242963insGA",
+            required = true)
+        @PathVariable String variant,
+        @ApiParam(value="Isoform override source. For example uniprot")
+        @RequestParam(required = false) String isoformOverrideSource,
+        @ApiParam(value="Indicates whether to return summary for all transcripts or only for canonical transcript")
+        @RequestParam(defaultValue = "ALL") TranscriptSummaryProjection projection)
+        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException
+    {
+        if (projection == TranscriptSummaryProjection.CANONICAL) {
+            return this.variantAnnotationSummaryService.getAnnotationSummaryForCanonical(variant, isoformOverrideSource);
+        }
+        else {
+            return this.variantAnnotationSummaryService.getAnnotationSummary(variant, isoformOverrideSource);
+        }
+
+    }
+}

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
@@ -22,7 +22,9 @@ public class ApiObjectMapper extends ObjectMapper
         mixinMap.put(PdbHeader.class, PdbHeaderMixin.class);
         mixinMap.put(TranscriptConsequence.class, TranscriptConsequenceMixin.class);
         mixinMap.put(ColocatedVariant.class, ColocatedVariantMixin.class);
+        mixinMap.put(TranscriptConsequenceSummary.class, TranscriptConsequenceSummaryMixin.class);
         mixinMap.put(VariantAnnotation.class, VariantAnnotationMixin.class);
+        mixinMap.put(VariantAnnotationSummary.class, VariantAnnotationSummaryMixin.class);
         mixinMap.put(EnsemblTranscript.class, EnsemblTranscriptMixin.class);
         mixinMap.put(PfamDomainRange.class, PfamDomainRangeMixin.class);
         mixinMap.put(ExonRange.class, ExonRangeMixin.class);

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/TranscriptConsequenceSummaryMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/TranscriptConsequenceSummaryMixin.java
@@ -1,0 +1,44 @@
+package org.cbioportal.genome_nexus.web.mixin;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+import org.cbioportal.genome_nexus.model.IntegerRange;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TranscriptConsequenceSummaryMixin
+{
+    @JsonProperty(required = true)
+    @ApiModelProperty(value = "Transcript id", required = true)
+    private String transcriptId;
+
+    @ApiModelProperty(value = "Codon change")
+    private String codonChange;
+
+    @ApiModelProperty(value = "Entrez gene id")
+    private String entrezGeneId;
+
+    @ApiModelProperty(value = "Consequence terms (comma separated)")
+    private String consequenceTerms;
+
+    @ApiModelProperty(value = "Hugo gene symbol")
+    private String hugoGeneSymbol;
+
+    @ApiModelProperty(value = "HGVSp short")
+    private String hgvspShort;
+
+    @ApiModelProperty(value = "HGVSp")
+    private String hgvsp;
+
+    @ApiModelProperty(value = "HGVSc")
+    private String hgvsc;
+
+    @ApiModelProperty(value = "Protein position (start and end)")
+    private IntegerRange proteinPosition;
+
+    @ApiModelProperty(value = "RefSeq id")
+    private String refSeq;
+
+    @ApiModelProperty(value = "Variant classification")
+    private String variantClassification;
+}

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationMixin.java
@@ -5,6 +5,7 @@ import io.swagger.annotations.ApiModelProperty;
 import org.cbioportal.genome_nexus.model.HotspotAnnotation;
 import org.cbioportal.genome_nexus.model.MutationAssessorAnnotation;
 import org.cbioportal.genome_nexus.model.TranscriptConsequence;
+import org.cbioportal.genome_nexus.model.VariantAnnotationSummary;
 
 import java.util.List;
 import java.util.Map;
@@ -67,6 +68,10 @@ public class VariantAnnotationMixin {
     @JsonProperty(value="hotspots", required = true)
     @ApiModelProperty(value = "Hotspot Annotation", required = false)
     private HotspotAnnotation hotspotAnnotation;
+
+    @JsonProperty(value="annotation_summary", required = true)
+    @ApiModelProperty(value = "Variant Annotation Summary", required = false)
+    private VariantAnnotationSummary annotationSummary;
 
     @JsonIgnore
     private Map<String, Object> dynamicProps;

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationSummaryMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationSummaryMixin.java
@@ -1,0 +1,35 @@
+package org.cbioportal.genome_nexus.web.mixin;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+import org.cbioportal.genome_nexus.model.GenomicLocation;
+import org.cbioportal.genome_nexus.model.TranscriptConsequenceSummary;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class VariantAnnotationSummaryMixin
+{
+    @JsonProperty(required = true)
+    @ApiModelProperty(value = "Variant key", required = true)
+    private String variant;
+
+    @ApiModelProperty(value = "Genomic location")
+    private GenomicLocation genomicLocation;
+
+    @ApiModelProperty(value = "Strand (- or +)")
+    private String strandSign;
+
+    @ApiModelProperty(value = "Variant type")
+    private String variantType;
+
+    @ApiModelProperty(value = "Assembly name")
+    private String assemblyName;
+
+    @ApiModelProperty(value = "Canonical transcript id")
+    private String canonicalTranscriptId;
+
+    @ApiModelProperty(value = "List of transcript consequence summaries", required = true)
+    private List<TranscriptConsequenceSummary> transcriptConsequences;
+}

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/param/TranscriptSummaryProjection.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/param/TranscriptSummaryProjection.java
@@ -1,0 +1,6 @@
+package org.cbioportal.genome_nexus.web.param;
+
+public enum TranscriptSummaryProjection {
+    ALL,
+    CANONICAL
+}


### PR DESCRIPTION
- Moved over remaining annotation resolvers from https://github.com/genome-nexus/genome-nexus-annotation-pipeline.
- Added a new service and endpoints to get annotation summary by genomic location.
- Couple of bug fixes and improvements.