### PR TITLE
EntrezGeneIdResolver bug fix

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/EnsemblCanonical.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/EnsemblCanonical.java
@@ -78,20 +78,40 @@ public class EnsemblCanonical
         return this.hugoSymbol;
     }
 
+    public void setHugoSymbol(String hugoSymbol) {
+        this.hugoSymbol = hugoSymbol;
+    }
+
     public String[] getSynonyms() {
         return EnsemblCanonical.splitByComma(this.synonyms);
+    }
+
+    public void setSynonyms(String synonyms) {
+        this.synonyms = synonyms;
     }
 
     public String[] getPreviousSymbols() {
         return EnsemblCanonical.splitByComma(this.previousSymbols);
     }
 
+    public void setPreviousSymbols(String previousSymbols) {
+        this.previousSymbols = previousSymbols;
+    }
+
     public String getEnsemblCanonicalGeneId() {
         return this.ensemblCanonicalGeneId;
     }
 
+    public void setEnsemblCanonicalGeneId(String ensemblCanonicalGeneId) {
+        this.ensemblCanonicalGeneId = ensemblCanonicalGeneId;
+    }
+
     public String getEnsemblCanonicalTranscriptId() {
         return this.ensemblCanonicalTranscriptId;
+    }
+
+    public void setEnsemblCanonicalTranscriptId(String ensemblCanonicalTranscriptId) {
+        this.ensemblCanonicalTranscriptId = ensemblCanonicalTranscriptId;
     }
 
     public String getEntrezGeneId() {
@@ -102,5 +122,9 @@ public class EnsemblCanonical
         } else {
             return this.entrezGeneId;
         }
+    }
+
+    public void setEntrezGeneId(String entrezGeneId) {
+        this.entrezGeneId = entrezGeneId;
     }
 }

--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/internal/EnsemblRepositoryCustom.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/internal/EnsemblRepositoryCustom.java
@@ -31,6 +31,7 @@
 
 package org.cbioportal.genome_nexus.persistence.internal;
 
+import java.util.*;
 import org.cbioportal.genome_nexus.model.EnsemblGene;
 import org.cbioportal.genome_nexus.model.EnsemblTranscript;
 
@@ -40,4 +41,6 @@ public interface EnsemblRepositoryCustom
     EnsemblGene getCanonicalEnsemblGeneIdByHugoSymbol(String hugoSymbol);
     EnsemblGene getCanonicalEnsemblGeneIdByEntrezGeneId(String ensemblGeneId);
     String findEntrezGeneIdByHugoSymbol(String hugoSymbol);
+    List<String> findEntrezGeneIdByHugoSymbol(String hugoSymbol, Boolean searchInAliases);
+    String findHugoSymbolByEntrezGeneId(String entrezGeneId);
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/EnsemblService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/EnsemblService.java
@@ -5,7 +5,7 @@ import org.cbioportal.genome_nexus.model.EnsemblTranscript;
 import org.cbioportal.genome_nexus.service.exception.EnsemblTranscriptNotFoundException;
 import org.cbioportal.genome_nexus.service.exception.NoEnsemblGeneIdForHugoSymbolException;
 import org.cbioportal.genome_nexus.service.exception.NoEnsemblGeneIdForEntrezGeneIdException;
-import java.util.List;
+import java.util.*;
 
 public interface EnsemblService
 {
@@ -27,4 +27,6 @@ public interface EnsemblService
     List<EnsemblTranscript> getEnsemblTranscripts(String geneId, String proteinId, String hugoSymbol);
     List<EnsemblTranscript> getEnsemblTranscripts(List<String> transcriptIds, List<String> geneIds, List<String> proteinIds, List<String> hugoSymbols);
     String getEntrezGeneIdByHugoSymbol(String hugoSymbol);
+    List<String> getEntrezGeneIdByHugoSymbol(String hugoSymbol, Boolean searchInAliases);
+    String getHugoSymbolByEntrezGeneId(String entrezGeneId);
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/EntrezGeneIdResolver.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/annotation/EntrezGeneIdResolver.java
@@ -1,5 +1,6 @@
 package org.cbioportal.genome_nexus.service.annotation;
 
+import java.util.*;
 import org.cbioportal.genome_nexus.component.annotation.CanonicalTranscriptResolver;
 import org.cbioportal.genome_nexus.model.EnsemblGene;
 import org.cbioportal.genome_nexus.model.TranscriptConsequence;
@@ -45,6 +46,9 @@ public class EntrezGeneIdResolver
             // if (ensemblGene != null) {
             //     entrezGeneId = ensemblGene.getEntrezGeneId();
             // } 
+            // NOTE: Transcript consequence does not have an entrez gene id field, therefore can
+            // only search for the entrez gene id by the hugo symbol.
+            // TODO: allow searching in gene aliases and/or by entrez gene id to get the hugo symbol
             entrezGeneId = this.ensemblService.getEntrezGeneIdByHugoSymbol(transcriptConsequence.getGeneSymbol());
         }
 

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/EnsemblServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/EnsemblServiceImpl.java
@@ -173,4 +173,14 @@ public class EnsemblServiceImpl implements EnsemblService
     public String getEntrezGeneIdByHugoSymbol(String hugoSymbol) {
         return this.ensemblRepository.findEntrezGeneIdByHugoSymbol(hugoSymbol);
     }
