### PR TITLE
Add actuator

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -48,6 +48,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-tomcat</artifactId>
       <scope>provided</scope>
       </dependency>


### PR DESCRIPTION
Accessible with e.g. `/actuator/health`. Makes it easy to monitor java apps.
There's a property to change the port if we don't want to make the metrics
visiible to the world:

```
management.port=8081
```