### PR TITLE
sort variant requests before making chunks

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/cached/BaseCachedExternalResourceFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/cached/BaseCachedExternalResourceFetcher.java
@@ -8,6 +8,7 @@ import org.cbioportal.genome_nexus.service.CachedExternalResourceFetcher;
 import org.cbioportal.genome_nexus.service.ExternalResourceFetcher;
 import org.cbioportal.genome_nexus.service.ResourceTransformer;
 import org.cbioportal.genome_nexus.service.exception.ResourceMappingException;
+import org.cbioportal.genome_nexus.util.NaturalOrderComparator;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -200,14 +201,15 @@ public abstract class BaseCachedExternalResourceFetcher<T, R extends MongoReposi
         }
     }
 
-    protected List<Set<String>> generateChunks(Set<String> needToFetch)
+    protected List<LinkedHashSet<String>> generateChunks(Set<String> needToFetch)
     {
-        List<Set<String>> chunks = new ArrayList<>();
-        List<String> list = new ArrayList<>(needToFetch);
+        List<LinkedHashSet<String>> chunks = new ArrayList<>();
+        List<String> sortedUncachedRegions = new ArrayList<>(needToFetch);
+        Collections.sort(sortedUncachedRegions, new NaturalOrderComparator());
 
         // chunk size should be at most maxPageSize
-        for (int i = 0; i < list.size(); i += this.maxPageSize) {
-            chunks.add(new LinkedHashSet<>(list.subList(i, Math.min(list.size(), i + this.maxPageSize))));
+        for (int i = 0; i < sortedUncachedRegions.size(); i += this.maxPageSize) {
+            chunks.add(new LinkedHashSet<>(sortedUncachedRegions.subList(i, Math.min(sortedUncachedRegions.size(), i + this.maxPageSize))));
         }
 
         return chunks;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/cached/CachedVariantAnnotationFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/cached/CachedVariantAnnotationFetcher.java
@@ -6,7 +6,6 @@ import org.cbioportal.genome_nexus.persistence.VariantAnnotationRepository;
 import org.cbioportal.genome_nexus.persistence.internal.VariantAnnotationRepositoryImpl;
 import org.cbioportal.genome_nexus.service.exception.ResourceMappingException;
 import org.cbioportal.genome_nexus.service.transformer.ExternalResourceTransformer;
-import org.cbioportal.genome_nexus.util.NaturalOrderComparator;
 import org.cbioportal.genome_nexus.service.remote.VEPDataFetcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,7 +17,6 @@ import java.util.stream.Collectors;
 @Component
 public class CachedVariantAnnotationFetcher extends BaseCachedExternalResourceFetcher<VariantAnnotation, VariantAnnotationRepository>
 {
-    public static final String FIXED_ENTRY = "AGT:c.803T>C";
 
     @Autowired
     public CachedVariantAnnotationFetcher(ExternalResourceTransformer<VariantAnnotation> transformer,
@@ -52,63 +50,6 @@ public class CachedVariantAnnotationFetcher extends BaseCachedExternalResourceFe
     }
 
     @Override
-    public List<VariantAnnotation> fetchAndCache(List<String> ids) throws ResourceMappingException
-    {
-        List<VariantAnnotation> annotations = super.fetchAndCache(ids);
-
-        // post process to remove the fixed entry (or duplicate fix entries depending on the number of total pages)
-        // filter out the fixed entry, so that it won't be included in the final list
-        List<VariantAnnotation> postProcessedAnnotations = annotations.stream().filter(
-            v -> !v.getVariant().equals(FIXED_ENTRY)).collect(Collectors.toList());
-
-        // very unlikely but in case the fixed entry is already in the original list we want to add it back
-        if (ids.contains(FIXED_ENTRY))
-        {
-            Optional<VariantAnnotation> first = annotations.stream().filter(
-                v -> v.getVariant().equals(FIXED_ENTRY)).findFirst();
-
-            // TODO add it back to its correct index not just at the end of the list: doable but not straightforward due to possible missing annotation(s)
-            first.ifPresent(postProcessedAnnotations::add);
-        }
-
-        return postProcessedAnnotations;
-    }
-
-    /**
-     * Overriding the base method in order to add a fixed first entry to the query (due to a bug in VEP web service):
-     * Basically, the query fails if the first entry in the list is invalid.
-     * See https://github.com/Ensembl/ensembl-vep/issues/156 for details.
-     */
-    @Override
-    protected List<Set<String>> generateChunks(Set<String> needToFetch)
-    {
-        List<Set<String>> chunks = new ArrayList<>();
-        List<String> list = new ArrayList<>(needToFetch);
-
-        // -1, because we add fixed entry to the beginning of each and every chunk
-        int chunkSize = this.maxPageSize - 1;
-
-        for (int i = 0; i < list.size(); i += chunkSize)
-        {
-            Set<String> chunk = new LinkedHashSet<>();
-
-            // add the fixed entry to the beginning of the chunk
-            chunk.add(FIXED_ENTRY);
-
-            // append the next slice
-            // VEP requires ids to be sorted
-            List<String> sortedChunk = list.subList(i, Math.min(list.size(), i + chunkSize));
-            Collections.sort(sortedChunk, new NaturalOrderComparator());
-
-            chunk.addAll(sortedChunk);
-
-            chunks.add(chunk);
-        }
-
-        return chunks;
-    }
-
-    @Override
     protected Object buildRequestBody(Set<String> ids)
     {
         HashMap<String, Object> requestBody = new HashMap<>();
@@ -118,18 +59,4 @@ public class CachedVariantAnnotationFetcher extends BaseCachedExternalResourceFe
         return requestBody;
     }
 
-    protected void saveToDb(DBObject value)
-    {
-        List<DBObject> dbObjects = this.transformer.transform(value);
-
-        for (DBObject dbObject: dbObjects) {
-            dbObject.put("_id", this.extractId(dbObject));
-        }
-
-        // never cache the fixed entry: filter out corresponding object
-        dbObjects = dbObjects.stream().filter(
-            o -> !this.extractId(o).equals(FIXED_ENTRY)).collect(Collectors.toList());
-
-        this.repository.saveDBObjects(this.collection, dbObjects);
-    }
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/RegionVariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/RegionVariantAnnotationService.java
@@ -44,7 +44,7 @@ import org.springframework.beans.factory.annotation.*;
 @Service
 public class RegionVariantAnnotationService extends BaseVariantAnnotationServiceImpl
 {
-    private static final Log LOG = LogFactory.getLog(DbsnpVariantAnnotationService.class);
+    private static final Log LOG = LogFactory.getLog(RegionVariantAnnotationService.class);
 
     @Autowired
     public RegionVariantAnnotationService(CachedVariantRegionAnnotationFetcher cachedVariantRegionAnnotationFetcher,


### PR DESCRIPTION
- base class BaseCachedExternalResourceFetcher chunk logic now common to all
- sort occurs on full set of requests before chunks are made
- removed the FIXED_ENTRY prepended to each chunk : (see genome-nexus issue #156)
    - tests showed that the original problem is no longer happening, so workaround is not needed and is degrading performance

Co-authored-by: Manda Wilson <1458628+mandawilson@users.noreply.github.com>
Co-authored-by: Robert Sheridan <7747489+sheridancbio@users.noreply.github.com>