### PR TITLE
fix annotation fail

### DIFF
--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/ProteinChangeResolver.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/ProteinChangeResolver.java
@@ -198,7 +198,7 @@ public class ProteinChangeResolver
                     hgvspShort += aaParts[1];
                 }
             }
-        } catch (NullPointerException e) {
+        } catch (Exception e) {
             // LOG.debug("Failed to salvage HGVSp_Short from protein start, amino acids, and consequence terms");
         }
 

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/cached/BaseCachedExternalResourceFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/cached/BaseCachedExternalResourceFetcher.java
@@ -169,14 +169,13 @@ public abstract class BaseCachedExternalResourceFetcher<T, R extends MongoReposi
         // send up to maxPageSize entities per request
         for (Set<String> subSet: this.generateChunks(needToFetch))
         {
-            DBObject rawValue;
+            DBObject rawValue = null;
 
             try {
                 // get the raw annotation string from the web service
                 rawValue = this.fetcher.fetchRawValue(this.buildRequestBody(subSet));
             } catch (HttpClientErrorException e) {
                 LOG.error("HTTP ERROR " + e.getStatusCode() + " for " + subSet.toString() + ": " + e.getResponseBodyAsString());
-                throw e;
             }
 
             if (rawValue != null) {


### PR DESCRIPTION
The annotation will fail if one of the variants is failed.

we catch all exceptions, ignore if they fail and just continue with the next one.