### PR TITLE
Annotation Summary Return All Consequence Summary

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotationSummary.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotationSummary.java
@@ -10,7 +10,11 @@ public class VariantAnnotationSummary
     private String variantType;
     private String assemblyName;
     private String canonicalTranscriptId;
-    private List<TranscriptConsequenceSummary> transcriptConsequences;
+    // all transcript consequences annotated with e.g. proteinStart/End
+    private List<TranscriptConsequenceSummary> transcriptConsequenceSummaries;
+    // most impactful canonical annotation, when looking to pick a single
+    // annotation
+    private TranscriptConsequenceSummary transcriptConsequenceSummary;
 
     public String getVariant() {
         return variant;
@@ -60,11 +64,19 @@ public class VariantAnnotationSummary
         this.canonicalTranscriptId = canonicalTranscriptId;
     }
 
-    public List<TranscriptConsequenceSummary> getTranscriptConsequences() {
-        return transcriptConsequences;
+    public List<TranscriptConsequenceSummary> getTranscriptConsequenceSummaries() {
+        return transcriptConsequenceSummaries;
     }
 
-    public void setTranscriptConsequences(List<TranscriptConsequenceSummary> transcriptConsequences) {
-        this.transcriptConsequences = transcriptConsequences;
+    public void setTranscriptConsequenceSummaries(List<TranscriptConsequenceSummary> transcriptConsequences) {
+        this.transcriptConsequenceSummaries = transcriptConsequences;
+    }
+
+    public TranscriptConsequenceSummary getTranscriptConsequenceSummary() {
+        return this.transcriptConsequenceSummary;
+    }
+
+    public void setTranscriptConsequenceSummary(TranscriptConsequenceSummary transcriptConsequenceSummary) {
+        this.transcriptConsequenceSummary = transcriptConsequenceSummary;
     }
 }

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotationSummary.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotationSummary.java
@@ -10,6 +10,12 @@ public class VariantAnnotationSummary
     private String variantType;
     private String assemblyName;
     private String canonicalTranscriptId;
+    // old list of consequence summaries that only lists the canonical summary
+    // when calling annotation/ and lists all when calling annotation/summary/
+    // This has been replaced by tanscriptConsequenceSummary and
+    // transcriptConsequenceSummaries respectively
+    @Deprecated
+    private List<TranscriptConsequenceSummary> transcriptConsequences;
     // all transcript consequences annotated with e.g. proteinStart/End
     private List<TranscriptConsequenceSummary> transcriptConsequenceSummaries;
     // most impactful canonical annotation, when looking to pick a single
@@ -62,6 +68,14 @@ public class VariantAnnotationSummary
 
     public void setCanonicalTranscriptId(String canonicalTranscriptId) {
         this.canonicalTranscriptId = canonicalTranscriptId;
+    }
+
+    public List<TranscriptConsequenceSummary> getTranscriptConsequences() {
+        return this.transcriptConsequences;
+    }
+
+    public void setTranscriptConsequences(List<TranscriptConsequenceSummary> transcriptConsequences) {
+        this.transcriptConsequences = transcriptConsequences;
     }
 
     public List<TranscriptConsequenceSummary> getTranscriptConsequenceSummaries() {

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/CanonicalTranscriptAnnotationEnricher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/CanonicalTranscriptAnnotationEnricher.java
@@ -1,9 +1,13 @@
 package org.cbioportal.genome_nexus.service.enricher;
 
 import org.cbioportal.genome_nexus.model.VariantAnnotationSummary;
+import org.cbioportal.genome_nexus.model.TranscriptConsequenceSummary;
 import org.cbioportal.genome_nexus.model.VariantAnnotation;
 import org.cbioportal.genome_nexus.service.AnnotationEnricher;
 import org.cbioportal.genome_nexus.service.VariantAnnotationSummaryService;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class CanonicalTranscriptAnnotationEnricher implements AnnotationEnricher
@@ -20,6 +24,11 @@ public class CanonicalTranscriptAnnotationEnricher implements AnnotationEnricher
     {
         VariantAnnotationSummary annotationSummary =
             this.variantAnnotationSummaryService.getAnnotationSummary(annotation);
+        // For backwards compatibility transcriptConsequences should be a list
+        // of one when used as enrichment
+        List<TranscriptConsequenceSummary> transcriptConsequences = new ArrayList<>(1);
+        transcriptConsequences.add(annotationSummary.getTranscriptConsequenceSummary());
+        annotationSummary.setTranscriptConsequences(transcriptConsequences);
 
         annotation.setAnnotationSummary(annotationSummary);
     }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/CanonicalTranscriptAnnotationEnricher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/CanonicalTranscriptAnnotationEnricher.java
@@ -19,7 +19,7 @@ public class CanonicalTranscriptAnnotationEnricher implements AnnotationEnricher
     public void enrich(VariantAnnotation annotation)
     {
         VariantAnnotationSummary annotationSummary =
-            this.variantAnnotationSummaryService.getAnnotationSummaryForCanonical(annotation);
+            this.variantAnnotationSummaryService.getAnnotationSummary(annotation);
 
         annotation.setAnnotationSummary(annotationSummary);
     }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
@@ -83,9 +83,7 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
 
         if (annotationSummary != null && canonicalTranscript != null)
         {
-            List<TranscriptConsequenceSummary> summaries = new ArrayList<>(1);
-            summaries.add(this.getTranscriptSummary(annotation, canonicalTranscript));
-            annotationSummary.setTranscriptConsequences(summaries);
+            annotationSummary.setTranscriptConsequenceSummary(this.getTranscriptSummary(annotation, canonicalTranscript));
             annotationSummary.setCanonicalTranscriptId(canonicalTranscript.getTranscriptId());
         }
 
@@ -141,7 +139,7 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
                 summaries.add(this.getTranscriptSummary(annotation, transcriptConsequence));
             }
 
-            annotationSummary.setTranscriptConsequences(summaries);
+            annotationSummary.setTranscriptConsequenceSummaries(summaries);
         }
 
         return annotationSummary;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
