### PR TITLE
Add endpoint to get canonical gene by entrez id

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/EnsemblCanonical.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/EnsemblCanonical.java
@@ -39,6 +39,8 @@ public class EnsemblCanonical
     private String refseqIds;
     @Field(value="uniprot_id")
     private String uniprotId;
+    @Field(value="entrez_gene_id")
+    private String entrezGeneId;
 
     private static String[] splitByComma(String input) {
         Pattern p = Pattern.compile("\\s*,\\s*");
@@ -86,5 +88,15 @@ public class EnsemblCanonical
 
     public String getEnsemblCanonicalTranscriptId() {
         return this.ensemblCanonicalTranscriptId;
+    }
+
+    public String getEntrezGeneId() {
+        // remove .0 for backwards compatibility with databases where
+        // entrez_gene_id field is a float
+        if (this.entrezGeneId != null && this.entrezGeneId.endsWith(".0")) {
+            return this.entrezGeneId.substring(0, this.entrezGeneId.length() - 2);
+        } else {
+            return this.entrezGeneId;
+        }
     }
 }

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/EnsemblGene.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/EnsemblGene.java
@@ -9,6 +9,7 @@ public class EnsemblGene
     private String hugoSymbol;
     private String[] synonyms;
     private String[] previousSymbols;
+    private String entrezGeneId;
 
     public EnsemblGene(EnsemblCanonical cn)
     {
@@ -16,6 +17,7 @@ public class EnsemblGene
         this.hugoSymbol = cn.getHugoSymbol();
         this.synonyms = cn.getSynonyms();
         this.previousSymbols = cn.getPreviousSymbols();
+        this.entrezGeneId = cn.getEntrezGeneId();
     }
 
     public String getGeneId() {
@@ -32,6 +34,10 @@ public class EnsemblGene
 
     public String[] getPreviousSymbols() {
         return this.previousSymbols;
+    }
+
+    public String getEntrezGeneId() {
+        return this.entrezGeneId;
     }
 }
 

--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/internal/EnsemblRepositoryCustom.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/internal/EnsemblRepositoryCustom.java
@@ -38,4 +38,5 @@ public interface EnsemblRepositoryCustom
 {
     EnsemblTranscript findOneByHugoSymbolIgnoreCase(String hugoSymbol, String isoformOverrideSource);
     EnsemblGene getCanonicalEnsemblGeneIdByHugoSymbol(String hugoSymbol);
+    EnsemblGene getCanonicalEnsemblGeneIdByEntrezGeneId(String ensemblGeneId);
 }

--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/internal/EnsemblRepositoryImpl.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/internal/EnsemblRepositoryImpl.java
@@ -61,9 +61,33 @@ public class EnsemblRepositoryImpl implements EnsemblRepositoryCustom
         return ensemblCanonical;
     }
 
