### PR TITLE
Make sure hotspots match the transcript id

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     depends_on:
       - db
   db:
-    build: https://github.com/genome-nexus/genome-nexus-importer.git#v0.3
+    build: https://github.com/genome-nexus/genome-nexus-importer.git#v0.4
     restart: always
     ports:
       - "27017:27017"

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/Hotspot.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/Hotspot.java
@@ -48,6 +48,10 @@ public class Hotspot
     @Field(value="hugo_symbol")
     private String hugoSymbol;
 
+    @Indexed
+    @Field(value="transcript_id")
+    private String transcriptId;
+
     @Field(value="residue")
     private String residue;
 
@@ -75,6 +79,14 @@ public class Hotspot
 
     public void setHugoSymbol(String hugoSymbol) {
         this.hugoSymbol = hugoSymbol;
+    }
+
+    public String getTranscriptId() {
+        return this.transcriptId;
+    }
+
+    public void setTranscriptId(String transcriptId) {
+        this.transcriptId = transcriptId;
     }
 
     public String getResidue() {

--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/HotspotRepository.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/HotspotRepository.java
@@ -43,6 +43,6 @@ import java.util.List;
  */
 public interface HotspotRepository extends MongoRepository<Hotspot, String>
 {
-    @Cacheable("hotspotsByHugoSymbol")
-    List<Hotspot> findByHugoSymbol(String hugoSymbol);
+    @Cacheable("hotspotsByTranscriptId")
+    List<Hotspot> findByTranscriptId(String transcriptId);
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
@@ -69,9 +69,9 @@ public class CancerHotspotServiceImpl implements CancerHotspotService
     }
 
     @Override
-    public List<Hotspot> getHotspots(String hugoSymbol) throws CancerHotspotsWebServiceException
+    public List<Hotspot> getHotspots(String transcriptId) throws CancerHotspotsWebServiceException
     {
-        return this.hotspotRepository.findByHugoSymbol(hugoSymbol);
+        return this.hotspotRepository.findByTranscriptId(transcriptId);
     }
 
     @Override
@@ -80,7 +80,7 @@ public class CancerHotspotServiceImpl implements CancerHotspotService
     {
         Set<Hotspot> hotspots = new LinkedHashSet<>();
 
-        for (Hotspot hotspot : this.getHotspots(transcript.getGeneSymbol()))
+        for (Hotspot hotspot : this.getHotspots(transcript.getTranscriptId()))
         {
             // include only the hotspots matching certain criteria
             if (this.filterHotspot(hotspot, transcript, annotation)) {

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationServiceTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationServiceTest.java
@@ -239,9 +239,9 @@ public class VariantAnnotationServiceTest
             Mockito.any(VariantAnnotation.class))).thenReturn(true);
 
         Mockito.when(this.cancerHotspotService.getHotspots(
-            "BRAF")).thenReturn(hotspotMockData.get("ENST00000288602"));
+            "ENST00000288602")).thenReturn(hotspotMockData.get("ENST00000288602"));
         Mockito.when(this.cancerHotspotService.getHotspots(
-            "KRAS")).thenReturn(hotspotMockData.get("ENST00000256078"));
+            "ENST00000256078")).thenReturn(hotspotMockData.get("ENST00000256078"));
     }
 
     private void mockIsoformOverrideServiceMethods(Map<String, IsoformOverride> isoformOverrideMockData)

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/HotspotMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/HotspotMixin.java
@@ -13,6 +13,9 @@ public class HotspotMixin
     @ApiModelProperty(value = "Hugo gene symbol")
     private String hugoSymbol;
 
+    @ApiModelProperty(value = "Ensembl Transcript Id")
+    private String transcriptId;
+
     @ApiModelProperty(value = "Hotspot residue")
     private String residue;
 

--- a/web/src/test/java/org/cbioportal/genome_nexus/web/mock/HotspotMixin.java
+++ b/web/src/test/java/org/cbioportal/genome_nexus/web/mock/HotspotMixin.java
@@ -8,6 +8,9 @@ public class HotspotMixin
 {
     @JsonProperty(value="hugo_symbol")
     private String hugoSymbol;
+    
+    @JsonProperty(value="transcript_id")
+    private String transcriptId;
 
     @JsonProperty(value="residue")
     private String residue;

--- a/web/src/test/resources/hotspot/hotspots_integration_test.json
+++ b/web/src/test/resources/hotspot/hotspots_integration_test.json
@@ -1,6 +1,7 @@
 [
     {
         "hugo_symbol": "BRAF",
+        "transcript_id": "ENST00000288602",
         "residue": "N581",
         "type": "single residue",
         "tumor_count": 21,
@@ -11,6 +12,7 @@
     },
     {
         "hugo_symbol": "BRAF",
+        "transcript_id": "ENST00000288602",
         "residue": "N581",
         "type": "3d",
         "tumor_count": 11,
@@ -21,6 +23,7 @@
     },
     {
         "hugo_symbol": "ERBB2",
+        "transcript_id": "ENST00000269571",
         "residue": "L755",
         "type": "single residue",
         "tumor_count": 44,
@@ -31,6 +34,7 @@
     },
     {
         "hugo_symbol": "ERBB2",
+        "transcript_id": "ENST00000269571",
         "residue": "V697",
         "type": "single residue",
         "tumor_count": 4,
@@ -41,6 +45,7 @@
     },
     {
         "hugo_symbol": "KRAS",
+        "transcript_id": "ENST00000256078",
         "residue": "G12",
         "type": "single residue",
         "tumor_count": 2175,
@@ -51,6 +56,7 @@
     },
     {
         "hugo_symbol": "NRAS",
+        "transcript_id": "ENST00000369535",
         "residue": "G12",
         "type": "single residue",
         "tumor_count": 74,
@@ -61,6 +67,7 @@
     },
     {
         "hugo_symbol": "KRAS",
+        "transcript_id": "ENST00000256078",
         "residue": "G12",
         "type": "3d",
         "tumor_count": 735,
@@ -71,6 +78,7 @@
     },
     {
         "hugo_symbol": "KRAS",
+        "transcript_id": "ENST00000256078",
         "residue": "E63",
         "type": "3d",
         "tumor_count": 2,
@@ -81,6 +89,7 @@
     },
     {
         "hugo_symbol": "EGFR",
+        "transcript_id": "ENST00000275493",
         "residue": "745-759",
         "type": "in-frame indel",
         "tumor_count": 155,
@@ -91,6 +100,7 @@
     },
     {
         "hugo_symbol": "EGFR",
+        "transcript_id": "ENST00000275493",
         "residue": "764-774",
         "type": "in-frame indel",
         "tumor_count": 33,
@@ -101,6 +111,7 @@
     },
     {
         "hugo_symbol": "EGFR",
+        "transcript_id": "ENST00000275493",
         "residue": "709-710",
         "type": "in-frame indel",
         "tumor_count": 9,
@@ -108,5 +119,16 @@
         "trunc_count": 0,
         "inframe_count": 9,
         "splice_count": 0
+    },
+    {
+        "hugoSymbol": "DNMT1",
+        "transcript_id": "ENST00000340748",
+        "residue": "E432",
+        "tumorCount": 7,
+        "type": "single residue",
+        "missenseCount": 7,
+        "truncatingCount": 0,
+        "inframeCount": 0,
+        "spliceCount": 0
     }
 ]


### PR DESCRIPTION
Currently any hotpsot that has a matching protein change with the annotation is
outputted as long as they have the same hugo symbol. This makes sure only
mutations with matching transcript id are outputted.