### PR TITLE
Add ensembl gene id by hugo endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     depends_on:
       - db
   db:
-    build: https://github.com/genome-nexus/genome-nexus-importer.git#v0.1
+    build: https://github.com/genome-nexus/genome-nexus-importer.git#df15a1b8cb58428c1051b5bb4abf67158b8ef17b
     restart: always
     ports:
       - "27017:27017"

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/EnsemblCanonical.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/EnsemblCanonical.java
@@ -1,0 +1,90 @@
+package org.cbioportal.genome_nexus.model;
+
+import java.util.regex.Pattern;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+/**
+ * Ensembl canonical mappings from Hugo Symbol to Ensembl Gene and Transcript.
+ */
+@Document(collection="ensembl.canonical_transcript_per_hgnc")
+public class EnsemblCanonical
+{
+    @Field(value="hgnc_symbol")
+    private String hugoSymbol;
+    @Field(value="ensembl_canonical_gene")
+    private String ensemblCanonicalGeneId;
+    @Field(value="ensembl_canonical_transcript")
+    private String ensemblCanonicalTranscriptId;
+    @Field(value="genome_nexus_canonical_transcript")
+    private String genomeNexusCanonicalTranscriptId;
+    @Field(value="uniprot_canonical_transcript")
+    private String uniprotCanonicalTranscriptId;
+    @Field(value="mskcc_canonical_trancript")
+    private String mskccCanonicalTranscriptId;
+    @Field(value="hgnc_id")
+    private String hgncId;
+    @Field(value="approved_name")
+    private String approvedName;
+    @Field(value="status")
+    private String status;
+    @Field(value="previous_symbols")
+    private String previousSymbols; // comma separated
+    @Field(value="synonyms")
+    private String synonyms; // comma separated
+    @Field(value="accession_numbers")
+    private String accessionNumbers; // comma separated
+    @Field(value="refseq_ids")
+    private String refseqIds;
+    @Field(value="uniprot_id")
+    private String uniprotId;
+
+    private static String[] splitByComma(String input) {
+        Pattern p = Pattern.compile("\\s*,\\s*");
+        String[] output = p.split(input);
+        if (output.length == 0 || (output.length == 1 && output[0].equals(""))) {
+            output = null;
+        }
+        return output;
+    }
+
+    public String getCanonicalTranscriptId(String isoformOverrideSource) {
+        String canonicalTranscriptId;
+        if (isoformOverrideSource == null) {
+            return this.uniprotCanonicalTranscriptId;
+        } else {
+            switch (isoformOverrideSource) {
+                case "mskcc":
+                    canonicalTranscriptId = this.mskccCanonicalTranscriptId;
+                case "uniprot":
+                    canonicalTranscriptId = this.uniprotCanonicalTranscriptId;
+                case "ensembl":
+                    canonicalTranscriptId = this.ensemblCanonicalTranscriptId;
+                default:
+                    canonicalTranscriptId = this.uniprotCanonicalTranscriptId;
+            }
+            return canonicalTranscriptId;
+        }
+    }
+
+    public String getHugoSymbol() {
+        return this.hugoSymbol;
+    }
+
+    public String[] getSynonyms() {
+        return EnsemblCanonical.splitByComma(this.synonyms);
+    }
+
+    public String[] getPreviousSymbols() {
+        return EnsemblCanonical.splitByComma(this.previousSymbols);
+    }
+
+    public String getEnsemblCanonicalGeneId() {
+        return this.ensemblCanonicalGeneId;
+    }
+
+    public String getEnsemblCanonicalTranscriptId() {
+        return this.ensemblCanonicalTranscriptId;
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/EnsemblGene.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/EnsemblGene.java
@@ -1,0 +1,31 @@
+package org.cbioportal.genome_nexus.model;
+
+/**
+ * Ensembl transcript
+ */
+public class EnsemblGene
+{
+    private String geneId;
+    private String[] synonyms;
+    private String[] previousSymbols;
+
+    public EnsemblGene(EnsemblCanonical cn)
+    {
+        this.geneId = cn.getEnsemblCanonicalGeneId();
+        this.synonyms = cn.getSynonyms();
+        this.previousSymbols = cn.getPreviousSymbols();
+    }
+
+    public String getGeneId() {
+        return this.geneId;
+    }
+
+    public String[] getSynonyms() {
+        return this.synonyms;
+    }
+
+    public String[] getPreviousSymbols() {
+        return this.previousSymbols;
+    }
+}
+

--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/internal/EnsemblRepositoryCustom.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/internal/EnsemblRepositoryCustom.java
@@ -31,9 +31,11 @@
 
 package org.cbioportal.genome_nexus.persistence.internal;
 
+import org.cbioportal.genome_nexus.model.EnsemblGene;
 import org.cbioportal.genome_nexus.model.EnsemblTranscript;
 
 public interface EnsemblRepositoryCustom
 {
     EnsemblTranscript findOneByHugoSymbolIgnoreCase(String hugoSymbol, String isoformOverrideSource);
+    EnsemblGene getCanonicalEnsemblGeneIdByHugoSymbol(String hugoSymbol);
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/EnsemblService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/EnsemblService.java
@@ -1,7 +1,9 @@
 package org.cbioportal.genome_nexus.service;
 
+import org.cbioportal.genome_nexus.model.EnsemblGene;
 import org.cbioportal.genome_nexus.model.EnsemblTranscript;
 import org.cbioportal.genome_nexus.service.exception.EnsemblTranscriptNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.NoEnsemblGeneIdForHugoSymbolException;
 
 import java.util.List;
 
@@ -9,6 +11,10 @@ public interface EnsemblService
 {
     EnsemblTranscript getEnsemblTranscriptsByTranscriptId(String transcriptId)
         throws EnsemblTranscriptNotFoundException;
+
+    EnsemblGene getCanonicalEnsemblGeneIdByHugoSymbol(String hugoSymbol)
+        throws NoEnsemblGeneIdForHugoSymbolException;
+    List<EnsemblGene> getCanonicalEnsemblGeneIdByHugoSymbols(List<String> hugoSymbol);
 
     EnsemblTranscript getCanonicalEnsemblTranscriptByHugoSymbol(String hugoSymbol, String isoformOverrideSource)
         throws EnsemblTranscriptNotFoundException;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/exception/NoEnsemblGeneIdForHugoSymbolException.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/exception/NoEnsemblGeneIdForHugoSymbolException.java
@@ -1,0 +1,25 @@
+package org.cbioportal.genome_nexus.service.exception;
+
+public class NoEnsemblGeneIdForHugoSymbolException extends Exception
+{
+    private String hugoSymbol;
+
+    public NoEnsemblGeneIdForHugoSymbolException(String hugoSymbol)
+    {
+        super();
+        this.hugoSymbol = hugoSymbol;
+    }
+
+    public String getHugoSymbol() {
+        return hugoSymbol;
+    }
+
+    public void sethugoSymbol(String hugoSymbol) {
+        this.hugoSymbol = hugoSymbol;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Hugo Symbol not found: " + this.getHugoSymbol();
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/EnsemblServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/EnsemblServiceImpl.java
@@ -1,9 +1,11 @@
 package org.cbioportal.genome_nexus.service.internal;
 
+import org.cbioportal.genome_nexus.model.EnsemblGene;
 import org.cbioportal.genome_nexus.model.EnsemblTranscript;
 import org.cbioportal.genome_nexus.persistence.EnsemblRepository;
 import org.cbioportal.genome_nexus.service.EnsemblService;
 import org.cbioportal.genome_nexus.service.exception.EnsemblTranscriptNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.NoEnsemblGeneIdForHugoSymbolException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -25,6 +27,35 @@ public class EnsemblServiceImpl implements EnsemblService
     @Override
     public EnsemblTranscript getEnsemblTranscriptsByTranscriptId(String transcriptId) {
         return this.ensemblRepository.findOneByTranscriptId(transcriptId);
+    }
+
+    @Override
+    public EnsemblGene getCanonicalEnsemblGeneIdByHugoSymbol(String hugoSymbol)
+        throws NoEnsemblGeneIdForHugoSymbolException
+    {
+        EnsemblGene ensemblGene = this.ensemblRepository.getCanonicalEnsemblGeneIdByHugoSymbol(hugoSymbol);
+
+        if (ensemblGene == null) {
+            throw new NoEnsemblGeneIdForHugoSymbolException(hugoSymbol);
+        }
+
+        return ensemblGene;
+    }
+
+    @Override
+    public List<EnsemblGene> getCanonicalEnsemblGeneIdByHugoSymbols(List<String> hugoSymbols) {
+        List<EnsemblGene> ensemblGenes = new ArrayList<>();
+
+        for (String hugoSymbol : hugoSymbols)
+        {
+            try {
+                ensemblGenes.add(this.getCanonicalEnsemblGeneIdByHugoSymbol(hugoSymbol));
+            } catch (NoEnsemblGeneIdForHugoSymbolException e) {
+                // ignore the exception for this hugo symbol
+            }
+        }
+
+        return ensemblGenes;
     }
 
     @Override

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/EnsemblController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/EnsemblController.java
@@ -3,12 +3,15 @@ package org.cbioportal.genome_nexus.web;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+
+import org.cbioportal.genome_nexus.model.EnsemblGene;
 import org.cbioportal.genome_nexus.model.EnsemblTranscript;
 import org.cbioportal.genome_nexus.model.GeneXref;
 import org.cbioportal.genome_nexus.service.EnsemblService;
 import org.cbioportal.genome_nexus.service.GeneXrefService;
 import org.cbioportal.genome_nexus.service.exception.EnsemblTranscriptNotFoundException;
 import org.cbioportal.genome_nexus.service.exception.EnsemblWebServiceException;
+import org.cbioportal.genome_nexus.service.exception.NoEnsemblGeneIdForHugoSymbolException;
 import org.cbioportal.genome_nexus.web.config.PublicApi;
 import org.cbioportal.genome_nexus.web.param.EnsemblFilter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +34,32 @@ public class EnsemblController
     {
         this.ensemblService = ensemblService;
         this.geneXrefService = geneXrefService;
+    }
+
+    @ApiOperation(value = "Retrieves canonical Ensembl Gene ID by Hugo Symbols",
+        nickname = "fetchCanonicalEnsemblGeneIdByHugoSymbolsPOST")
+    @RequestMapping(value = "/ensembl/canonical-gene/hgnc",
+        method = RequestMethod.POST,
+        produces = "application/json")
+    public List<EnsemblGene> fetchCanonicalEnsemblGeneIdByHugoSymbolPOST(
+        @ApiParam(value = "List of Hugo Symbols. For example [\"TP53\",\"PIK3CA\",\"BRCA1\"]",
+            required = true)
+        @RequestBody List<String> hugoSymbols)
+    {
+        return this.ensemblService.getCanonicalEnsemblGeneIdByHugoSymbols(hugoSymbols);
+    }
+
+    @ApiOperation(value = "Retrieves Ensembl canonical gene id by Hugo Symbol",
+        nickname = "fetchCanonicalEnsemblGeneIdByHugoSymbolGET")
+    @RequestMapping(value = "/ensembl/canonical-gene/hgnc/{hugoSymbol}",
+        method = RequestMethod.GET,
+        produces = "application/json")
+    public EnsemblGene fetchCanonicalEnsemblGeneIdByHugoSymbolGET(
+        @ApiParam(value = "A Hugo Symbol. For example TP53",
+            required = true)
+        @PathVariable String hugoSymbol) throws NoEnsemblGeneIdForHugoSymbolException
+    {
+        return this.ensemblService.getCanonicalEnsemblGeneIdByHugoSymbol(hugoSymbol);
     }
 
     @ApiOperation(value = "Retrieves Ensembl Transcripts by protein ID, and gene ID. " +

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
@@ -24,6 +24,7 @@ public class ApiObjectMapper extends ObjectMapper
         mixinMap.put(ColocatedVariant.class, ColocatedVariantMixin.class);
         mixinMap.put(VariantAnnotation.class, VariantAnnotationMixin.class);
         mixinMap.put(EnsemblTranscript.class, EnsemblTranscriptMixin.class);
+        mixinMap.put(EnsemblGene.class, EnsemblGeneMixin.class);
         mixinMap.put(PfamDomainRange.class, PfamDomainRangeMixin.class);
         mixinMap.put(ExonRange.class, ExonRangeMixin.class);
         mixinMap.put(GenomicLocation.class, GenomicLocationMixin.class);

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/EnsemblGeneMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/EnsemblGeneMixin.java
@@ -1,0 +1,18 @@
+package org.cbioportal.genome_nexus.web.mixin;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.annotations.ApiModelProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EnsemblGeneMixin {
+    @ApiModelProperty(value = "Ensembl gene id", position=1, required = true)
+    private String geneId;
+
+    @ApiModelProperty(value = "Hugo symbol synonyms", position=2, required = false)
+    private String[] synonyms;
+
+    @ApiModelProperty(value = "Hugo symbol synonyms", position=3, required = false)
+    private String[] previousSymbols;
+}


### PR DESCRIPTION
Use extended ensembl_biomart_canonical_transcript_per_hgnc.txt from genome-nexus-importer to get the canonical gene for each hugo symbol. Add EnsemblCanonical model to represent rows in this file. Use a simple EnsemblGene model that we can further extend if we'd like to add more fields.