### PR TITLE
Fix #200 convert 23/24-X/Y

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/NotationConverter.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/NotationConverter.java
@@ -15,6 +15,14 @@ public class NotationConverter
 {
     public static final String DEFAULT_DELIMITER = ",";
 
+    public String hgvsNormalizer(String hgvs) {
+        return hgvs.replace("chr","").replace("23:g.","X:g.").replace("24:g.","Y:g.");
+    }
+
+    public String chromosomeNormalizer(String chromosome) {
+        return chromosome.trim().replace("chr","").replace("23","X").replace("24","Y");
+    }
+
     @Nullable
     public GenomicLocation parseGenomicLocation(String genomicLocation)
     {
@@ -40,7 +48,7 @@ public class NotationConverter
 
             location = new GenomicLocation();
 
-            location.setChromosome(parts[0]);
+            location.setChromosome(this.chromosomeNormalizer(parts[0]));
             location.setStart(Integer.parseInt(parts[1]));
             location.setEnd(Integer.parseInt(parts[2]));
             location.setReferenceAllele(parts[3]);
@@ -64,7 +72,7 @@ public class NotationConverter
         }
 
         // trim string values
-        String chr = genomicLocation.getChromosome().trim();
+        String chr = this.chromosomeNormalizer(genomicLocation.getChromosome().trim());
         Integer start = genomicLocation.getStart();
         Integer end = genomicLocation.getEnd();
         String ref = genomicLocation.getReferenceAllele().trim();

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationServiceImpl.java
@@ -56,6 +56,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * @author Benjamin Gross
@@ -94,13 +95,16 @@ public class VariantAnnotationServiceImpl implements VariantAnnotationService
     public VariantAnnotation getAnnotation(String variant)
         throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException
     {
-        return this.getVariantAnnotation(variant, null);
+        return this.getVariantAnnotation(notationConverter.hgvsNormalizer(variant), null);
     }
 
     @Override
     public List<VariantAnnotation> getAnnotations(List<String> variants)
     {
-        return this.getVariantAnnotations(variants, null);
+        return this.getVariantAnnotations(
+            variants.stream().map(v -> notationConverter.hgvsNormalizer(v)).collect(Collectors.toList()),
+            null
+        );
     }
 
     @Override
@@ -109,7 +113,7 @@ public class VariantAnnotationServiceImpl implements VariantAnnotationService
     {
         EnrichmentService postEnrichmentService = this.initPostEnrichmentService(isoformOverrideSource, fields);
 
-        return this.getVariantAnnotation(variant, postEnrichmentService);
+        return this.getVariantAnnotation(notationConverter.hgvsNormalizer(variant), postEnrichmentService);
     }
 
     @Override
@@ -117,7 +121,10 @@ public class VariantAnnotationServiceImpl implements VariantAnnotationService
     {
         EnrichmentService postEnrichmentService = this.initPostEnrichmentService(isoformOverrideSource, fields);
 
-        return this.getVariantAnnotations(variants, postEnrichmentService);
+        return this.getVariantAnnotations(
+            variants.stream().map(v -> notationConverter.hgvsNormalizer(v)).collect(Collectors.toList()),
+            postEnrichmentService
+        );
     }
 
     private List<VariantAnnotation> getVariantAnnotations(List<String> variants)

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/NotationConverterTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/NotationConverterTest.java
@@ -29,6 +29,22 @@ public class NotationConverterTest
         assertEquals((Integer)9784948, location.getEnd());
         assertEquals("-", location.getReferenceAllele());
         assertEquals("AGA", location.getVariantAllele());
+
+        GenomicLocation location2 = this.notationConverter.parseGenomicLocation("chr23,41242962,41242963,-,GA");
+
+        assertEquals("X", location2.getChromosome());
+        assertEquals((Integer)41242962, location2.getStart());
+        assertEquals((Integer)41242963, location2.getEnd());
+        assertEquals("-", location2.getReferenceAllele());
+        assertEquals("GA", location2.getVariantAllele());
+
+        GenomicLocation location3 = this.notationConverter.parseGenomicLocation("chr24,41242962,41242963,-,GA");
+
+        assertEquals("Y", location3.getChromosome());
+        assertEquals((Integer)41242962, location3.getStart());
+        assertEquals((Integer)41242963, location3.getEnd());
+        assertEquals("-", location3.getReferenceAllele());
+        assertEquals("GA", location3.getVariantAllele());
     }
 
     @Test
