### PR TITLE
Hotspots by transcript id and protein location

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/AggregatedHotspots.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/AggregatedHotspots.java
@@ -6,6 +6,7 @@ public class AggregatedHotspots
 {
     private GenomicLocation genomicLocation;
     private String variant;
+    private ProteinLocation proteinLocation;
     private List<Hotspot> hotspots;
 
     public String getVariant() {
@@ -30,5 +31,13 @@ public class AggregatedHotspots
 
     public void setHotspots(List<Hotspot> hotspots) {
         this.hotspots = hotspots;
+    }
+
+    public void setProteinLocation(ProteinLocation proteinLocation) {
+        this.proteinLocation = proteinLocation;
+    }
+
+    public ProteinLocation getProteinLocation() {
+        return proteinLocation;
     }
 }

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/AggregatedHotspots.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/AggregatedHotspots.java
@@ -6,6 +6,7 @@ public class AggregatedHotspots
 {
     private GenomicLocation genomicLocation;
     private String variant;
+    private String transcriptId;
     private ProteinLocation proteinLocation;
     private List<Hotspot> hotspots;
 
@@ -39,5 +40,13 @@ public class AggregatedHotspots
 
     public ProteinLocation getProteinLocation() {
         return proteinLocation;
+    }
+
+    public String getTranscriptId() {
+        return transcriptId;
+    }
+
+    public void setTranscriptId(String transcriptId) {
+        this.transcriptId = transcriptId;
     }
 }

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/ProteinLocation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/ProteinLocation.java
@@ -1,0 +1,82 @@
+package org.cbioportal.genome_nexus.model;
+
+import java.util.*;
+
+public class ProteinLocation
+{
+    private String transcriptId;
+    private Integer start;
+    private Integer end;
+    private String mutationType;
+
+    public String getTranscriptId() {
+        return transcriptId;
+    }
+
+    public Integer getStart() {
+        return start;
+    }
+
+    public Integer getEnd() {
+        return end;
+    }
+
+    public String getMutationType() {
+        return mutationType;
+    }
+
+    public List<Hotspot> filterHotspot(List<Hotspot> hotspots, ProteinLocation proteinLocation){
+        int start = proteinLocation.getStart();
+        int end = proteinLocation.getEnd();
+        String type = proteinLocation.getMutationType();
+        List<Hotspot> result = new ArrayList<>();
+        for (Hotspot hotspot: hotspots) {
+            boolean valid = true;
+            
+            //Position
+            int hotspotStart, hotspotStop;
+            String hotspotPosition = hotspot.getResidue();
+            hotspotPosition = hotspotPosition.replaceAll("[^0-9.]", "");
+            if (hotspotPosition.split("-").length > 1){
+                hotspotStart = Integer.parseInt(hotspotPosition.split("-")[0]);
+                hotspotStop = Integer.parseInt(hotspotPosition.split("-")[1]);
+            }
+            else {
+                hotspotStart = Integer.parseInt(hotspotPosition);
+                hotspotStop = Integer.parseInt(hotspotPosition);
+            }
+            valid &= (start <= hotspotStart && end >= hotspotStop) ? true : false;
+            
+            //Type
+            if (type.equals("Missense_Mutation")) {
+                if (hotspot.getType().contains("3d") || hotspot.getType().contains("single residue")) {
+                    valid &= true;
+                }
+                else {
+                    valid = false;
+                }
+            }
+            if (type.equals("In_Frame_Ins") || type.equals("In_Frame_Del")) {
+                if (hotspot.getType().contains("in-frame")) {
+                    valid &= true;
+                }
+                else {
+                    valid = false;
+                }
+            }
+            if (type.equals("Splice_Site") || type.equals("Splice_Region")) {
+                if (hotspot.getType().contains("splice")) {
+                    valid &= true;
+                }
+                else {
+                    valid = false;
+                }
+            }
+
+            //Add hotspot
+            if (valid) result.add(hotspot);
+        }
+        
+        return result;
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/ProteinLocation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/ProteinLocation.java
@@ -1,6 +1,5 @@
 package org.cbioportal.genome_nexus.model;
 
-import java.util.*;
 
 public class ProteinLocation
 {
@@ -34,58 +33,4 @@ public class ProteinLocation
         return mutationType;
     }
 
-    public List<Hotspot> filterHotspot(List<Hotspot> hotspots, ProteinLocation proteinLocation){
-        int start = proteinLocation.getStart();
-        int end = proteinLocation.getEnd();
-        String type = proteinLocation.getMutationType();
-        List<Hotspot> result = new ArrayList<>();
-        for (Hotspot hotspot: hotspots) {
-            boolean valid = true;
-            
-            // Protein location
-            int hotspotStart, hotspotStop;
-            String hotspotPosition = hotspot.getResidue();
-            hotspotPosition = hotspotPosition.replaceAll("[^0-9.]", "");
-            if (hotspotPosition.split("-").length > 1){
-                hotspotStart = Integer.parseInt(hotspotPosition.split("-")[0]);
-                hotspotStop = Integer.parseInt(hotspotPosition.split("-")[1]);
-            }
-            else {
-                hotspotStart = Integer.parseInt(hotspotPosition);
-                hotspotStop = Integer.parseInt(hotspotPosition);
-            }
-            valid &= (start <= hotspotStart && end >= hotspotStop) ? true : false;
-            
-            // Mutation type
-            if (type.equals("Missense_Mutation")) {
-                if (hotspot.getType().contains("3d") || hotspot.getType().contains("single residue")) {
-                    valid &= true;
-                }
-                else {
-                    valid = false;
-                }
-            }
-            if (type.equals("In_Frame_Ins") || type.equals("In_Frame_Del")) {
-                if (hotspot.getType().contains("in-frame")) {
-                    valid &= true;
-                }
-                else {
-                    valid = false;
-                }
-            }
-            if (type.equals("Splice_Site") || type.equals("Splice_Region")) {
-                if (hotspot.getType().contains("splice")) {
-                    valid &= true;
-                }
-                else {
-                    valid = false;
-                }
-            }
-
-            // Add hotspot
-            if (valid) result.add(hotspot);
-        }
-        
-        return result;
-    }
 }

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/ProteinLocation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/ProteinLocation.java
@@ -9,6 +9,15 @@ public class ProteinLocation
     private Integer end;
     private String mutationType;
 
+    public ProteinLocation() {}
+
+    public ProteinLocation(String transcriptId, Integer start, Integer end, String mutationType) {
+        this.transcriptId = transcriptId;
+        this.start = start;
+        this.end = end;
+        this.mutationType = mutationType;
+    }
+
     public String getTranscriptId() {
         return transcriptId;
     }
@@ -33,7 +42,7 @@ public class ProteinLocation
         for (Hotspot hotspot: hotspots) {
             boolean valid = true;
             
-            //Position
+            // Protein location
             int hotspotStart, hotspotStop;
             String hotspotPosition = hotspot.getResidue();
             hotspotPosition = hotspotPosition.replaceAll("[^0-9.]", "");
@@ -47,7 +56,7 @@ public class ProteinLocation
             }
             valid &= (start <= hotspotStart && end >= hotspotStop) ? true : false;
             
-            //Type
+            // Mutation type
             if (type.equals("Missense_Mutation")) {
                 if (hotspot.getType().contains("3d") || hotspot.getType().contains("single residue")) {
                     valid &= true;
@@ -73,7 +82,7 @@ public class ProteinLocation
                 }
             }
 
-            //Add hotspot
+            // Add hotspot
             if (valid) result.add(hotspot);
         }
         

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/CancerHotspotService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/CancerHotspotService.java
@@ -53,5 +53,5 @@ public interface CancerHotspotService
         throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException, CancerHotspotsWebServiceException;
     List<Hotspot> getHotspotAnnotationsByGenomicLocation(String genomicLocation)
         throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException, CancerHotspotsWebServiceException;
-    List<List<Hotspot>> getHotspotAnnotationsByProteinLocations(List<ProteinLocation> proteinLocations) throws CancerHotspotsWebServiceException;
+    List<AggregatedHotspots> getHotspotAnnotationsByProteinLocations(List<ProteinLocation> proteinLocations) throws CancerHotspotsWebServiceException;
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/CancerHotspotService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/CancerHotspotService.java
@@ -47,6 +47,7 @@ public interface CancerHotspotService
     List<Hotspot> getHotspots(String transcriptId) throws CancerHotspotsWebServiceException;
     List<Hotspot> getHotspots(TranscriptConsequence transcript, VariantAnnotation annotation) throws CancerHotspotsWebServiceException;
     List<Hotspot> getHotspots() throws CancerHotspotsWebServiceException;
+    List<AggregatedHotspots> getHotspotsByTranscriptIds(List<String> transcriptIds) throws CancerHotspotsWebServiceException;
     List<AggregatedHotspots> getHotspotAnnotationsByVariants(List<String> variants) throws CancerHotspotsWebServiceException;
     List<AggregatedHotspots> getHotspotAnnotationsByGenomicLocations(List<GenomicLocation> genomicLocations) throws CancerHotspotsWebServiceException;
     List<Hotspot> getHotspotAnnotationsByVariant(String variant)

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/CancerHotspotService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/CancerHotspotService.java
@@ -53,4 +53,5 @@ public interface CancerHotspotService
         throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException, CancerHotspotsWebServiceException;
     List<Hotspot> getHotspotAnnotationsByGenomicLocation(String genomicLocation)
         throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException, CancerHotspotsWebServiceException;
+    List<List<Hotspot>> getHotspotAnnotationsByProteinLocations(List<ProteinLocation> proteinLocations) throws CancerHotspotsWebServiceException;
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ProteinPositionResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/ProteinPositionResolver.java
@@ -53,7 +53,7 @@ public class ProteinPositionResolver
     }
 
     @Nullable
