### PR TITLE
Make reference genome configurable (GRCh37 or GRCh38)

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+REF_ENSEMBL_VERSION=ensembl92_grch37
+VEP_ASSEMBLY=GRCh37
+VEP_CACHE=/opt/vep/.vep/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
+FROM maven:latest
+RUN mkdir /genome-nexus
+ADD . /genome-nexus
+WORKDIR /genome-nexus
+RUN mvn -DskipTests clean install
+
 FROM openjdk:8-jre
-# copy application WAR (with libraries inside)
-COPY web/target/*.war /app.war
-# specify default command
+COPY --from=0 /genome-nexus/web/target/*.war /app.war
 CMD ["/usr/bin/java", "-Dspring.data.mongodb.uri=${MONGODB_URI}", "-jar", "/app.war"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:latest
+FROM maven:3.5.4
 RUN mkdir /genome-nexus
 ADD . /genome-nexus
 WORKDIR /genome-nexus

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For example `grch37_ensembl92`, `grch38_ensembl92` or `grch38_ensembl95`:
 export REF_ENSEMBL_VERSION=grch38_ensembl92
 ```
 
-If you would like to do local VEP annotations instead of using the public Ensembl API, please uncomment `# gn_vep.region.url=http://localhost:6060/vep/human/region/VARIANT` in your `application.properties`. This will require you to download the VEP cache files for the preferred Ensembl Release and Reference genome, see our documentation on [downloading the Genome Nexus VEP Cache](https://github.com/thehyve/genome-nexus-vep/tree/vep_grch38#create-vep-cache). This will take several hours.
+If you would like to do local VEP annotations instead of using the public Ensembl API, please uncomment `# gn_vep.region.url=http://localhost:6060/vep/human/region/VARIANT` in your `application.properties`. This will require you to download the VEP cache files for the preferred Ensembl Release and Reference genome, see our documentation on [downloading the Genome Nexus VEP Cache](https://github.com/genome-nexus/genome-nexus-vep/blob/master/README.md#create-vep-cache). This will take several hours.
 ```
 # Set local cache dir
 export VEP_CACHE=<local_vep_cache>

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Run without recreating images:
 docker-compose up -d
 ```
 
+Run without Genome Nexus VEP:
+```
+# Start both the Web and DB (dependency of Web) containers
+docker-compose up -d web
+```
+
 Stop and remove containers:
 ```
 docker-compose down

--- a/README.md
+++ b/README.md
@@ -25,14 +25,38 @@ for interpreting variants and patients.
 
 ## Run
 
-### Alternative 1 - run genome-nexus and mongoDB in docker containers
-Run with docker (assumes mvn installed locally):
+### Alternative 1 - run genome-nexus, mongoDB and genome-nexus-vep in docker containers
+First, set environment variables for Ensembl Release, VEP Assembly and location of VEP Cache. If these are not, the default values from `.env` will be set.
+
+The reference genome and Ensembl release must be consistent with a version in [genome-nexus-importer/data/](https://github.com/genome-nexus/genome-nexus-importer/tree/rc/data).
+For example `grch37_ensembl92`, `grch38_ensembl92` or `grch38_ensembl95`:
 ```
-mvn  -DskipTests clean install
-docker-compose up --build
+export REF_ENSEMBL_VERSION=grch38_ensembl92
 ```
-The mongo image `genomenexus/gn-mongo` comes with all the required tables
-initialized.
+
+If you would like to do local VEP annotations instead of using the public Ensembl API, please uncomment `# gn_vep.region.url=http://localhost:6060/vep/human/region/VARIANT` in your `application.properties`. This will require you to download the VEP cache files for the preferred Ensembl Release and Reference genome, see our documentation on [downloading the Genome Nexus VEP Cache](https://github.com/thehyve/genome-nexus-vep/tree/vep_grch38#create-vep-cache). This will take several hours.
+```
+# Set local cache dir
+export VEP_CACHE=<local_vep_cache>
+
+# GRCh38 or GRCh37
+export VEP_ASSEMBLY=GRCh38
+```
+
+Run docker-compose to create images and containers:
+```
+docker-compose up --build -d
+```
+
+Run without recreating images:
+```
+docker-compose up -d
+```
+
+Stop and remove containers:
+```
+docker-compose down
+```
 
 ### Alternative 2 - run genome-nexus locally, but mongoDB in docker container
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,13 +13,13 @@ services:
       - db
 
   db:
-    build: https://github.com/genome-nexus/genome-nexus-importer.git#rc
+    build: https://github.com/genome-nexus/genome-nexus-importer.git
     environment:
       - REF_ENSEMBL_VERSION=${REF_ENSEMBL_VERSION}
     restart: always
 
   vep:
-    build: https://github.com/thehyve/genome-nexus-vep.git#vep_grch38
+    build: https://github.com/genome-nexus/genome-nexus-vep.git
     environment:
       - VEP_ASSEMBLY=${VEP_ASSEMBLY}
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,25 @@ services:
     ports:
       - "8888:8888"
     environment:
-        - SERVER_PORT=8888
-        - MONGODB_URI=mongodb://db:27017/annotator
+      - SERVER_PORT=8888
+      - MONGODB_URI=mongodb://db:27017/annotator
     links:
       - db
     depends_on:
       - db
+
   db:
-    build: https://github.com/genome-nexus/genome-nexus-importer.git#v0.4
+    build: https://github.com/genome-nexus/genome-nexus-importer.git#rc
+    environment:
+      - REF_ENSEMBL_VERSION=${REF_ENSEMBL_VERSION}
+    restart: always
+
+  vep:
+    build: https://github.com/thehyve/genome-nexus-vep.git#vep_grch38
+    environment:
+      - VEP_ASSEMBLY=${VEP_ASSEMBLY}
     restart: always
     ports:
-      - "27017:27017"
+      - "6060:8080"
+    volumes:
+      - ${VEP_CACHE}:/opt/vep/.vep/:ro

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/TranscriptConsequence.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/TranscriptConsequence.java
@@ -55,7 +55,7 @@ public class TranscriptConsequence
     private String geneSymbol;
     private String geneId;
     private String aminoAcids;
-    private Integer hgncId;
+    private String hgncId;
     private String canonical;
     private Double polyphenScore;
     private String polyphenPrediction;
@@ -233,12 +233,12 @@ public class TranscriptConsequence
     }
 
     @Field(value="hgnc_id")
-    public Integer getHgncId()
+    public String getHgncId()
     {
         return hgncId;
     }
 
-    public void setHgncId(Integer hgncId)
+    public void setHgncId(String hgncId)
     {
         this.hgncId = hgncId;
     }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/TranscriptConsequenceMixin.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/TranscriptConsequenceMixin.java
@@ -42,7 +42,7 @@ public class TranscriptConsequenceMixin
     private String aminoAcids;
 
     @JsonProperty(value="hgnc_id", required = true)
-    private Integer hgncId;
+    private String hgncId;
 
     @JsonProperty(value="canonical", required = true)
     private String canonical;

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationController.java
@@ -81,7 +81,8 @@ public class AnnotationController
     @Deprecated
     public List<VariantAnnotation> getVariantAnnotation(
         @PathVariable
-        @ApiParam(value="Comma separated list of variants. For example X:g.66937331T>A,17:g.41242962_41242963insGA",
+        @ApiParam(value="Comma separated list of variants. For example X:g.66937331T>A,17:g.41242962_41242963insGA " +
+            "(GRCh37) or 1:g.182712A>C,2:g.265023C>T,3:g.319781del,19:g.110753dup,1:g.1385015_1387562del (GRCh38)",
             required = true,
             allowMultiple = true)
         List<String> variants,
@@ -107,7 +108,8 @@ public class AnnotationController
     @Deprecated
     public List<VariantAnnotation> postVariantAnnotation(
         @RequestParam
-        @ApiParam(value="Comma separated list of variants. For example X:g.66937331T>A,17:g.41242962_41242963insGA",
+        @ApiParam(value="Comma separated list of variants. For example X:g.66937331T>A,17:g.41242962_41242963insGA " +
+            "(GRCh37) or 1:g.182712A>C,2:g.265023C>T,3:g.319781del,19:g.110753dup,1:g.1385015_1387562del (GRCh38)",
             required = true,
             allowMultiple = true)
             List<String> variants,
@@ -129,7 +131,9 @@ public class AnnotationController
         method = RequestMethod.POST,
         produces = "application/json")
     public List<VariantAnnotation> fetchVariantAnnotationPOST(
-        @ApiParam(value="List of variants. For example [\"X:g.66937331T>A\",\"17:g.41242962_41242963insGA\"]",
+        @ApiParam(value="List of variants. For example [\"X:g.66937331T>A\",\"17:g.41242962_41242963insGA\"] (GRCh37) " +
+            "or [\"1:g.182712A>C\", \"2:g.265023C>T\", \"3:g.319781del\", \"19:g.110753dup\", " +
+            "\"1:g.1385015_1387562del\"] (GRCh38)",
             required = true)
         @RequestBody List<String> variants,
         @ApiParam(value="Isoform override source. For example uniprot",

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationSummaryController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationSummaryController.java
@@ -33,7 +33,9 @@ public class AnnotationSummaryController
         method = RequestMethod.POST,
         produces = "application/json")
     public List<VariantAnnotationSummary> fetchVariantAnnotationSummaryPOST(
-        @ApiParam(value="List of variants. For example [\"X:g.66937331T>A\",\"17:g.41242962_41242963insGA\"]",
+        @ApiParam(value="List of variants. For example [\"X:g.66937331T>A\",\"17:g.41242962_41242963insGA\"] (GRCh37) " +
+            "or [\"1:g.182712A>C\", \"2:g.265023C>T\", \"3:g.319781del\", \"19:g.110753dup\", " +
+            "\"1:g.1385015_1387562del\"] (GRCh38)",
             required = true)
         @RequestBody List<String> variants,
         @ApiParam(value="Isoform override source. For example uniprot")

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/TranscriptConsequenceMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/TranscriptConsequenceMixin.java
@@ -55,7 +55,7 @@ public class TranscriptConsequenceMixin
 
     @JsonProperty(value="hgnc_id", required = true)
     @ApiModelProperty(value = "HGNC id", required = false)
-    private Integer hgncId;
+    private String hgncId;
 
     @JsonProperty(value="canonical", required = true)
     @ApiModelProperty(value = "Canonical transcript indicator", required = false)


### PR DESCRIPTION
- This branch refers to data in RC branch of genome-nexus-importer, containing both GRCh37 and GRCh38 data, see https://github.com/genome-nexus/genome-nexus-importer/pull/16
- Environment variables to specify GRCh38 or GRCh37, Ensembl Release and VEP Cache.
- Move Maven commands to Docker
- Include Genome Nexus VEP in docker-compose, see https://github.com/genome-nexus/genome-nexus-vep/pull/1
- Small modifications to java code for compatibility with GRCh38
- Update examples in API documentation

When the changes in genome-nexus-importer and genome-nexus-vep are merged to their respective master branches, the URLs in this PR should be updated.