@@ -83,8 +83,14 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
 
         if (annotationSummary != null && canonicalTranscript != null)
         {
+
             annotationSummary.setTranscriptConsequenceSummary(this.getTranscriptSummary(annotation, canonicalTranscript));
             annotationSummary.setCanonicalTranscriptId(canonicalTranscript.getTranscriptId());
+
+            // for backwards compatibility set transcriptConsequences
+            List<TranscriptConsequenceSummary> transcriptConsequences = new ArrayList<>(1);
+            transcriptConsequences.add(annotationSummary.getTranscriptConsequenceSummary());
+            annotationSummary.setTranscriptConsequences(transcriptConsequences);
         }
 
         return annotationSummary;
@@ -140,6 +146,7 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
             }
 
             annotationSummary.setTranscriptConsequenceSummaries(summaries);
+            annotationSummary.setTranscriptConsequences(summaries);
         }
 
         return annotationSummary;

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationController.java
@@ -197,7 +197,7 @@ public class AnnotationController
     @RequestMapping(value = "/annotation/dbsnp/",
         method = RequestMethod.POST,
         produces = "application/json")
-    public List<VariantAnnotation> fetchVariantIdAnnotationPOST(
+    public List<VariantAnnotation> fetchVariantbyDbSnpIdAnnotationPOST(
         @ApiParam(value="List of variant IDs. For example [\"rs116035550\"]",
             required = true)
         @RequestBody List<String> variantIds,
@@ -216,7 +216,7 @@ public class AnnotationController
     @RequestMapping(value = "/annotation/dbsnp/{variantId:.+}",
         method = RequestMethod.GET,
         produces = "application/json")
-    public VariantAnnotation fetchVariantAnnotationByIdGET(
+    public VariantAnnotation fetchVariantAnnotationByDbSnpIdGET(
         @ApiParam(value="dbSNP id. For example rs116035550.",
             required = true)
         @PathVariable String variantId,

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationSummaryController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationSummaryController.java
@@ -65,6 +65,9 @@ public class AnnotationSummaryController
         throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException
     {
         if (projection == TranscriptSummaryProjection.CANONICAL) {
+            // Default projection returns both the canonical and all transcript
+            // consequence summaries. This returns just the summary for the
+            // canonical transcript
             return this.variantAnnotationSummaryService.getAnnotationSummaryForCanonical(variant, isoformOverrideSource);
         }
         else {

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationSummaryMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationSummaryMixin.java
@@ -35,4 +35,7 @@ public class VariantAnnotationSummaryMixin
 
     @ApiModelProperty(value = "All transcript consequence summaries", required = true)
     private List<TranscriptConsequenceSummary> transcriptConsequenceSummaries;
+
+    @ApiModelProperty(value = "(Deprecated) Transcript consequence summaries (list of one when using annotation/, multiple when using annotation/summary/", required = true)
+    private List<TranscriptConsequenceSummary> transcriptConsequences;
 }

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationSummaryMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationSummaryMixin.java
@@ -30,6 +30,9 @@ public class VariantAnnotationSummaryMixin
     @ApiModelProperty(value = "Canonical transcript id")
     private String canonicalTranscriptId;
 
-    @ApiModelProperty(value = "List of transcript consequence summaries", required = true)
-    private List<TranscriptConsequenceSummary> transcriptConsequences;
+    @ApiModelProperty(value = "Most impactful transcript consequence of canonical transcript or if non-existent any transcript", required = true)
+    private TranscriptConsequenceSummary transcriptConsequenceSummary;
+
+    @ApiModelProperty(value = "All transcript consequence summaries", required = true)
+    private List<TranscriptConsequenceSummary> transcriptConsequenceSummaries;
 }


### PR DESCRIPTION
Before when doing the enrichment, only the canonical
transcriptConsequenceSummary was returned. Instead here we create a new field
transcriptConsequenceSummary that gives that one and also return all other
transcriptConsequenceSummaries. That way only one call is necessary to get all the annotations. The transcriptConsequenceSummary can serve as the default.

Also retain backwards compatibility for transcriptConsequences field:

- Support transcriptConsequences field. VariantAnnotationSummary service only
  used the canonical summary when used as an enricher. Then
  transcriptConsequences field would be a list of one. However when using the
  default projection of annotation/summary the list would include all
  transcriptConsequences. This changes the endpoint to return both through the
  fields transcriptConsequenceSummary (for canonical) and
  transcriptConsequencesSummaries (for all). Canonical projection is prolly not
  needed anymore but we can support it for backward compatibility.