-    private IntegerRange extractProteinPos(String proteinChange)
+    public IntegerRange extractProteinPos(String proteinChange)
     {
         IntegerRange proteinPos = null;
         Integer start = -1;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
@@ -185,14 +185,20 @@ public class CancerHotspotServiceImpl implements CancerHotspotService
     }
 
     @Override
-    public List<List<Hotspot>> getHotspotAnnotationsByProteinLocations(List<ProteinLocation> proteinLocations)
+    public List<AggregatedHotspots> getHotspotAnnotationsByProteinLocations(List<ProteinLocation> proteinLocations)
         throws CancerHotspotsWebServiceException
     {
-
-        List<List<Hotspot>> hotspots = new ArrayList<>();
+        List<AggregatedHotspots> hotspots = new ArrayList<>();
         for (ProteinLocation proteinLocation : proteinLocations)
         {
-            hotspots.add(proteinLocation.filterHotspot(this.getHotspots(proteinLocation.getTranscriptId()), proteinLocation));
+            AggregatedHotspots aggregatedHotspots = new AggregatedHotspots();
+
+            // add protein location information
+            aggregatedHotspots.setProteinLocation(proteinLocation);
+            
+            // query hotspots service by protein location
+            aggregatedHotspots.setHotspots(proteinLocation.filterHotspot(this.getHotspots(proteinLocation.getTranscriptId()), proteinLocation));
+            hotspots.add(aggregatedHotspots);
         }
         
         return hotspots;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
@@ -96,6 +96,23 @@ public class CancerHotspotServiceImpl implements CancerHotspotService
     {
         return this.hotspotRepository.findAll();
     }
+   
+    public List<AggregatedHotspots> getHotspotsByTranscriptIds(List<String> transcriptIds) throws CancerHotspotsWebServiceException
+    {
+        List<AggregatedHotspots> hotspots = new ArrayList<>();
+        for (String transcriptId : transcriptIds) {
+            AggregatedHotspots aggregatedHotspots = new AggregatedHotspots();
+            
+            // add protein location information
+            aggregatedHotspots.setTranscriptId(transcriptId);
+            
+            // query hotspots service by protein location
+            aggregatedHotspots.setHotspots(this.getHotspots(transcriptId));
+            hotspots.add(aggregatedHotspots);
+        }
+
+        return hotspots;
+    }
 
     @Override
     public List<Hotspot> getHotspotAnnotationsByVariant(String variant)

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
@@ -195,9 +195,9 @@ public class CancerHotspotServiceImpl implements CancerHotspotService
 
             // add protein location information
             aggregatedHotspots.setProteinLocation(proteinLocation);
-            
+
             // query hotspots service by protein location
-            aggregatedHotspots.setHotspots(proteinLocation.filterHotspot(this.getHotspots(proteinLocation.getTranscriptId()), proteinLocation));
+            aggregatedHotspots.setHotspots(hotspotFilter.proteinLocationHotspotsFilter(this.getHotspots(proteinLocation.getTranscriptId()), proteinLocation));
             hotspots.add(aggregatedHotspots);
         }
         

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
@@ -183,4 +183,18 @@ public class CancerHotspotServiceImpl implements CancerHotspotService
 
         return new ArrayList<>(hotspots);
     }
