### PR TITLE
Renamed the nickname of the function fetchVariantAnnotationSummaryPOST

### DIFF
--- a/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationSummaryController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationSummaryController.java
@@ -28,7 +28,7 @@ public class AnnotationSummaryController
     }
 
     @ApiOperation(value = "Retrieves VEP annotation summary for the provided list of variants",
-        nickname = "fetchVariantAnnotationPOST")
+        nickname = "fetchVariantAnnotationSummaryPOST")
     @RequestMapping(value = "/annotation/summary",
         method = RequestMethod.POST,
         produces = "application/json")


### PR DESCRIPTION
Renamed `fetchVariantAnnotationPOST` to `fetchVariantAnnotationSummaryPOST` for consistency.