### PR TITLE
Remove get all ensembl transcripts, pfam domains

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/PfamDomainService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/PfamDomainService.java
@@ -11,6 +11,5 @@ import java.util.List;
 public interface PfamDomainService
 {
     PfamDomain getPfamDomainByPfamAccession(String pfamDomainAccession) throws PfamDomainNotFoundException;
-    List<PfamDomain> getAllPfamDomains();
     List<PfamDomain> getPfamDomainsByPfamAccession(List<String> pfamDomainAccessions);
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/EnsemblServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/EnsemblServiceImpl.java
@@ -92,7 +92,7 @@ public class EnsemblServiceImpl implements EnsemblService
     {
         if (geneId == null && proteinId == null && hugoSymbol == null)
         {
-            return this.ensemblRepository.findAll();
+            return new ArrayList<EnsemblTranscript>();
         }
         else if (geneId != null && proteinId == null && hugoSymbol == null)
         {
@@ -135,7 +135,7 @@ public class EnsemblServiceImpl implements EnsemblService
             return this.ensemblRepository.findByHugoSymbolsIn(hugoSymbols);
         }
         else {
-            return this.ensemblRepository.findAll();
+            return new ArrayList<EnsemblTranscript>();
         }
     }
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/PfamDomainServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/PfamDomainServiceImpl.java
@@ -24,11 +24,6 @@ public class PfamDomainServiceImpl implements PfamDomainService
     }
 
     @Override
-    public List<PfamDomain> getAllPfamDomains() {
-        return this.pfamDomainRepository.findAll();
-    }
-
-    @Override
     public PfamDomain getPfamDomainByPfamAccession(String pfamDomainAccession) throws PfamDomainNotFoundException
     {
         PfamDomain domain = this.pfamDomainRepository.findOneByPfamAccession(pfamDomainAccession);

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/PfamController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/PfamController.java
@@ -30,16 +30,6 @@ public class PfamController
         this.pfamDomainService = pfamDomainService;
     }
 
-    @ApiOperation(value = "Retrieves all PFAM domains",
-        nickname = "fetchPfamDomainsGET")
-    @RequestMapping(value = "/pfam/domain",
-        method = RequestMethod.GET,
-        produces = "application/json")
-    public List<PfamDomain> fetchPfamDomainsGET()
-    {
-        return pfamDomainService.getAllPfamDomains();
-    }
-
     @ApiOperation(value = "Retrieves PFAM domains by PFAM domain accession IDs",
         nickname = "fetchPfamDomainsByPfamAccessionPOST")
     @RequestMapping(value = "/pfam/domain",


### PR DESCRIPTION
We noticed in the access log that a lot of requests to get all ensembl
transcripts overloads the server quite heavily. We don't really use these
endpoints and it prolly makes more sense to just get the data dump in those use
cases.