+
+    @Override
+    public List<List<Hotspot>> getHotspotAnnotationsByProteinLocations(List<ProteinLocation> proteinLocations)
+        throws CancerHotspotsWebServiceException
+    {
+
+        List<List<Hotspot>> hotspots = new ArrayList<>();
+        for (ProteinLocation proteinLocation : proteinLocations)
+        {
+            hotspots.add(proteinLocation.filterHotspot(this.getHotspots(proteinLocation.getTranscriptId()), proteinLocation));
+        }
+        
+        return hotspots;
+    }
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HotspotFilter.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HotspotFilter.java
@@ -34,10 +34,10 @@ public class HotspotFilter
             proteinPos != null &&
             // filter by protein position:
             // only include the hotspot if the protein change position overlaps with the current transcript
-            Numerical.overlaps(hotspot.getResidue(), proteinPos.getStart(), proteinPos.getEnd())
+            Numerical.overlaps(hotspot.getResidue(), proteinPos.getStart(), proteinPos.getEnd()) &&
             // filter by mutation type:
             // only include the hotspot if the variant classification matches the hotspot type
-            //this.typeMatches(hotspot.getType(), this.variantClassificationResolver.resolveAll(annotation, transcript))
+            this.typeMatches(hotspot.getType(), this.variantClassificationResolver.resolveAll(annotation, transcript))
         );
     }
 

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HotspotFilter.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HotspotFilter.java
@@ -34,10 +34,10 @@ public class HotspotFilter
             proteinPos != null &&
             // filter by protein position:
             // only include the hotspot if the protein change position overlaps with the current transcript
