### PR TITLE
Fix myvariant.info when using `gn_vep.region.url`

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/TranscriptConsequence.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/TranscriptConsequence.java
@@ -47,6 +47,7 @@ public class TranscriptConsequence
 
     private String hgvsp;
     private String hgvsc;
+    private String hgvsg;
     private String variantAllele;
     private String codons;
     private String proteinId;
@@ -110,6 +111,17 @@ public class TranscriptConsequence
     public void setHgvsc(String hgvsc)
     {
         this.hgvsc = hgvsc;
+    }
+
+    @Field(value="hgvsg")
+    public String getHgvsg()
+    {
+        return hgvsg;
+    }
+
+    public void setHgvsg(String hgvsg)
+    {
+        this.hgvsg = hgvsg;
     }
 
     @Field(value="variant_allele")

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
@@ -270,6 +270,25 @@ public class VariantAnnotation
         return ptmAnnotation;
     }
 
+    public String getHgvsg() {
+        if (this.getVariantId().contains("g."))
+        {
+            return this.getVariantId();
+        }
+        // id is not of hgvsg format
+        else {
+            // determine hgvsg from VEP output
+            for (TranscriptConsequence ts : this.getTranscriptConsequences()) {
+                if (ts.getHgvsg() != null && !ts.getHgvsg().isEmpty()) {
+                    return ts.getHgvsg();
+                }
+
+            }
+            // TODO: check intergenic if still no hgvsg
+            return null;
+        }
+    }
+
     public void setPtmAnnotation(PtmAnnotation ptmAnnotation) {
         this.ptmAnnotation = ptmAnnotation;
     }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/MyVariantInfoServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/MyVariantInfoServiceImpl.java
@@ -69,12 +69,20 @@ public class MyVariantInfoServiceImpl implements MyVariantInfoService
     public MyVariantInfo getMyVariantInfo(VariantAnnotation annotation)
         throws MyVariantInfoNotFoundException, MyVariantInfoWebServiceException
     {
-        MyVariantInfo myVariantInfo = this.getMyVariantInfoByMyVariantInfoVariant(buildRequest(annotation.getVariantId()));
+        // get hgvsg from VEP (ID might not be in hgvsg format)
+        String hgvsg = annotation.getHgvsg();
+        if (hgvsg != null)
+        {
+            MyVariantInfo myVariantInfo = this.getMyVariantInfoByMyVariantInfoVariant(buildRequest(hgvsg));
 
-        // add original hgvs variant value too
-        myVariantInfo.setHgvs(annotation.getVariant());
+            // add original hgvsg variant value too
+            myVariantInfo.setHgvs(hgvsg);
 
-        return myVariantInfo;
+            return myVariantInfo;
+        }
+        else {
+            return null;
+        }
     }
 
     /**

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/TranscriptConsequenceMixin.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/TranscriptConsequenceMixin.java
@@ -17,6 +17,9 @@ public class TranscriptConsequenceMixin
     @JsonProperty(value="hgvsc", required = true)
     private String hgvsc;
 
+    @JsonProperty(value="hgvsg", required = true)
+    private String hgvsg;
+
     @JsonProperty(value="variant_allele", required = true)
     private String variantAllele;
 

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/TranscriptConsequenceMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/TranscriptConsequenceMixin.java
@@ -21,6 +21,10 @@ public class TranscriptConsequenceMixin
     @ApiModelProperty(value = "HGVSc", required = false)
     private String hgvsc;
 
+    @JsonProperty(value="hgvsg", required = true)
+    @ApiModelProperty(value = "HGVSg", required = false)
+    private String hgvsg;
+
     @JsonProperty(value="variant_allele", required = true)
     @ApiModelProperty(value = "Variant allele", required = false)
     private String variantAllele;


### PR DESCRIPTION
In this case the id for VariantAnnotation is region instead of hgvsg, so
instead we determine hgvsg from the VEP response.