### PR TITLE
Use _splice hgvspShort when splice is most severe

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ProteinChangeResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ProteinChangeResolver.java
@@ -155,6 +155,8 @@ public class ProteinChangeResolver
         try {
             String[] aaParts = transcriptConsequence.getAminoAcids().split("/");
 
+            // TODO: always using get(0) here, maybe better to get most
+            // impactful consequence and use that?
             if (transcriptConsequence.getConsequenceTerms() != null &&
                 transcriptConsequence.getConsequenceTerms().get(0).toLowerCase().contains("inframe_insertion"))
             {
@@ -223,8 +225,13 @@ public class ProteinChangeResolver
     {
         String hgvsp = null;
 
+        String variantClassification = this.variantClassificationResolver.resolve(null, transcriptConsequence);
+
+        // only use hgvsp if the most severe impact is not a splice variant
         if (transcriptConsequence != null &&
-            transcriptConsequence.getHgvsp() != null)
+            transcriptConsequence.getHgvsp() != null &&
+            !(variantClassification != null && variantClassification.toLowerCase().contains("splice"))
+            )
         {
             hgvsp = this.normalizeHgvsp(transcriptConsequence.getHgvsp());
         }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/VariantClassificationResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/VariantClassificationResolver.java
@@ -132,7 +132,7 @@ public class VariantClassificationResolver
     {
         String defaultValue = "Targeted_Region";
 
-        if (variant == null || variantType == null) {
+        if (variant == null || (variantType == null && !variant.contains("splice"))) {
             return defaultValue;
         }
         else {

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/ProteinChangeResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/ProteinChangeResolverTest.java
@@ -1,5 +1,6 @@
 package org.cbioportal.genome_nexus.service.annotation;
 
+import org.cbioportal.genome_nexus.model.TranscriptConsequence;
 import org.cbioportal.genome_nexus.model.VariantAnnotation;
 import org.cbioportal.genome_nexus.service.mock.CanonicalTranscriptResolverMocker;
 import org.cbioportal.genome_nexus.service.mock.VariantAnnotationMockData;
@@ -11,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -168,6 +170,28 @@ public class ProteinChangeResolverTest
             this.proteinChangeResolver.resolveHgvspShort(
                 variantMockData.get("22:g.29091840_29091841delTGinsCA"),
                 variantMockData.get("22:g.29091840_29091841delTGinsCA").getTranscriptConsequences().get(0)
+            )
+        );
+
+        assertEquals(
+            "p.X210_splice",
+            this.proteinChangeResolver.resolveHgvspShort(
+                variantMockData.get("7:g.55220240G>T"),
+                variantMockData.get("7:g.55220240G>T").getTranscriptConsequences().get(0)
+            )
+        );
+    }
+
+    @Test
+    public void resolveHgvsp() throws IOException
+    {
+        Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
+        this.variantClassificationResolverMocker.mockMethods(variantMockData, this.variantClassificationResolver);
+
+        assertNull(
+            "Hgvsp is null when most severe consequence is splice",
+            this.proteinChangeResolver.resolveHgvsp(
+                variantMockData.get("7:g.55220240G>T").getTranscriptConsequences().get(0)
             )
         );
     }

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/ProteinPositionResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/ProteinPositionResolverTest.java
@@ -11,6 +11,9 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Arrays;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class ProteinPositionResolverTest

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/VariantClassificationResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/VariantClassificationResolverTest.java
@@ -170,5 +170,13 @@ public class VariantClassificationResolverTest
                 variantMockData.get("19:g.46141892_46141893delTCinsAA").getTranscriptConsequences().get(1)
             )
         );
+
+        assertEquals(
+            "Splice_Region",
+            this.variantClassificationResolver.resolve(
+                null,
+                variantMockData.get("7:g.55220240G>T").getTranscriptConsequences().get(0)
+            )
+        );
     }
 }

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantAnnotationMockData.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantAnnotationMockData.java
@@ -37,6 +37,8 @@ public class VariantAnnotationMockData implements MockData<VariantAnnotation>
             this.objectMapper.readVariantAnnotation("6_g.137519505_137519506delCTinsA.json"));
         mockData.put("6:g.137519505_137519506delCT",
             this.objectMapper.readVariantAnnotation("6_g.137519505_137519506delCT.json"));
+        mockData.put("7:g.55220240G>T",
+            this.objectMapper.readVariantAnnotation("7_g.55220240G_T.json"));
         mockData.put("7:g.140453136A>T",
             this.objectMapper.readVariantAnnotation("7_g.140453136A_T.json"));
         mockData.put("8:g.37696499_37696500insG",

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantClassificationResolverMocker.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantClassificationResolverMocker.java
@@ -124,5 +124,11 @@ public class VariantClassificationResolverMocker
         ).thenReturn(
             "In_Frame_Del"
         );
+
+        Mockito.when(
+            variantClassificationResolver.resolve(null, variantMockData.get("7:g.55220240G>T").getTranscriptConsequences().get(0))
+        ).thenReturn(
+            "Splice_Region"
+        );
     }
 }