+    private EnsemblCanonical findOneCanonicalByEntrezGeneId(String entrezGeneId) {
+        EnsemblCanonical ensemblCanonical;
+        Query query;
+
+        // search by entrez gene id
+        Criteria criteria = Criteria.where("entrez_gene_id").is(Integer.valueOf(entrezGeneId));
+        query = new Query();
+        query.addCriteria(criteria);
+        ensemblCanonical = mongoTemplate.findOne(query,
+            EnsemblCanonical.class, CANONICAL_TRANSCRIPTS_COLLECTION);
+
+        return ensemblCanonical;
+    }
+
     @Override
     public EnsemblGene getCanonicalEnsemblGeneIdByHugoSymbol(String hugoSymbol) {
         EnsemblCanonical ensemblCanonical = this.findOneCanonicalByHugoSymbol(hugoSymbol);
+        if (ensemblCanonical != null) {
+            return new EnsemblGene(ensemblCanonical);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public EnsemblGene getCanonicalEnsemblGeneIdByEntrezGeneId(String entrezGeneId) {
+        EnsemblCanonical ensemblCanonical = this.findOneCanonicalByEntrezGeneId(entrezGeneId);
         if (ensemblCanonical != null) {
             return new EnsemblGene(ensemblCanonical);
         } else {

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/EnsemblService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/EnsemblService.java
@@ -4,6 +4,7 @@ import org.cbioportal.genome_nexus.model.EnsemblGene;
 import org.cbioportal.genome_nexus.model.EnsemblTranscript;
 import org.cbioportal.genome_nexus.service.exception.EnsemblTranscriptNotFoundException;
 import org.cbioportal.genome_nexus.service.exception.NoEnsemblGeneIdForHugoSymbolException;
+import org.cbioportal.genome_nexus.service.exception.NoEnsemblGeneIdForEntrezGeneIdException;
 
 import java.util.List;
 
@@ -15,6 +16,10 @@ public interface EnsemblService
     EnsemblGene getCanonicalEnsemblGeneIdByHugoSymbol(String hugoSymbol)
         throws NoEnsemblGeneIdForHugoSymbolException;
     List<EnsemblGene> getCanonicalEnsemblGeneIdByHugoSymbols(List<String> hugoSymbol);
+
+    EnsemblGene getCanonicalEnsemblGeneIdByEntrezGeneId(String entrezGeneId)
+        throws NoEnsemblGeneIdForEntrezGeneIdException;
+    List<EnsemblGene> getCanonicalEnsemblGeneIdByEntrezGeneIds(List<String> entrezGeneId);
 
     EnsemblTranscript getCanonicalEnsemblTranscriptByHugoSymbol(String hugoSymbol, String isoformOverrideSource)
         throws EnsemblTranscriptNotFoundException;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/exception/NoEnsemblGeneIdForEntrezGeneIdException.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/exception/NoEnsemblGeneIdForEntrezGeneIdException.java
@@ -1,0 +1,25 @@
+package org.cbioportal.genome_nexus.service.exception;
+
+public class NoEnsemblGeneIdForEntrezGeneIdException extends Exception
+{
+    private String entrezGeneId;
+
+    public NoEnsemblGeneIdForEntrezGeneIdException(String entrezGeneId)
+    {
+        super();
+        this.entrezGeneId = entrezGeneId;
+    }
+
+    public String getEntrezGeneId() {
+        return entrezGeneId;
+    }
+
+    public void setEntrezGeneId(String entrezGeneId) {
+        this.entrezGeneId = entrezGeneId;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Entrez Gene Id not found: " + this.getEntrezGeneId();
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/EnsemblServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/EnsemblServiceImpl.java
@@ -5,6 +5,7 @@ import org.cbioportal.genome_nexus.model.EnsemblTranscript;
 import org.cbioportal.genome_nexus.persistence.EnsemblRepository;
 import org.cbioportal.genome_nexus.service.EnsemblService;
 import org.cbioportal.genome_nexus.service.exception.EnsemblTranscriptNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.NoEnsemblGeneIdForEntrezGeneIdException;
 import org.cbioportal.genome_nexus.service.exception.NoEnsemblGeneIdForHugoSymbolException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -43,6 +44,19 @@ public class EnsemblServiceImpl implements EnsemblService
     }
 
     @Override
+    public EnsemblGene getCanonicalEnsemblGeneIdByEntrezGeneId(String entrezGeneId)
+        throws NoEnsemblGeneIdForEntrezGeneIdException
+    {
+        EnsemblGene ensemblGene = this.ensemblRepository.getCanonicalEnsemblGeneIdByEntrezGeneId(entrezGeneId);
+
+        if (ensemblGene == null) {
+            throw new NoEnsemblGeneIdForEntrezGeneIdException(entrezGeneId);
+        }
+
+        return ensemblGene;
+    }
+
+    @Override
     public List<EnsemblGene> getCanonicalEnsemblGeneIdByHugoSymbols(List<String> hugoSymbols) {
         List<EnsemblGene> ensemblGenes = new ArrayList<>();
 
@@ -51,6 +65,22 @@ public class EnsemblServiceImpl implements EnsemblService
             try {
                 ensemblGenes.add(this.getCanonicalEnsemblGeneIdByHugoSymbol(hugoSymbol));
             } catch (NoEnsemblGeneIdForHugoSymbolException e) {
+                // ignore the exception for this hugo symbol
+            }
+        }
+
+        return ensemblGenes;
+    }
+
+    @Override
+    public List<EnsemblGene> getCanonicalEnsemblGeneIdByEntrezGeneIds(List<String> entrezGeneIds) {
+        List<EnsemblGene> ensemblGenes = new ArrayList<>();
+
+        for (String entrezGeneId : entrezGeneIds)
+        {
+            try {
+                ensemblGenes.add(this.getCanonicalEnsemblGeneIdByEntrezGeneId(entrezGeneId));
+            } catch (NoEnsemblGeneIdForEntrezGeneIdException e) {
                 // ignore the exception for this hugo symbol
             }
         }

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/EnsemblController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/EnsemblController.java
@@ -12,6 +12,7 @@ import org.cbioportal.genome_nexus.service.GeneXrefService;
 import org.cbioportal.genome_nexus.service.exception.EnsemblTranscriptNotFoundException;
 import org.cbioportal.genome_nexus.service.exception.EnsemblWebServiceException;
 import org.cbioportal.genome_nexus.service.exception.NoEnsemblGeneIdForHugoSymbolException;
+import org.cbioportal.genome_nexus.service.exception.NoEnsemblGeneIdForEntrezGeneIdException;
 import org.cbioportal.genome_nexus.web.config.PublicApi;
 import org.cbioportal.genome_nexus.web.param.EnsemblFilter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,6 +61,32 @@ public class EnsemblController
         @PathVariable String hugoSymbol) throws NoEnsemblGeneIdForHugoSymbolException
     {
         return this.ensemblService.getCanonicalEnsemblGeneIdByHugoSymbol(hugoSymbol);
+    }
+
+    @ApiOperation(value = "Retrieves canonical Ensembl Gene ID by Entrez Gene Ids",
+        nickname = "fetchCanonicalEnsemblGeneIdByEntrezGeneIdsPOST")
+    @RequestMapping(value = "/ensembl/canonical-gene/entrez",
+        method = RequestMethod.POST,
+        produces = "application/json")
+    public List<EnsemblGene> fetchCanonicalEnsemblGeneIdByEntrezGeneIdPOST(
+        @ApiParam(value = "List of Entrez Gene Ids. For example [\"23140\",\"26009\",\"100131879\"]",
+            required = true)
+        @RequestBody List<String> entrezGeneIds)
+    {
+        return this.ensemblService.getCanonicalEnsemblGeneIdByEntrezGeneIds(entrezGeneIds);
+    }
+
+    @ApiOperation(value = "Retrieves Ensembl canonical gene id by Entrez Gene Id",
+        nickname = "fetchCanonicalEnsemblGeneIdByEntrezGeneIdGET")
+    @RequestMapping(value = "/ensembl/canonical-gene/entrez/{entrezGeneId}",
+        method = RequestMethod.GET,
+        produces = "application/json")
+    public EnsemblGene fetchCanonicalEnsemblGeneIdByEntrezGeneIdGET(
+        @ApiParam(value = "An Entrez Gene Id. For example 23140",
+            required = true)
+        @PathVariable String entrezGeneId) throws NoEnsemblGeneIdForEntrezGeneIdException
+    {
+        return this.ensemblService.getCanonicalEnsemblGeneIdByEntrezGeneId(entrezGeneId);
     }
 
     @ApiOperation(value = "Retrieves Ensembl Transcripts by protein ID, and gene ID. " +

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/EnsemblGeneMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/EnsemblGeneMixin.java
@@ -16,4 +16,7 @@ public class EnsemblGeneMixin {
 
     @ApiModelProperty(value = "Previous Hugo symbols", position=4, required = false)
     private String[] previousSymbols;
+
+    @ApiModelProperty(value = "Entrez Gene Id", position=5, required = false)
+    private String entrezGeneId;
 }


### PR DESCRIPTION
Fix #208
Fix #12 

e.g.

/ensembl/canonical-gene/entrez/23140

gives

```
{
  "geneId": "ENSG00000074755",
  "hugoSymbol": "ZZEF1",
  "synonyms": [
    "KIAA0399",
    "ZZZ4",
    "FLJ10821"
  ],
  "entrezGeneId": "23140"
}
```