@@ -54,6 +70,24 @@ public class NotationConverterTest
 
         assertEquals("22:g.36689419_36689421delCCT",
             this.notationConverter.genomicToHgvs("22,36689419,36689421,CCT,-"));
+            
+        assertEquals("X:g.41242962_41242963insGA",
+            this.notationConverter.genomicToHgvs("X,41242962,41242963,-,GA"));
+
+        assertEquals("X:g.41242962_41242963insGA",
+            this.notationConverter.genomicToHgvs("chrX,41242962,41242963,-,GA"));
+
+        assertEquals("X:g.41242962_41242963insGA",
+            this.notationConverter.genomicToHgvs("chr23,41242962,41242963,-,GA"));
+
+        assertEquals("Y:g.41242962_41242963insGA",
+            this.notationConverter.genomicToHgvs("Y,41242962,41242963,-,GA"));
+
+        assertEquals("Y:g.41242962_41242963insGA",
+            this.notationConverter.genomicToHgvs("chrY,41242962,41242963,-,GA"));
+
+        assertEquals("Y:g.41242962_41242963insGA",
+            this.notationConverter.genomicToHgvs("chr24,41242962,41242963,-,GA"));
 
         assertEquals("3:g.14106026_14106037delCCAGCAGTAGCT",
             this.notationConverter.genomicToHgvs("3,14106026,14106037,CCAGCAGTAGCT,-"));

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantAnnotationMockData.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantAnnotationMockData.java
@@ -59,6 +59,10 @@ public class VariantAnnotationMockData implements MockData<VariantAnnotation>
             this.objectMapper.readVariantAnnotation("22_g.29091840_29091841delTGinsCA.json"));
         mockData.put("22:g.36689419_36689421delCCT",
             this.objectMapper.readVariantAnnotation("22_g.36689419_36689421delCCT.json"));
+        mockData.put("X:g.41242962_41242963insGA",
+            this.objectMapper.readVariantAnnotation("X_g.41242962_41242963insGA.json"));
+        mockData.put("Y:g.41242962_41242963insGA",
+            this.objectMapper.readVariantAnnotation("Y_g.41242962_41242963insGA.json"));
 
         return mockData;
     }

--- a/service/src/test/resources/variant/X_g.41242962_41242963insGA.json
+++ b/service/src/test/resources/variant/X_g.41242962_41242963insGA.json
@@ -1,0 +1,11 @@
+{
+    "variant": "X:g.41242962_41242963insGA",
+    "id": "X:g.41242962_41242963insGA",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "X",
+    "start": 41242963,
+    "end": 41242962,
+    "allele_string": "-/GA",
+    "strand": 1,
+    "most_severe_consequence": "regulatory_region_variant"
+}

--- a/service/src/test/resources/variant/Y_g.41242962_41242963insGA.json
+++ b/service/src/test/resources/variant/Y_g.41242962_41242963insGA.json
@@ -1,0 +1,11 @@
+{
+    "variant": "Y:g.41242962_41242963insGA",
+    "id": "Y:g.41242962_41242963insGA",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "Y",
+    "start": 41242963,
+    "end": 41242962,
+    "allele_string": "-/GA",
+    "strand": 1,
+    "most_severe_consequence": "intergenic_variant"
+}


### PR DESCRIPTION
- Add methods to NotationConverter class to normalize chr23 to X, and chr24 to
  Y. Taking care of both using variants prefixed with chr and the 23/x and 24/y
  issue.
- Add tests for the variant annotation service. The NotionConverter utility
  functions are v simple, so seems better to test the annotation service
  directly.