-            Numerical.overlaps(hotspot.getResidue(), proteinPos.getStart(), proteinPos.getEnd()) &&
+            Numerical.overlaps(hotspot.getResidue(), proteinPos.getStart(), proteinPos.getEnd())
             // filter by mutation type:
             // only include the hotspot if the variant classification matches the hotspot type
-            this.typeMatches(hotspot.getType(), this.variantClassificationResolver.resolveAll(annotation, transcript))
+            //this.typeMatches(hotspot.getType(), this.variantClassificationResolver.resolveAll(annotation, transcript))
         );
     }
 

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HotspotFilter.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HotspotFilter.java
@@ -2,6 +2,7 @@ package org.cbioportal.genome_nexus.service.internal;
 
 import org.cbioportal.genome_nexus.model.Hotspot;
 import org.cbioportal.genome_nexus.model.IntegerRange;
+import org.cbioportal.genome_nexus.model.ProteinLocation;
 import org.cbioportal.genome_nexus.model.TranscriptConsequence;
 import org.cbioportal.genome_nexus.model.VariantAnnotation;
 import org.cbioportal.genome_nexus.service.annotation.ProteinPositionResolver;
@@ -10,6 +11,8 @@ import org.cbioportal.genome_nexus.util.Numerical;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 @Component
@@ -78,5 +81,33 @@ public class HotspotFilter
         }
 
         return typeMatches;
