### PR TITLE
Enabled indexing and caching for hotspot repository

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/Hotspot.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/Hotspot.java
@@ -33,6 +33,7 @@
 package org.cbioportal.genome_nexus.model;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -43,6 +44,7 @@ public class Hotspot
     @Id
     private String id;
 
+    @Indexed
     @Field(value="hugo_symbol")
     private String hugoSymbol;
 

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -20,6 +20,10 @@
             <artifactId>model</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/HotspotRepository.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/HotspotRepository.java
@@ -33,6 +33,7 @@
 package org.cbioportal.genome_nexus.persistence;
 
 import org.cbioportal.genome_nexus.model.Hotspot;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.List;
@@ -42,5 +43,6 @@ import java.util.List;
  */
 public interface HotspotRepository extends MongoRepository<Hotspot, String>
 {
+    @Cacheable("hotspotsByHugoSymbol")
     List<Hotspot> findByHugoSymbol(String hugoSymbol);
 }

--- a/web/src/main/java/org/cbioportal/genome_nexus/GenomeNexusAnnotation.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/GenomeNexusAnnotation.java
@@ -38,6 +38,7 @@ import org.cbioportal.genome_nexus.web.config.PublicApi;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import springfox.documentation.builders.ApiInfoBuilder;
@@ -55,6 +56,7 @@ import java.util.HashSet;
  * @author Benjamin Gross
  */
 @SpringBootApplication(scanBasePackages = "org.cbioportal.genome_nexus") // shorthand for @Configuration, @EnableAutoConfiguration, @ComponentScan
+@EnableCaching
 @EnableSwagger2 // enable swagger2 documentation
 public class GenomeNexusAnnotation extends SpringBootServletInitializer
 {


### PR DESCRIPTION
Enabled default caching of hotspot queries by hugo symbols.

Default caching uses in-memory `ConcurrentHashMap`: https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-caching.html#boot-features-caching-provider-simple