### PR TITLE
Update docker-compose instructions: use http://vep:8080 for VEP cache.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ For example `grch37_ensembl92`, `grch38_ensembl92` or `grch38_ensembl95`:
 export REF_ENSEMBL_VERSION=grch38_ensembl92
 ```
 
-If you would like to do local VEP annotations instead of using the public Ensembl API, please uncomment `# gn_vep.region.url=http://localhost:6060/vep/human/region/VARIANT` in your `application.properties`. This will require you to download the VEP cache files for the preferred Ensembl Release and Reference genome, see our documentation on [downloading the Genome Nexus VEP Cache](https://github.com/genome-nexus/genome-nexus-vep/blob/master/README.md#create-vep-cache). This will take several hours.
+If you would like to do local VEP annotations instead of using the public Ensembl API,
+please add `gn_vep.region.url=http://vep:8080/vep/human/region/VARIANT` in your `application.properties`.
+This will require you to download the VEP cache files for the preferred Ensembl Release and Reference genome,
+see our documentation on [downloading the Genome Nexus VEP Cache](https://github.com/genome-nexus/genome-nexus-vep/blob/master/README.md#create-vep-cache).
+This will take several hours.
 ```
 # Set local cache dir
 export VEP_CACHE=<local_vep_cache>


### PR DESCRIPTION
Fixes #247.