+    }
+
+    public List<Hotspot> proteinLocationHotspotsFilter(List<Hotspot> hotspots, ProteinLocation proteinLocation) {
+        int start = proteinLocation.getStart();
+        int end = proteinLocation.getEnd();
+        String type = proteinLocation.getMutationType();
+        List<Hotspot> result = new ArrayList<>();
+        
+        for (Hotspot hotspot: hotspots) {
+            boolean validPosition = true;
+            
+            // Protein location
+            int hotspotStart = proteinPositionResolver.extractProteinPos(hotspot.getResidue()).getStart();
+            int hotspotStop = proteinPositionResolver.extractProteinPos(hotspot.getResidue()).getEnd();
+            validPosition &= (start <= hotspotStart && end >= hotspotStop);
+            
+            // Mutation type
+            boolean validMissense = type.equals("Missense_Mutation") && (hotspot.getType().contains("3d") || hotspot.getType().contains("single residue"));
+            boolean validInFrame = type.equals("In_Frame_Ins") || type.equals("In_Frame_Ins") && (hotspot.getType().contains("in-frame"));
+            boolean validSplice = type.equals("Splice_Site") || type.equals("Splice_Region") && (hotspot.getType().contains("splice"));
+            
+            // Add hotspot
+            if (validPosition && (validMissense || validInFrame || validSplice)) {
+                result.add(hotspot);
+            }
+        }
+        
+        return result;
     }
 }

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/CancerHotspotsController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/CancerHotspotsController.java
@@ -92,12 +92,12 @@ public class CancerHotspotsController
     }
 
     @ApiOperation(value = "Retrieves hotspot annotations for the provided transcript ID",
-    nickname = "fetchHotspotAnnotationByTranscriptIdGET")
+        nickname = "fetchHotspotAnnotationByTranscriptIdGET")
     @RequestMapping(value = "/cancer_hotspots/transcript/{transcriptId}",
         method = RequestMethod.GET,
         produces = "application/json")
     public List<Hotspot> fetchHotspotAnnotationByTranscriptIdGET(
-        @ApiParam(value="A Transcript ID. For example ENST00000288602",
+        @ApiParam(value="A Transcript Id. For example ENST00000288602",
             required = true,
             allowMultiple = true)
         @PathVariable String transcriptId)

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/CancerHotspotsController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/CancerHotspotsController.java
@@ -5,6 +5,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.cbioportal.genome_nexus.model.GenomicLocation;
 import org.cbioportal.genome_nexus.model.Hotspot;
+import org.cbioportal.genome_nexus.model.ProteinLocation;
 import org.cbioportal.genome_nexus.model.AggregatedHotspots;
 import org.cbioportal.genome_nexus.service.CancerHotspotService;
 import org.cbioportal.genome_nexus.service.exception.CancerHotspotsWebServiceException;
@@ -105,5 +106,19 @@ public class CancerHotspotsController
         CancerHotspotsWebServiceException
     {
         return this.hotspotService.getHotspots(transcriptId);
+    }
+
+    @ApiOperation(value = "Retrieves hotspot annotations for the provided transcript id, protein location and mutaion type",
+        nickname = "fetchHotspotAnnotationByProteinLocationsPOST")
+    @RequestMapping(value = "/cancer_hotspots/proteinLocations",
+        method = RequestMethod.POST,
+        produces = "application/json")
+    public List<List<Hotspot>> fetchHotspotAnnotationByProteinLocationsPOST(
+        @ApiParam(value="List of transcript id, protein start location, protein end location, mutation type. For example: ",
+            required = true,
+            allowMultiple = true)
+        @RequestBody List<ProteinLocation> proteinLocations) throws CancerHotspotsWebServiceException
+    {
+        return this.hotspotService.getHotspotAnnotationsByProteinLocations(proteinLocations);
     }
 }

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/CancerHotspotsController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/CancerHotspotsController.java
@@ -113,8 +113,8 @@ public class CancerHotspotsController
     @RequestMapping(value = "/cancer_hotspots/proteinLocations",
         method = RequestMethod.POST,
         produces = "application/json")