--- a/service/src/test/resources/variant/7_g.55220240G_T.json
+++ b/service/src/test/resources/variant/7_g.55220240G_T.json
@@ -1,0 +1,170 @@
+{
+    "variant": "7:g.55220240G>T",
+    "colocatedVariants": [
+        {},
+        {},
+        {},
+        {}
+    ],
+    "id": "7:g.55220240G>T",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "7",
+    "start": 55220240,
+    "end": 55220240,
+    "allele_string": "G/T",
+    "strand": 1,
+    "most_severe_consequence": "splice_region_variant",
+    "transcript_consequences": [
+        {
+            "transcript_id": "ENST00000275493",
+            "hgvsp": "ENSP00000275493.2:p.Leu210=",
+            "hgvsc": "ENST00000275493.2:c.630G>T",
+            "variant_allele": "T",
+            "codons": "ctG/ctT",
+            "protein_id": "ENSP00000275493",
+            "protein_start": 210,
+            "protein_end": 210,
+            "gene_symbol": "EGFR",
+            "gene_id": "ENSG00000146648",
+            "amino_acids": "L",
+            "hgnc_id": 3236,
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_005228.3"
+            ],
+            "consequence_terms": [
+                "splice_region_variant",
+                "synonymous_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000342916",
+            "hgvsp": "ENSP00000342376.3:p.Leu210=",
+            "hgvsc": "ENST00000342916.3:c.630G>T",
+            "variant_allele": "T",
+            "codons": "ctG/ctT",
+            "protein_id": "ENSP00000342376",
+            "protein_start": 210,
+            "protein_end": 210,
+            "gene_symbol": "EGFR",
+            "gene_id": "ENSG00000146648",
+            "amino_acids": "L",
+            "hgnc_id": 3236,
+            "refseq_transcript_ids": [
+                "NM_201282.1"
+            ],
+            "consequence_terms": [
+                "splice_region_variant",
+                "synonymous_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000344576",
+            "hgvsp": "ENSP00000345973.2:p.Leu210=",
+            "hgvsc": "ENST00000344576.2:c.630G>T",
+            "variant_allele": "T",
+            "codons": "ctG/ctT",
+            "protein_id": "ENSP00000345973",
+            "protein_start": 210,
+            "protein_end": 210,
+            "gene_symbol": "EGFR",
+            "gene_id": "ENSG00000146648",
+            "amino_acids": "L",
+            "hgnc_id": 3236,
+            "refseq_transcript_ids": [
+                "NM_201284.1"
+            ],
+            "consequence_terms": [
+                "splice_region_variant",
+                "synonymous_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000420316",
+            "hgvsp": "ENSP00000413843.2:p.Leu210=",
+            "hgvsc": "ENST00000420316.2:c.630G>T",
+            "variant_allele": "T",
+            "codons": "ctG/ctT",
+            "protein_id": "ENSP00000413843",
+            "protein_start": 210,
+            "protein_end": 210,
+            "gene_symbol": "EGFR",
+            "gene_id": "ENSG00000146648",
+            "amino_acids": "L",
+            "hgnc_id": 3236,
+            "refseq_transcript_ids": [
+                "NM_201283.1"
+            ],
+            "consequence_terms": [
+                "splice_region_variant",
+                "synonymous_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000442591",
+            "hgvsp": "ENSP00000410031.1:p.Leu210=",
+            "hgvsc": "ENST00000442591.1:c.630G>T",
+            "variant_allele": "T",
+            "codons": "ctG/ctT",
+            "protein_id": "ENSP00000410031",
+            "protein_start": 210,
+            "protein_end": 210,
+            "gene_symbol": "EGFR",
+            "gene_id": "ENSG00000146648",
+            "amino_acids": "L",
+            "hgnc_id": 3236,
+            "consequence_terms": [
+                "splice_region_variant",
+                "synonymous_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000454757",
+            "hgvsp": "ENSP00000395243.2:p.Leu157=",
+            "hgvsc": "ENST00000454757.2:c.471G>T",
+            "variant_allele": "T",
+            "codons": "ctG/ctT",
+            "protein_id": "ENSP00000395243",
+            "protein_start": 157,
+            "protein_end": 157,
+            "gene_symbol": "EGFR",
+            "gene_id": "ENSG00000146648",
+            "amino_acids": "L",
+            "hgnc_id": 3236,
+            "consequence_terms": [
+                "splice_region_variant",
+                "synonymous_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000455089",
+            "hgvsp": "ENSP00000415559.1:p.Leu165=",
+            "hgvsc": "ENST00000455089.1:c.495G>T",
+            "variant_allele": "T",
+            "codons": "ctG/ctT",
+            "protein_id": "ENSP00000415559",
+            "protein_start": 165,
+            "protein_end": 165,
+            "gene_symbol": "EGFR",
+            "gene_id": "ENSG00000146648",
+            "amino_acids": "L",
+            "hgnc_id": 3236,
+            "consequence_terms": [
+                "splice_region_variant",
+                "synonymous_variant"
+            ]
+        }
+    ],
+    "hotspots": {
+        "license": "https://opendatacommons.org/licenses/odbl/1.0/",
+        "annotation": [
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            []
+        ]
+    }
+}


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/2236

When there are multiple consequence terms and splice is the most severe, use *_splice for hgvspShort.

```
{
"transcriptId": "ENST00000275493",
"codonChange": "ctG/ctT",
"entrezGeneId": "1956",
"consequenceTerms": "splice_region_variant,synonymous_variant",
"hugoGeneSymbol": "EGFR",
"hgvspShort": "L210=",
"hgvsp": "p.Leu210=",
"hgvsc": "ENST00000275493.2:c.630G>T",
"proteinPosition": {
"start": 210,
"end": 210
},
"refSeq": "NM_005228.3",
"variantClassification": "Splice_Region"
},
```
becomes
```
{
"transcriptId": "ENST00000275493",
"codonChange": "ctG/ctT",
"entrezGeneId": "1956",
"consequenceTerms": "splice_region_variant,synonymous_variant",
"hugoGeneSymbol": "EGFR",
"hgvspShort": "X210_splice",
"hgvsc": "ENST00000275493.2:c.630G>T",
"proteinPosition": {
"start": 210,
"end": 210
},
"refSeq": "NM_005228.3",
"variantClassification": "Splice_Region"
}
```