### PR TITLE
Remove old auto VCF -> MAF conversion code

### DIFF
--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
@@ -94,11 +94,7 @@ public class NotationConverter
     }
 
     /*
-     * Normalize genomic location:
-     *
-     * 1. Convert VCF style start,end,ref,alt to MAF by looking for common
-     * prefix. (TODO: not sure if this is always a good idea)
-     * 2. Normalize chromsome names.
+     * Normalize genomic location
      */
     public GenomicLocation normalizeGenomicLocation(GenomicLocation genomicLocation) {
         GenomicLocation normalizedGenomicLocation = new GenomicLocation();
@@ -107,41 +103,10 @@ public class NotationConverter
         String chr = this.chromosomeNormalizer(genomicLocation.getChromosome().trim());
         normalizedGenomicLocation.setChromosome(chr);
 
-        // convert vcf style start,end,ref,alt to MAF style
         Integer start = genomicLocation.getStart();
         Integer end = genomicLocation.getEnd();
         String ref = genomicLocation.getReferenceAllele().trim();
         String var = genomicLocation.getVariantAllele().trim();
-
-        String prefix = "";
-
-        if(!ref.equals(var)) {
-            prefix = longestCommonPrefix(ref, var);
-        }
-
-        if(!ref.equals(var)) {
-            prefix = longestCommonPrefix(ref, var);
-        }
-//        else {
-//            log.warn("Warning: Reference allele extracted from " + chr + ":" + start + "-" + end + " matches alt allele.");
-//        }
-
-        // Remove common prefix and adjust variant position accordingly
-        if (prefix.length() > 0)
-        {
-            ref = ref.substring(prefix.length());
-            var = var.substring(prefix.length());
-
-            int nStart = start;
-
-            nStart += prefix.length();
-
-            if (ref.length() == 0) {
-                nStart -= 1;
-            }
-
-            start = nStart;
-        }
 
         normalizedGenomicLocation.setStart(start);
         normalizedGenomicLocation.setEnd(end);


### PR DESCRIPTION
This in some cases results in incorrect annotations, so better to have
people explicitly convert their VCF to MAF before importing by e.g.
using:

https://github.com/genome-nexus/genome-nexus-cli#convert-vcf-to-maf-ready-for-annotation

One thing is that the annotation pipeline does somehow correctly annotate it. I'm not entirely sure why, I guess it uses a different endpoint then:

https://www.genomenexus.org/annotation/genomic/7%2C55242467%2C55242482%2CAATTAAGAGAACATCT%2CAGCAA?isoformOverrideSource
https://github.com/genome-nexus/genome-nexus-annotation-pipeline/pull/113