-    public List<List<Hotspot>> fetchHotspotAnnotationByProteinLocationsPOST(
-        @ApiParam(value="List of transcript id, protein start location, protein end location, mutation type. For example: ",
+    public List<AggregatedHotspots> fetchHotspotAnnotationByProteinLocationsPOST(
+        @ApiParam(value="List of transcript id, protein start location, protein end location, mutation type. The mutation types are limited to Missense_Mutation, 'In_Frame_Ins', 'In_Frame_Del', 'Splice_Site', and 'Splice_Region'",
             required = true,
             allowMultiple = true)
         @RequestBody List<ProteinLocation> proteinLocations) throws CancerHotspotsWebServiceException

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/CancerHotspotsController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/CancerHotspotsController.java
@@ -108,13 +108,28 @@ public class CancerHotspotsController
         return this.hotspotService.getHotspots(transcriptId);
     }
 
-    @ApiOperation(value = "Retrieves hotspot annotations for the provided transcript id, protein location and mutaion type",
+    @ApiOperation(value = "Retrieves hotspot annotations for the provided list of transcript ID",
+        nickname = "fetchHotspotAnnotationByTranscriptIdPOST")
+    @RequestMapping(value = "/cancer_hotspots/transcript",
+        method = RequestMethod.POST,
+        produces = "application/json")
+    public List<AggregatedHotspots> fetchHotspotAnnotationByTranscriptIdPOST(
+        @ApiParam(value="List of transcript Id. For example [\"ENST00000288602\",\"ENST00000256078\"]",
+            required = true,
+            allowMultiple = true)
+        @RequestBody List<String> transcriptIds)
+        throws CancerHotspotsWebServiceException
+    {
+        return this.hotspotService.getHotspotsByTranscriptIds(transcriptIds);
+    }
+
+    @ApiOperation(value = "Retrieves hotspot annotations for the provided list of transcript id, protein location and mutation type",
         nickname = "fetchHotspotAnnotationByProteinLocationsPOST")
     @RequestMapping(value = "/cancer_hotspots/proteinLocations",
         method = RequestMethod.POST,
         produces = "application/json")
     public List<AggregatedHotspots> fetchHotspotAnnotationByProteinLocationsPOST(
-        @ApiParam(value="List of transcript id, protein start location, protein end location, mutation type. The mutation types are limited to Missense_Mutation, 'In_Frame_Ins', 'In_Frame_Del', 'Splice_Site', and 'Splice_Region'",
+        @ApiParam(value="List of transcript id, protein start location, protein end location, mutation type. The mutation types are limited to 'Missense_Mutation', 'In_Frame_Ins', 'In_Frame_Del', 'Splice_Site', and 'Splice_Region'",
             required = true,
             allowMultiple = true)
         @RequestBody List<ProteinLocation> proteinLocations) throws CancerHotspotsWebServiceException

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/CancerHotspotsController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/CancerHotspotsController.java
@@ -90,4 +90,20 @@ public class CancerHotspotsController
     {
         return this.hotspotService.getHotspotAnnotationsByGenomicLocations(genomicLocations);
     }
+
+    @ApiOperation(value = "Retrieves hotspot annotations for the provided transcript ID",
+    nickname = "fetchHotspotAnnotationByTranscriptIdGET")
+    @RequestMapping(value = "/cancer_hotspots/transcript/{transcriptId}",
+        method = RequestMethod.GET,
+        produces = "application/json")
+    public List<Hotspot> fetchHotspotAnnotationByTranscriptIdGET(
+        @ApiParam(value="A Transcript ID. For example ENST00000288602",
+            required = true,
+            allowMultiple = true)
+        @PathVariable String transcriptId)
+        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException,
+        CancerHotspotsWebServiceException
+    {
+        return this.hotspotService.getHotspots(transcriptId);
+    }
 }

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
@@ -34,6 +34,7 @@ public class ApiObjectMapper extends ObjectMapper
         mixinMap.put(UntranslatedRegion.class, UntranslatedRegionMixin.class);
         mixinMap.put(GenomicLocation.class, GenomicLocationMixin.class);
         mixinMap.put(AggregatedHotspots.class, AggregatedHotspotsMixin.class);
+        mixinMap.put(ProteinLocation.class, ProteinLocationMixin.class);
         mixinMap.put(MyVariantInfo.class, MyVariantInfoMixin.class);
         mixinMap.put(Snpeff.class, SnpeffMixin.class);
         mixinMap.put(Ann.class, AnnMixin.class);

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/ProteinLocationMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/ProteinLocationMixin.java
@@ -1,0 +1,18 @@
+package org.cbioportal.genome_nexus.web.mixin;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class ProteinLocationMixin
+{
+    @ApiModelProperty(value = "Ensembl Transcript ID", position = 1, required = true)
+    private String transcriptId;
+
+    @ApiModelProperty(value = "Start Position Residue", position = 2, required = true)
+    private Integer start;
+    
+    @ApiModelProperty(value = "End Position Residue", position = 3, required = true)
+    private Integer end;
+
+    @ApiModelProperty(value = "Mutation Type e.g. Missense_Mutation", position = 4, required = true)
+    private String mutationType;
+}

--- a/web/src/test/java/org/cbioportal/genome_nexus/web/CancerHotspotsIntegrationTest.java
+++ b/web/src/test/java/org/cbioportal/genome_nexus/web/CancerHotspotsIntegrationTest.java
@@ -284,14 +284,8 @@ public class CancerHotspotsIntegrationTest
 
     assertEquals(2, hotspots0.length);
     assertEquals("BRAF", hotspots0[0].getHugoSymbol());
-    assertEquals("ENST00000288602", hotspots0[0].getTranscriptId());
-    assertEquals("V600", hotspots0[0].getResidue());
-    assertEquals("897", hotspots0[0].getTumorCount());
+    assertEquals("N581", hotspots0[0].getResidue());
     assertEquals("single residue", hotspots0[0].getType());
-    assertEquals("897", hotspots0[0].getMissenseCount());
-    assertEquals("0", hotspots0[0].getTruncatingCount());
-    assertEquals("0", hotspots0[0].getInframeCount());
-    assertEquals("0", hotspots0[0].getSpliceCount());
 
     for (int i = 0; i < hotspots0.length; i++) {
         assertEquals(transcriptIds[0], hotspots0[i].getTranscriptId());

--- a/web/src/test/java/org/cbioportal/genome_nexus/web/CancerHotspotsIntegrationTest.java
+++ b/web/src/test/java/org/cbioportal/genome_nexus/web/CancerHotspotsIntegrationTest.java
@@ -69,6 +69,11 @@ public class CancerHotspotsIntegrationTest
         return this.restTemplate.getForObject(BASE_URL + genomicLocation, Hotspot[].class);
     }
 
+    private Hotspot[] fetchHotspotsByTranscriptGET(String transcriptId)
+    {
+        return this.restTemplate.getForObject("http://localhost:38888/cancer_hotspots/transcript/" + transcriptId, Hotspot[].class);
+    }
+
     private AggregatedHotspots[] fetchHotspotsPOST(List<GenomicLocation> genomicLocationsInstances)
     {
         return this.restTemplate.postForObject(BASE_URL, genomicLocationsInstances, AggregatedHotspots[].class);
@@ -265,4 +270,34 @@ public class CancerHotspotsIntegrationTest
         // GET and POST requests should return exact same hotspots
         assertEquals(aggregatedHotspots[0].getHotspots().size(), hotspots0.length);
     }
+
+    @Test
+    public void testTranscriptIdHotspots()
+  {
+    String[] transcriptIds = {"ENST00000288602", "Not an id"};
+
+    //////////////////
+    // GET requests //
+    //////////////////
+
+    Hotspot[] hotspots0 = this.fetchHotspotsByTranscriptGET(transcriptIds[0]);
+
+    assertEquals(2, hotspots0.length);
+    assertEquals("BRAF", hotspots0[0].getHugoSymbol());
+    assertEquals("ENST00000288602", hotspots0[0].getTranscriptId());
+    assertEquals("V600", hotspots0[0].getResidue());
+    assertEquals("897", hotspots0[0].getTumorCount());
+    assertEquals("single residue", hotspots0[0].getType());
+    assertEquals("897", hotspots0[0].getMissenseCount());
+    assertEquals("0", hotspots0[0].getTruncatingCount());
+    assertEquals("0", hotspots0[0].getInframeCount());
+    assertEquals("0", hotspots0[0].getSpliceCount());
+
+    for (int i = 0; i < hotspots0.length; i++) {
+        assertEquals(transcriptIds[0], hotspots0[i].getTranscriptId());
+    }
+
+    Hotspot[] hotspots1 = this.fetchHotspotsByTranscriptGET(transcriptIds[1]);
+    assertEquals(0, hotspots1.length);
+  }
 }

--- a/web/src/test/java/org/cbioportal/genome_nexus/web/CancerHotspotsIntegrationTest.java
+++ b/web/src/test/java/org/cbioportal/genome_nexus/web/CancerHotspotsIntegrationTest.java
@@ -76,6 +76,11 @@ public class CancerHotspotsIntegrationTest
         return this.restTemplate.getForObject("http://localhost:38888/cancer_hotspots/transcript/" + transcriptId, Hotspot[].class);
     }
 
