### PR TITLE
Validate genomic location input

### DIFF
--- a/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationController.java
@@ -33,16 +33,20 @@
 package org.cbioportal.genome_nexus.web;
 
 import io.swagger.annotations.*;
+
 import org.cbioportal.genome_nexus.model.*;
 import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
 import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
 import org.cbioportal.genome_nexus.service.*;
+import org.cbioportal.genome_nexus.web.validation.*;
 
 import org.cbioportal.genome_nexus.web.config.PublicApi;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.*;
+
 
 /**
  * @author Benjamin Gross
@@ -51,6 +55,7 @@ import java.util.*;
 @RestController // shorthand for @Controller, @ResponseBody
 @CrossOrigin(origins="*") // allow all cross-domain requests
 @RequestMapping(value= "/")
+@Validated
 public class AnnotationController
 {
     private final VariantAnnotationService variantAnnotationService;
@@ -180,7 +185,7 @@ public class AnnotationController
     public VariantAnnotation fetchVariantAnnotationByGenomicLocationGET(
         @ApiParam(value="A genomic location. For example 7,140453136,140453136,A,T",
             required = true)
-        @PathVariable String genomicLocation,
+        @PathVariable @ValidGenomicLocation String genomicLocation,
         @ApiParam(value="Isoform override source. For example uniprot",
             required = false)
         @RequestParam(required = false) String isoformOverrideSource,
@@ -232,3 +237,4 @@ public class AnnotationController
     }
 
 }
+

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/validation/GenomicLocationValidator.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/validation/GenomicLocationValidator.java
@@ -1,0 +1,30 @@
+package org.cbioportal.genome_nexus.web.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import org.cbioportal.genome_nexus.web.validation.ValidGenomicLocation;
+
+public class GenomicLocationValidator implements ConstraintValidator<ValidGenomicLocation, String> {
+    
+    public void initialize(ValidGenomicLocation constraintAnnotation) {
+    }
+
+    public boolean isValid(String genomicLocation, ConstraintValidatorContext context) 
+    {
+        String[] genomicLocationSplit = genomicLocation.split(",");
+        if (genomicLocationSplit.length < 5) {
+            return false;
+        }
+        else {
+            boolean result = true;
+            // chr [1,24] or X or Y
+            result &= genomicLocationSplit[0].matches("X") || genomicLocationSplit[0].matches("Y") ||
+            genomicLocationSplit[0].matches("[0-9]+") && Integer.valueOf(genomicLocationSplit[0]) >= 1 && Integer.valueOf(genomicLocationSplit[0]) <= 24;
+            // start & end should be positive integer
+            result &= Integer.valueOf(genomicLocationSplit[1]) >= 0 && Integer.valueOf(genomicLocationSplit[2]) >= 0;
+            // variant & ref allele should only contain T,C,G,A,-
+            result &= genomicLocationSplit[3].matches("[TCGA-]*") && genomicLocationSplit[4].matches("[TCGA-]*");
+            return result;
+        }
+    }
+}

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/validation/ValidGenomicLocation.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/validation/ValidGenomicLocation.java
@@ -1,0 +1,19 @@
+package org.cbioportal.genome_nexus.web.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Constraint(validatedBy = { GenomicLocationValidator.class })
+public @interface ValidGenomicLocation {
+    String message() default "genomicLocation is incorrect";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/web/src/test/java/org/cbioportal/genome_nexus/web/validation/GenomicLocationValidatorTest.java
+++ b/web/src/test/java/org/cbioportal/genome_nexus/web/validation/GenomicLocationValidatorTest.java
@@ -1,0 +1,35 @@
+package org.cbioportal.genome_nexus.web.validation;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class GenomicLocationValidatorTest
+{
+    @Test
+    public void testMyVariantInfoAnnotation()
+    {
+        String[] genomicLocation = {
+            "7,140453136,140453136,A,ATGC-T", // true
+            "A,37880220,37880220,T,C", // false
+            "7,-1,37879794,G,C", // false
+            "12,25398284,-2,CC,GA", // false
+            "12,25380271,25380271,12,T", // false
+            "10,89692940,89692940,C,Q", // false
+            "X,89692940,89692940,C,", // false
+            "X_89692940_89692940_C_T" //false
+        };
+        GenomicLocationValidator validator = new GenomicLocationValidator();
+        assertEquals(true, validator.isValid(genomicLocation[0], null));
+        assertEquals(false, validator.isValid(genomicLocation[1], null));
+        assertEquals(false, validator.isValid(genomicLocation[2], null));
+        assertEquals(false, validator.isValid(genomicLocation[3], null));
+        assertEquals(false, validator.isValid(genomicLocation[4], null));
+        assertEquals(false, validator.isValid(genomicLocation[5], null));
+        assertEquals(false, validator.isValid(genomicLocation[6], null));
+        assertEquals(false, validator.isValid(genomicLocation[7], null));
+    }
+}
+


### PR DESCRIPTION
This checks whether the genomic location input of the request doesn't contain any unexpected characters.

- [x] logic implemented
- [x] tests
- [ ] return 4x error on incorrect input instead of 5x error