### PR TITLE
Enable gzip compression in example properties

### DIFF
--- a/web/src/main/resources/application.properties.EXAMPLE
+++ b/web/src/main/resources/application.properties.EXAMPLE
@@ -27,3 +27,8 @@ spring.data.mongodb.uri=mongodb://127.0.0.1:27017/annotator
 # Server port number for the embedded tomcat. This property is required only when building
 # a jar file, and ignored when building a war file.
 server.port=38080
+
+# enable compression when running embedded tomcat
+server.compression.enabled=true
+server.compression.min-response-size=2048
+server.compression.mime-types=application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css


### PR DESCRIPTION
This is for running the jar as embedded tomcat

This does not apply to production, that tomcat does have gzip enabled. But the k8s deployment was running it using embedded tomcat