+    private AggregatedHotspots[] fetchHotspotsByTranscriptPOST(List<String> transcriptIds)
+    {
+        return this.restTemplate.postForObject("http://localhost:38888/cancer_hotspots/transcript", transcriptIds, AggregatedHotspots[].class);
+    }
+
     private AggregatedHotspots[] fetchHotspotsByProteinLocationPOST(List<ProteinLocation> locations)
     {
         return this.restTemplate.postForObject("http://localhost:38888/cancer_hotspots/proteinLocations", locations, AggregatedHotspots[].class);
@@ -297,6 +302,17 @@ public class CancerHotspotsIntegrationTest
         for (int i = 0; i < hotspots0.length; i++) {
             assertEquals(transcriptIds[0], hotspots0[i].getTranscriptId());
         }
+
+        //////////////////
+        // POST request //
+        //////////////////
+
+        AggregatedHotspots[] hotspots1 = this.fetchHotspotsByTranscriptPOST(Arrays.asList(transcriptIds));
+        
+        assertEquals(1, hotspots1.length);
+        assertEquals("ENST00000288602", hotspots1[0].getTranscriptId());
+        assertEquals(2, hotspots1[0].getHotspots().size());        
+
     }
 
     @Test


### PR DESCRIPTION
Allow users to Query Genome nexus by transcript id and protein location, return the list of `Hotspots` as the result of the query.

- Fetching by `/cancer_hotspots/transcript/transcriptId`.
Input `transcriptId:string`

- Fetching by  `/cancer_hotspots/proteinLocations`.
Input `[{transcriptId:string,proteinStart:number,proteinEnd:number,mutationType:string}]`
`mutationType` can be one of:  
    `Missense_Mutation`: 3d and single residue
    `In_Frame_Ins`and `In_Frame_Del`: in-frame
    `Splice_Site` and `Splice_Region`: splice

- [x] fetching hotspot by transcript id 
- [x] fetching hotspot by protein location

Future work: 
Implement protein location GET if needed.