+
+    @Override
+    public List<String> getEntrezGeneIdByHugoSymbol(String hugoSymbol, Boolean searchInAliases) {
+        return this.ensemblRepository.findEntrezGeneIdByHugoSymbol(hugoSymbol, searchInAliases);
+    }
+
+    @Override
+    public String getHugoSymbolByEntrezGeneId(String entrezGeneId) {
+        return this.ensemblRepository.findHugoSymbolByEntrezGeneId(entrezGeneId);
+    }
 }

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/EntrezGeneIdResolverIntegrationTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/annotation/EntrezGeneIdResolverIntegrationTest.java
@@ -1,0 +1,37 @@
+package org.cbioportal.genome_nexus.service.annotation;
+
+import org.cbioportal.genome_nexus.service.EnsemblService;
+import org.cbioportal.genome_nexus.service.config.EntrezGeneResolverIntegrationConfig;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ *
+ * @author ochoaa
+ */
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@TestPropertySource(
+    properties = {
+        "vep.url=http://grch37.rest.ensembl.org/vep/human/hgvs/VARIANT?content-type=application/json&xref_refseq=1&ccds=1&canonical=1&domains=1&hgvs=1&numbers=1&protein=1",
+        "spring.data.mongodb.uri=mongodb://localhost/integration",
+        "server.port=38888"
+    },
+    inheritLocations = false
+)
+@ContextConfiguration(classes=EntrezGeneResolverIntegrationConfig.class)
+public class EntrezGeneIdResolverIntegrationTest {
+    @Autowired
+    private EnsemblService ensemblService;
+
+    @Test
+    public void testEntrezGeneIdResolver() {
+        assertEquals("23269", ensemblService.getEntrezGeneIdByHugoSymbol("MGA"));
+        assertEquals("8972", ensemblService.getEntrezGeneIdByHugoSymbol("MGAM"));
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/config/EntrezGeneResolverIntegrationConfig.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/config/EntrezGeneResolverIntegrationConfig.java
@@ -1,0 +1,75 @@
+package org.cbioportal.genome_nexus.service.config;
+
+import java.io.IOException;
+import java.util.*;
+import org.cbioportal.genome_nexus.model.EnsemblCanonical;
+import org.cbioportal.genome_nexus.persistence.EnsemblRepository;
+import org.cbioportal.genome_nexus.service.internal.EnsemblServiceImpl;
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+/**
+ *
+ * @author ochoaa
+ */
+@Configuration
+public class EntrezGeneResolverIntegrationConfig {
+    private final String CANONICAL_TRANSCRIPTS_COLLECTION = "ensembl.canonical_transcript_per_hgnc";
+
+    public MongoTemplate mongoTemplate() throws IOException {
+        MongoTemplate mongoTemplate = Mockito.mock(MongoTemplate.class);
+        Mockito.when(mongoTemplate.findAll(EnsemblCanonical.class, CANONICAL_TRANSCRIPTS_COLLECTION)).thenReturn(mockEnsemblCanonicalTranscriptsList());
+        return mongoTemplate;
+    }
+
+    @Bean
+    public EnsemblRepository ensemblRepository() throws IOException {
+        EnsemblRepository ensemblRepository = Mockito.mock(EnsemblRepository.class);
+
+        Map<String, String> hugoToEntrezIdMap = mockEnsemblHugoSymbolEntrezIdMap();
+        for (Map.Entry<String, String> entry : hugoToEntrezIdMap.entrySet()) {
+            Mockito.when(ensemblRepository.findEntrezGeneIdByHugoSymbol(entry.getKey())).thenReturn(entry.getValue());
+        }
+        return ensemblRepository;
+    }
+
+    @Bean
+    public EnsemblServiceImpl ensemblService() throws IOException {
+        return new EnsemblServiceImpl(ensemblRepository());
+    }
+
+    private List<EnsemblCanonical>  mockEnsemblCanonicalTranscriptsList() throws IOException {
+        List<EnsemblCanonical> transcripts = new ArrayList<>();
+        EnsemblCanonical transcript1 = new EnsemblCanonical();
+        transcript1.setHugoSymbol("MGAM");
+        transcript1.setEntrezGeneId("8972");
+        transcript1.setEnsemblCanonicalGeneId("ENSG00000257335");
+        transcript1.setEnsemblCanonicalTranscriptId("ENST00000549489");
+        transcript1.setPreviousSymbols("");
+        transcript1.setSynonyms("MGA");
+        transcripts.add(transcript1);
+
+        EnsemblCanonical transcript2 = new EnsemblCanonical();
+        transcripts.add(transcript2);
+        transcript2.setHugoSymbol("MGA");
+        transcript2.setEntrezGeneId("23269");
+        transcript2.setEnsemblCanonicalGeneId("ENSG00000174197");
+        transcript2.setEnsemblCanonicalTranscriptId("ENST00000219905");
+        transcript2.setPreviousSymbols("");
+        transcript2.setSynonyms("KIAA0518, MAD5, MXD5, FLJ12634");
+        transcripts.add(transcript2);
+
+        return transcripts;
+    }
+
+    private Map<String, String> mockEnsemblHugoSymbolEntrezIdMap() throws IOException {
+        Map<String, String> map = new HashMap<>();
+        for (EnsemblCanonical t : mockEnsemblCanonicalTranscriptsList()) {
+            map.put(t.getHugoSymbol(), t.getEntrezGeneId());
+        }
+        return map;
+    }
+
+}


### PR DESCRIPTION
Hugo symbols are non-unique with respect to both their primary gene symbol and their aliases, which can match a primary gene symbol or aliases of other genes.

This fix stores only primary gene symbols in the `hugoSymbolToEntrezGeneIdMap` map. Aliases and "previous" symbols are stored in a separate alias map.

Example case:

- Gene "MGA" has entrez gene id 23269.
- Gene `"MGAM" has entrez gene id 8972 and alias "MGA".

Genome nexus was returning entrez id 8972 for variants linked to the non-alias gene "MGA" and should have been returning 23269 instead.

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>