### PR TITLE
Ignore HGVS where position is 0

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/NotationConverter.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/NotationConverter.java
@@ -100,7 +100,8 @@ public class NotationConverter
         String hgvs;
 
         // cannot convert invalid locations
-        if (start < 0) {
+        // Ensembl uses a one-based coordinate system
+        if (start < 1) {
             hgvs = null;
         }
         /*

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/cached/CachedVariantAnnotationFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/cached/CachedVariantAnnotationFetcher.java
@@ -35,7 +35,7 @@ public class CachedVariantAnnotationFetcher extends BaseCachedExternalResourceFe
 
     @Override
     protected Boolean isValidId(String id) {
-        return !id.contains("N") && !id.contains("-") && !id.contains("undefined") && id.contains(":") && id.split(":")[1].matches(".*\\d+.*");
+        return !id.contains("N") && !id.contains("-") && !id.contains("undefined") && !id.contains("g.0") && id.contains(":") && id.split(":")[1].matches(".*\\d+.*");
     }
 
     @Override


### PR DESCRIPTION
Ensembl only has 1 based coordinates, so ignore those when querying. Also show
subset causing error in logs instead of only the entire query.