### PR TITLE
Hugo to gene id endpoint fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     depends_on:
       - db
   db:
-    build: https://github.com/genome-nexus/genome-nexus-importer.git#df15a1b8cb58428c1051b5bb4abf67158b8ef17b
+    build: https://github.com/genome-nexus/genome-nexus-importer.git#91adbf34dd40c6a2ccf4a97f09ffd814d8cd15b6
     restart: always
     ports:
       - "27017:27017"

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/EnsemblGene.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/EnsemblGene.java
@@ -6,18 +6,24 @@ package org.cbioportal.genome_nexus.model;
 public class EnsemblGene
 {
     private String geneId;
+    private String hugoSymbol;
     private String[] synonyms;
     private String[] previousSymbols;
 
     public EnsemblGene(EnsemblCanonical cn)
     {
         this.geneId = cn.getEnsemblCanonicalGeneId();
+        this.hugoSymbol = cn.getHugoSymbol();
         this.synonyms = cn.getSynonyms();
         this.previousSymbols = cn.getPreviousSymbols();
     }
 
     public String getGeneId() {
         return this.geneId;
+    }
+
+    public String getHugoSymbol() {
+        return this.hugoSymbol;
     }
 
     public String[] getSynonyms() {

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/EnsemblGeneMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/EnsemblGeneMixin.java
@@ -1,7 +1,5 @@
 package org.cbioportal.genome_nexus.web.mixin;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -10,9 +8,12 @@ public class EnsemblGeneMixin {
     @ApiModelProperty(value = "Ensembl gene id", position=1, required = true)
     private String geneId;
 
-    @ApiModelProperty(value = "Hugo symbol synonyms", position=2, required = false)
-    private String[] synonyms;
+    @ApiModelProperty(value = "Approved Hugo symbol", position=2, required = true)
+    private String hugoSymbol;
 
     @ApiModelProperty(value = "Hugo symbol synonyms", position=3, required = false)
+    private String[] synonyms;
+
+    @ApiModelProperty(value = "Previous Hugo symbols", position=4, required = false)
     private String[] previousSymbols;
 }


### PR DESCRIPTION
- Query in order: approved, synonym, previous symbols. This is necessary
  because there is overlap between these three.
- Show hugo symbol in response