### PR TITLE
Integration OncoKB annotation in Genome Nexus

### DIFF
--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/OncokbResolver.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/OncokbResolver.java
@@ -1,0 +1,40 @@
+package org.cbioportal.genome_nexus.component.annotation;
+
+import org.cbioportal.genome_nexus.model.Alteration;
+import org.cbioportal.genome_nexus.model.TranscriptConsequenceSummary;
+import org.cbioportal.genome_nexus.model.VariantAnnotationSummary;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OncokbResolver
+{
+    @Nullable
+    public Alteration resolve(VariantAnnotationSummary annotationSummary)
+    {
+        Alteration alteration = null;
+
+        if (annotationSummary != null) {
+            TranscriptConsequenceSummary transcriptConsequenceSummary = annotationSummary.getTranscriptConsequenceSummary();
+            if (transcriptConsequenceSummary != null) {
+                alteration = new Alteration(transcriptConsequenceSummary.getHugoGeneSymbol(),
+                                            Integer.parseInt(transcriptConsequenceSummary.getEntrezGeneId()),
+                                            normalizeProteinChange(transcriptConsequenceSummary.getHgvspShort()),
+                                            transcriptConsequenceSummary.getConsequenceTerms(),
+                                            transcriptConsequenceSummary.getProteinPosition() != null ? transcriptConsequenceSummary.getProteinPosition().getStart() : null,
+                                            transcriptConsequenceSummary.getProteinPosition() != null ? transcriptConsequenceSummary.getProteinPosition().getEnd() : null,
+                                            // TODO tumorType is optional for the query, currently genome nexus doesn't have tumorType data
+                                            null);
+            }
+        }
+
+        return alteration;
+    }
+
+    private String normalizeProteinChange(String proteinChange) {
+        if (proteinChange.contains("p.")) {
+            return proteinChange.replace("p.", "");
+        }
+        return proteinChange;
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/Alteration.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/Alteration.java
@@ -1,0 +1,95 @@
+package org.cbioportal.genome_nexus.model;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+public class Alteration
+{
+    @Field(value = "hugoSymbol")
+    private String hugoSymbol;
+
+    @Field(value = "entrezGeneId")
+    private Integer entrezGeneId;
+
+    @Field(value = "alteration")
+    private String alteration;
+
+    @Field(value = "consequence")
+    private String consequence;
+
+    @Field(value = "proteinStart")
+    private Integer proteinStart;
+
+    @Field(value = "proteinEnd")
+    private Integer proteinEnd;
+
+    @Field(value = "tumorType")
+    private String tumorType;
+
+    public Alteration(String hugoSymbol, Integer entrezGeneId, String alteration,
+                        String consequence, Integer proteinStart, Integer proteinEnd, String tumorType)
+    {
+        this.hugoSymbol = hugoSymbol;
+        this.entrezGeneId = entrezGeneId;
+        this.alteration = alteration;
+        this.consequence = consequence;
+        this.proteinStart = proteinStart;
+        this.proteinEnd = proteinEnd;
+        this.tumorType = tumorType;
+    }
+
+    public String getHugoSymbol() {
+        return hugoSymbol;
+    }
+
+    public void setHugoSymbol(String hugoSymbol) {
+        this.hugoSymbol = hugoSymbol;
+    }
+
+    public Integer getEntrezGeneId() {
+        return entrezGeneId;
+    }
+
+    public void setEntrezGeneId(Integer entrezGeneId) {
+        this.entrezGeneId = entrezGeneId;
+    }
+
+    public String getAlteration() {
+        return alteration;
+    }
+
+    public void setAlteration(String alteration) {
+        this.alteration = alteration;
+    }
+
+    public String getConsequence() {
+        return consequence;
+    }
+
+    public void setConsequence(String consequence) {
+        this.consequence = consequence;
+    }
+
+    public Integer getProteinStart() {
+        return proteinStart;
+    }
+
+    public void setProteinStart(Integer proteinStart) {
+        this.proteinStart = proteinStart;
+    }
+
+    public Integer getProteinEnd() {
+        return proteinEnd;
+    }
+
+    public void setProteinEnd(Integer proteinEnd) {
+        this.proteinEnd = proteinEnd;
+    }
+
+    public String getTumorType() {
+        return tumorType;
+    }
+
+    public void setTumorType(String tumorType) {
+        this.tumorType = tumorType;
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/OncokbAnnotation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/OncokbAnnotation.java
@@ -1,0 +1,41 @@
+package org.cbioportal.genome_nexus.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.oncokb.client.IndicatorQueryResp;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+public class OncokbAnnotation
+{
+    @Field(value = "license")
+    private String license;
+
+    @Field(value = "annotation")
+    private IndicatorQueryResp annotation;
+
+    public OncokbAnnotation()
+    {
+        this.license = "https://www.oncokb.org/terms";
+        this.annotation = new IndicatorQueryResp();
+    }
+
+    public String getLicense()
+    {
+        return license;
+    }
+
+    public void setLicense(String license)
+    {
+        this.license = license;
+    }
+    public IndicatorQueryResp getAnnotation()
+    {
+        return annotation;
+    }
+
+    public void setAnnotation(IndicatorQueryResp annotation)
+    {
+        this.annotation = annotation;
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
@@ -68,6 +68,7 @@ public class VariantAnnotation
     private MyVariantInfoAnnotation myVariantInfoAnnotation;
     private HotspotAnnotation hotspotAnnotation;
     private PtmAnnotation ptmAnnotation;
+    private OncokbAnnotation oncokbAnnotation;
     private VariantAnnotationSummary annotationSummary;
 
     private Map<String, Object> dynamicProps;
@@ -291,6 +292,14 @@ public class VariantAnnotation
 
     public void setPtmAnnotation(PtmAnnotation ptmAnnotation) {
         this.ptmAnnotation = ptmAnnotation;
+    }
+
+    public OncokbAnnotation getOncokbAnnotation() {
+        return oncokbAnnotation;
+    }
+
+    public void setOncokbAnnotation(OncokbAnnotation oncokbAnnotation) {
+        this.oncokbAnnotation = oncokbAnnotation;
     }
 
     public void setDynamicProp(String key, Object value)

--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/OncokbCancerGenesListRepository.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/OncokbCancerGenesListRepository.java
@@ -1,0 +1,12 @@
+package org.cbioportal.genome_nexus.persistence;
+
+import java.util.List;
+
+import org.oncokb.client.CancerGene;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+
+public interface OncokbCancerGenesListRepository extends MongoRepository<CancerGene, String>, GenericMongoRepository {
+        List<CancerGene> getOncokbCancerGenesList();
+    }

--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/internal/OncokbCancerGenesListRepositoryImpl.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/internal/OncokbCancerGenesListRepositoryImpl.java
@@ -1,0 +1,24 @@
+package org.cbioportal.genome_nexus.persistence.internal;
+
+import java.util.List;
+
+import org.oncokb.client.CancerGene;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class OncokbCancerGenesListRepositoryImpl extends JsonMongoRepositoryImpl
+{
+    public static final String COLLECTION = "oncokb.gene";
+
+    @Autowired
+    public OncokbCancerGenesListRepositoryImpl(MongoTemplate mongoTemplate)
+    {
+        super(mongoTemplate);
+    }
+
+    public List<CancerGene> getOncokbCancerGenesList() {
+        return this.mongoTemplate.findAll(CancerGene.class, COLLECTION);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>com.github.leexgh.oncokb-java-api-client</groupId>
+          <groupId>com.github.genome-nexus.oncokb-java-api-client</groupId>
           <artifactId>oncokbPublicApiClient</artifactId>
           <version>fb669f193ba0ad2791b4e2f2680225aa892498f1</version>
         </dependency>
         <dependency>
-          <groupId>com.github.leexgh.oncokb-java-api-client</groupId>
+          <groupId>com.github.genome-nexus.oncokb-java-api-client</groupId>
           <artifactId>oncokbPremiumApiClient</artifactId>
           <version>fb669f193ba0ad2791b4e2f2680225aa892498f1</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,17 @@
       <module>service</module>
       <module>web</module>
     </modules>
-
+    <repositories>
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
+  </repositories>
     <!-- inherit defaults from spring boot -->
     <parent>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-parent</artifactId>
-      <version>2.0.1.RELEASE</version>
+      <version>2.2.1.RELEASE</version>
     </parent>
 
     <properties>
@@ -34,6 +39,16 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>com.github.leexgh.oncokb-java-api-client</groupId>
+          <artifactId>oncokbPublicApiClient</artifactId>
+          <version>fb669f193ba0ad2791b4e2f2680225aa892498f1</version>
+        </dependency>
+        <dependency>
+          <groupId>com.github.leexgh.oncokb-java-api-client</groupId>
+          <artifactId>oncokbPremiumApiClient</artifactId>
+          <version>fb669f193ba0ad2791b4e2f2680225aa892498f1</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -41,7 +56,7 @@
         <plugin>
          <groupId>org.jacoco</groupId>
          <artifactId>jacoco-maven-plugin</artifactId>
-         <version>0.7.7.201606060606</version>
+         <version>0.8.5</version>
          <executions>
           <execution>
            <goals>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>annotations</artifactId>
             <version>16.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.3</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/GenomicLocationAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/GenomicLocationAnnotationService.java
@@ -38,6 +38,7 @@ import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundEx
 import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
 
 import java.util.List;
+import java.util.Map;
 
 public interface GenomicLocationAnnotationService
 {
@@ -46,7 +47,7 @@ public interface GenomicLocationAnnotationService
     VariantAnnotation getAnnotation(String genomicLocation)
         throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException;
     List<VariantAnnotation> getAnnotations(List<GenomicLocation> genomicLocations);
-    VariantAnnotation getAnnotation(String genomicLocation, String isoformOverrideSource, List<String> fields)
+    VariantAnnotation getAnnotation(String genomicLocation, String isoformOverrideSource, Map<String, String> token, List<String> fields)
         throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException;
-    List<VariantAnnotation> getAnnotations(List<GenomicLocation> genomicLocations, String isoformOverrideSource, List<String> fields);
+    List<VariantAnnotation> getAnnotations(List<GenomicLocation> genomicLocations, String isoformOverrideSource, Map<String, String> token, List<String> fields);
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/OncokbService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/OncokbService.java
@@ -1,0 +1,17 @@
+package org.cbioportal.genome_nexus.service;
+
+import java.util.List;
+
+import org.cbioportal.genome_nexus.model.Alteration;
+import org.oncokb.client.CancerGene;
+import org.oncokb.client.IndicatorQueryResp;
+
+import org.cbioportal.genome_nexus.service.exception.OncokbNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.OncokbWebServiceException;
+
+public interface OncokbService
+{
+    IndicatorQueryResp getOncokb(Alteration alteration, String token)
+        throws OncokbNotFoundException, OncokbWebServiceException;
+    List<CancerGene>  getOncokbCancerGenesList();
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/VariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/VariantAnnotationService.java
@@ -37,6 +37,7 @@ import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundEx
 import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Benjamin Gross
@@ -46,7 +47,7 @@ public interface VariantAnnotationService
     VariantAnnotation getAnnotation(String variant)
         throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException;
     List<VariantAnnotation> getAnnotations(List<String> variants);
-    VariantAnnotation getAnnotation(String variant, String isoformOverrideSource, List<String> fields)
+    VariantAnnotation getAnnotation(String variant, String isoformOverrideSource, Map<String, String> token, List<String> fields)
         throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException;
-    List<VariantAnnotation> getAnnotations(List<String> variants, String isoformOverrideSource, List<String> fields);
+    List<VariantAnnotation> getAnnotations(List<String> variants, String isoformOverrideSource, Map<String, String> token, List<String> fields);
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/OncokbAnnotationEnricher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/OncokbAnnotationEnricher.java
@@ -1,0 +1,68 @@
+package org.cbioportal.genome_nexus.service.enricher;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.cbioportal.genome_nexus.component.annotation.OncokbResolver;
+import org.cbioportal.genome_nexus.model.Alteration;
+import org.cbioportal.genome_nexus.model.OncokbAnnotation;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.model.VariantAnnotationSummary;
+import org.cbioportal.genome_nexus.service.AnnotationEnricher;
+import org.cbioportal.genome_nexus.service.OncokbService;
+import org.cbioportal.genome_nexus.service.VariantAnnotationSummaryService;
+import org.cbioportal.genome_nexus.service.exception.OncokbNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.OncokbWebServiceException;
+import org.oncokb.client.CancerGene;
+import org.oncokb.client.IndicatorQueryResp;
+
+public class OncokbAnnotationEnricher implements AnnotationEnricher
+{
+    private static final Log LOG = LogFactory.getLog(OncokbAnnotationEnricher.class);
+    private final VariantAnnotationSummaryService variantAnnotationSummaryService;
+    private final OncokbResolver oncokbResolver = new OncokbResolver();
+    
+    private OncokbService oncokbService;
+    private String token;
+
+    public OncokbAnnotationEnricher(OncokbService oncokbService, VariantAnnotationSummaryService variantAnnotationSummaryService, String token) {
+        this.oncokbService = oncokbService;
+        this.variantAnnotationSummaryService = variantAnnotationSummaryService;
+        this.token = token;
+    }
+
+    @Override
+    public void enrich(VariantAnnotation annotation) {
+        if (annotation != null)
+        {
+            IndicatorQueryResp oncokb = null;
+            VariantAnnotationSummary annotationSummary = this.variantAnnotationSummaryService.getAnnotationSummaryForCanonical(annotation);
+            Alteration alteration = oncokbResolver.resolve(annotationSummary);
+
+            // get OncoKB cancer gene list from database
+            List<CancerGene> oncokbCancerGenesList = this.oncokbService.getOncokbCancerGenesList();
+            Set<String> hugoSymbolSet = oncokbCancerGenesList.stream().map(CancerGene::getHugoSymbol).collect(Collectors.toSet());
+            // if the query gene is not in the hugo symbol set, then skip the query
+            if (hugoSymbolSet.contains(alteration.getHugoSymbol())) {
+                try {
+                    oncokb = oncokbService.getOncokb(alteration, token);
+                } catch (OncokbWebServiceException e) {
+                    LOG.warn(e.getLocalizedMessage());
+                } catch (OncokbNotFoundException e) {
+                    // fail silently for this variant annotation
+                }
+            }
+            
+            if (oncokb != null)
+            {
+                OncokbAnnotation oncokbAnnotation = new OncokbAnnotation();
+                oncokbAnnotation.setAnnotation(oncokb);
+                annotation.setOncokbAnnotation(oncokbAnnotation);
+            }
+        }
+    }
+
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/exception/OncokbNotFoundException.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/exception/OncokbNotFoundException.java
@@ -1,0 +1,26 @@
+package org.cbioportal.genome_nexus.service.exception;
+
+import org.cbioportal.genome_nexus.model.Alteration;
+
+public class OncokbNotFoundException extends Exception
+{
+    private Alteration alteration;
+
+    public OncokbNotFoundException(Alteration alteration) {
+        super();
+        this.alteration = alteration;
+    }
+
+    public Alteration getAlteration() {
+        return alteration;
+    }
+
+    public void setVariant(Alteration alteration) {
+        this.alteration = alteration;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Oncokb annotation not found for hugo gene symbol: " + this.getAlteration().getHugoSymbol();
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/exception/OncokbWebServiceException.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/exception/OncokbWebServiceException.java
@@ -1,0 +1,14 @@
+package org.cbioportal.genome_nexus.service.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class OncokbWebServiceException extends DefaultWebServiceException
+{
+    public OncokbWebServiceException(String responseBody) {
+        super(responseBody);
+    }
+
+    public OncokbWebServiceException(String responseBody, HttpStatus statusCode) {
+        super(responseBody, statusCode);
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/DbsnpVariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/DbsnpVariantAnnotationService.java
@@ -55,7 +55,8 @@ public class DbsnpVariantAnnotationService extends BaseVariantAnnotationServiceI
                                          @Lazy MutationAssessorService mutationAssessorService,
                                          @Lazy MyVariantInfoService myVariantInfoService,
                                          @Lazy VariantAnnotationSummaryService variantAnnotationSummaryService,
-                                         @Lazy PostTranslationalModificationService postTranslationalModificationService)
+                                         @Lazy PostTranslationalModificationService postTranslationalModificationService,
+                                         @Lazy OncokbService oncokbService)
     {
         super(cachedVariantIdAnnotationFetcher,
             isoformOverrideService,
@@ -63,6 +64,7 @@ public class DbsnpVariantAnnotationService extends BaseVariantAnnotationServiceI
             mutationAssessorService,
             myVariantInfoService,
             variantAnnotationSummaryService,
-            postTranslationalModificationService);
+            postTranslationalModificationService,
+            oncokbService);
     }
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/GenomicLocationAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/GenomicLocationAnnotationServiceImpl.java
@@ -46,6 +46,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class GenomicLocationAnnotationServiceImpl implements GenomicLocationAnnotationService
@@ -104,12 +105,14 @@ public class GenomicLocationAnnotationServiceImpl implements GenomicLocationAnno
     @Override
     public VariantAnnotation getAnnotation(String genomicLocation,
                                            String isoformOverrideSource,
+                                           Map<String, String> token,
                                            List<String> fields)
         throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
     {
         return this.variantAnnotationService.getAnnotation(
             this.genomicLocationToVariantFormat.convert(genomicLocation),
             isoformOverrideSource,
+            token,
             fields
         );
     }
@@ -117,11 +120,13 @@ public class GenomicLocationAnnotationServiceImpl implements GenomicLocationAnno
     @Override
     public List<VariantAnnotation> getAnnotations(List<GenomicLocation> genomicLocations,
                                                                     String isoformOverrideSource,
+                                                                    Map<String, String> token,
                                                                     List<String> fields)
     {
         return this.variantAnnotationService.getAnnotations(
             this.genomicLocationsToVariantFormats.convert(genomicLocations),
             isoformOverrideSource,
+            token,
             fields
         );
     }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HgvsVariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HgvsVariantAnnotationService.java
@@ -57,7 +57,8 @@ public class HgvsVariantAnnotationService extends BaseVariantAnnotationServiceIm
                                         @Lazy MutationAssessorService mutationAssessorService,
                                         @Lazy MyVariantInfoService myVariantInfoService,
                                         @Lazy VariantAnnotationSummaryService variantAnnotationSummaryService,
-                                        @Lazy PostTranslationalModificationService postTranslationalModificationService)
+                                        @Lazy PostTranslationalModificationService postTranslationalModificationService,
+                                        @Lazy OncokbService oncokbService)
     {
         super(cachedVariantAnnotationFetcher,
             isoformOverrideService,
@@ -65,7 +66,8 @@ public class HgvsVariantAnnotationService extends BaseVariantAnnotationServiceIm
             mutationAssessorService,
             myVariantInfoService,
             variantAnnotationSummaryService,
-            postTranslationalModificationService);
+            postTranslationalModificationService,
+            oncokbService);
 
         this.notationConverter = notationConverter;
     }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/OncokbServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/OncokbServiceImpl.java
@@ -1,0 +1,107 @@
+package org.cbioportal.genome_nexus.service.internal;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.cbioportal.genome_nexus.model.Alteration;
+import org.cbioportal.genome_nexus.persistence.OncokbCancerGenesListRepository;
+import org.cbioportal.genome_nexus.service.OncokbService;
+import org.cbioportal.genome_nexus.service.exception.OncokbNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.OncokbWebServiceException;
+import org.cbioportal.genome_nexus.service.exception.ResourceMappingException;
+import org.cbioportal.genome_nexus.service.remote.OncokbDataFetcher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.oncokb.client.CancerGene;
+import org.oncokb.client.IndicatorQueryResp;
+
+@Service
+public class OncokbServiceImpl implements OncokbService {
+    private static final Log LOG = LogFactory.getLog(OncokbServiceImpl.class);
+
+    private final OncokbDataFetcher oncokbDataFetcher;
+    private final OncokbCancerGenesListRepository oncokbCancerGenesListRepository;
+
+    @Autowired
+    public OncokbServiceImpl(OncokbDataFetcher oncokbDataFetcher, OncokbCancerGenesListRepository oncokbCancerGenesListRepository) {
+        this.oncokbDataFetcher = oncokbDataFetcher;
+        this.oncokbCancerGenesListRepository = oncokbCancerGenesListRepository;
+    }
+
+    public IndicatorQueryResp getOncokbByProteinChange(Alteration alteration, String token) throws OncokbNotFoundException, OncokbWebServiceException {
+        Optional<IndicatorQueryResp> oncokb = null;
+        
+        oncokbDataFetcher.setOncokbToken(token);
+        try {
+            // get the annotation from the web service
+            List<IndicatorQueryResp> list = oncokbDataFetcher.fetchInstances(generateQueryString(alteration));
+            if (list.size() > 0) {
+                oncokb = Optional.ofNullable(list.get(0));
+            }
+        } catch (HttpServerErrorException e) {
+            // failure fetching external resource
+            LOG.error("Failure fetching external resource: " + e.getLocalizedMessage());
+        } catch (ResourceMappingException e) {
+            throw new OncokbWebServiceException(e.getMessage());
+        } catch (HttpClientErrorException e) {
+            throw new OncokbWebServiceException(e.getResponseBodyAsString(), e.getStatusCode());
+        } catch (ResourceAccessException e) {
+            throw new OncokbWebServiceException(e.getMessage());
+        }
+
+        try {
+            return oncokb.get();
+        } catch (NoSuchElementException e) {
+            throw new OncokbNotFoundException(alteration);
+        }
+    }
+
+    @Override
+    public IndicatorQueryResp getOncokb(Alteration alteration, String token) throws OncokbNotFoundException, OncokbWebServiceException {
+        if (alteration != null) {
+            IndicatorQueryResp oncokb = this.getOncokbByProteinChange(alteration, token);
+            return oncokb;
+        } else {
+            return null;
+        }
+    }
+
+    private String generateQueryString(Alteration alteration) {
+        // example url: hugoSymbol=BRAF&entrezGeneId=673&alteration=V600E&consequence=missense_variant&proteinStart=600&proteinEnd=600&tumorType=Melanoma
+        String query = "";
+        if (alteration.getHugoSymbol() != null) {
+            query = query + "hugoSymbol=" + alteration.getHugoSymbol();
+        }
+        if (alteration.getEntrezGeneId() != null) {
+            query = query + "&entrezGeneId=" + alteration.getEntrezGeneId();
+        }
+        if (alteration.getAlteration() != null) {
+            query= query + "&alteration=" + alteration.getAlteration();
+        }
+        if (alteration.getConsequence() != null) {
+            query = query + "&consequence=" + alteration.getConsequence();
+        }
+        if (alteration.getProteinStart() != null) {
+            query = query + "&proteinStart=" + alteration.getProteinStart();
+        }
+        if (alteration.getProteinEnd() != null) {
+            query = query + "&proteinEnd=" + alteration.getProteinEnd();
+        }
+        if (alteration.getTumorType() != null) {
+            query = query + "&tumorType=" + alteration.getTumorType();
+        }
+        // TODO tumorType is optional for the query, currently genome nexus doesn't have tumorType data
+
+        return query;
+    }
+
+    public List<CancerGene> getOncokbCancerGenesList() {
+        return this.oncokbCancerGenesListRepository.getOncokbCancerGenesList();
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/RegionVariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/RegionVariantAnnotationService.java
@@ -55,7 +55,8 @@ public class RegionVariantAnnotationService extends BaseVariantAnnotationService
                                           @Lazy MutationAssessorService mutationAssessorService,
                                           @Lazy MyVariantInfoService myVariantInfoService,
                                           @Lazy VariantAnnotationSummaryService variantAnnotationSummaryService,
-                                          @Lazy PostTranslationalModificationService postTranslationalModificationService)
+                                          @Lazy PostTranslationalModificationService postTranslationalModificationService,
+                                          @Lazy OncokbService oncokbService)
     {
         super(cachedVariantRegionAnnotationFetcher,
             isoformOverrideService,
@@ -63,6 +64,7 @@ public class RegionVariantAnnotationService extends BaseVariantAnnotationService
             mutationAssessorService,
             myVariantInfoService,
             variantAnnotationSummaryService,
-            postTranslationalModificationService);
+            postTranslationalModificationService,
+            oncokbService);
     }
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
@@ -76,7 +76,7 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
         throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
     {
         return this.getAnnotationSummaryForCanonical(
-            this.variantAnnotationService.getAnnotation(variant, isoformOverrideSource, null));
+            this.variantAnnotationService.getAnnotation(variant, isoformOverrideSource, null, null));
     }
 
     @Override
@@ -105,7 +105,7 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
         throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
     {
         return this.getAnnotationSummary(
-            this.variantAnnotationService.getAnnotation(variant, isoformOverrideSource, null));
+            this.variantAnnotationService.getAnnotation(variant, isoformOverrideSource, null, null));
     }
 
     @Override
@@ -113,7 +113,7 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
         List<VariantAnnotationSummary> summaries = new ArrayList<>();
 
         List<VariantAnnotation> annotations =
-            this.variantAnnotationService.getAnnotations(variants, isoformOverrideSource, null);
+            this.variantAnnotationService.getAnnotations(variants, isoformOverrideSource, null, null);
 
         for (VariantAnnotation annotation: annotations) {
             summaries.add(this.getAnnotationSummary(annotation));
@@ -127,7 +127,7 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
         List<VariantAnnotationSummary> summaries = new ArrayList<>();
 
         List<VariantAnnotation> annotations =
-            this.variantAnnotationService.getAnnotations(variants, isoformOverrideSource, null);
+            this.variantAnnotationService.getAnnotations(variants, isoformOverrideSource, null, null);
 
         for (VariantAnnotation annotation: annotations) {
             summaries.add(this.getAnnotationSummaryForCanonical(annotation));

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/remote/OncokbDataFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/remote/OncokbDataFetcher.java
@@ -1,0 +1,114 @@
+package org.cbioportal.genome_nexus.service.remote;
+
+import org.cbioportal.genome_nexus.service.exception.ResourceMappingException;
+import org.cbioportal.genome_nexus.service.transformer.ExternalResourceTransformer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+import java.util.List;
+import java.util.Map;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import org.oncokb.client.IndicatorQueryResp;
+
+
+@Component
+public class OncokbDataFetcher extends BaseExternalResourceFetcher<IndicatorQueryResp>
+{
+    private String oncokbToken;
+    private static final String MAIN_QUERY_PARAM = "alteration";
+    private static final String PLACEHOLDER = "PROTEINCHANGE";
+
+    private final ExternalResourceTransformer<IndicatorQueryResp> transformer;
+
+    @Autowired
+    public OncokbDataFetcher(ExternalResourceTransformer<IndicatorQueryResp> transformer,
+                                       @Value("${oncokb.url:https://www.oncokb.org/api/v1/annotate/mutations/byProteinChange?PROTEINCHANGE}") String oncokbUrl)
+    {
+        super(oncokbUrl, MAIN_QUERY_PARAM, PLACEHOLDER);
+        this.transformer = transformer;
+    }
+
+    public String getOncokbToken() {
+        return oncokbToken;
+    }
+
+    public void setOncokbToken(String oncokbToken) {
+        this.oncokbToken = oncokbToken;
+    }
+
+    @Override
+    public List<IndicatorQueryResp> fetchInstances(Map<String, String> queryParams)
+        throws HttpClientErrorException, ResourceAccessException, ResourceMappingException
+    {
+        return this.transformer.transform(this.fetchRawValue(queryParams), IndicatorQueryResp.class);
+    }
+
+    @Override
+    public List<IndicatorQueryResp> fetchInstances(Object requestBody)
+        throws HttpClientErrorException, ResourceAccessException, ResourceMappingException
+    {
+        return this.transformer.transform(this.fetchRawValue(requestBody), IndicatorQueryResp.class);
+    }
+
+    @Override
+    public DBObject fetchRawValue(Map<String, String> queryParams)
+        throws HttpClientErrorException, ResourceAccessException
+    {
+        // get the value of the main (single) parameter
+        String paramValue = queryParams.get(this.mainQueryParam);
+        String uri = this.URI;
+
+        // replace the placeholder with the value in the uri
+        if (paramValue != null && paramValue.length() > 0) {
+            uri = uri.replace(this.placeholder, paramValue);
+        }
+
+        return this.getForObject(uri, queryParams);
+    }
+
+    @Override
+    public DBObject fetchRawValue(Object requestBody)
+        throws HttpClientErrorException, ResourceAccessException
+    {
+        return this.postForObject(this.URI, requestBody);
+    }
+
+    @Override
+    protected DBObject getForObject(String uri, Map<String, String> queryParams) {
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add("Authorization", "Bearer " + this.oncokbToken);
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        HttpEntity<String> entity = new HttpEntity<String>(queryParams.toString(), httpHeaders);
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<BasicDBObject> response = restTemplate.exchange(
+            uri, HttpMethod.GET, entity, BasicDBObject.class);
+        return response.getBody();
+    }
+
+    public ExternalResourceTransformer getTransformer() {
+        return transformer;
+    }
+
+    @Override
+    protected DBObject postForObject(String uri, Object requestBody)
+    {
+
+        HttpHeaders httpHeaders = new HttpHeaders();        
+        httpHeaders.add("Authorization", "Bearer " + this.oncokbToken);
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);      
+        
+        RestTemplate restTemplate = new RestTemplate();
+        HttpEntity<String> request = new HttpEntity<String>(requestBody.toString(), httpHeaders);
+        return restTemplate.postForObject(uri, request, BasicDBObject.class);
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/util/TokenMapConverter.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/util/TokenMapConverter.java
@@ -1,0 +1,24 @@
+package org.cbioportal.genome_nexus.util;
+
+import java.util.*;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+
+
+public class TokenMapConverter {
+
+    public Map<String, String> convertToMap(String token) {
+        Gson gson = new Gson();
+        Map<String, String> tokenMap = new HashMap<String, String>();
+        try {
+            tokenMap = gson.fromJson(token, Map.class);
+        }
+        catch (JsonParseException e) {
+            System.out.println("The format of token is invalid. For example {\"source1\":\"put-your-token1-here\",\"source2\":\"put-your-token2-here\"}");
+        }
+        return tokenMap;
+    }
+}
+
+

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationServiceTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationServiceTest.java
@@ -148,13 +148,13 @@ public class VariantAnnotationServiceTest
         fields.add("mutation_assessor");
 
         VariantAnnotation annotation1 = variantAnnotationService.getAnnotation(
-            "7:g.140453136A>T", null, fields);
+            "7:g.140453136A>T", null, null, fields);
 
         assertEquals(maMockData.get("7,140453136,A,T"),
             annotation1.getMutationAssessorAnnotation().getAnnotation());
 
         VariantAnnotation annotation2 = variantAnnotationService.getAnnotation(
-            "12:g.25398285C>A", null, fields);
+            "12:g.25398285C>A", null, null, fields);
 
         assertEquals(maMockData.get("12,25398285,C,A"),
             annotation2.getMutationAssessorAnnotation().getAnnotation());
@@ -178,13 +178,13 @@ public class VariantAnnotationServiceTest
         fields.add("my_variant_info");
 
         VariantAnnotation annotation1 = variantAnnotationService.getAnnotation(
-            "7:g.140453136A>T", null, fields);
+            "7:g.140453136A>T", null, null, fields);
 
         assertEquals(mviMockData.get("7:g.140453136A>T"),
             annotation1.getMyVariantInfoAnnotation().getAnnotation());
 
         VariantAnnotation annotation2 = variantAnnotationService.getAnnotation(
-            "12:g.25398285C>A", null, fields);
+            "12:g.25398285C>A", null, null, fields);
 
         assertEquals(mviMockData.get("12:g.25398285C>A"),
             annotation2.getMyVariantInfoAnnotation().getAnnotation());
@@ -206,13 +206,13 @@ public class VariantAnnotationServiceTest
         fields.add("ptms");
 
         VariantAnnotation annotation1 = variantAnnotationService.getAnnotation(
-            "7:g.140453136A>T", null, fields);
+            "7:g.140453136A>T", null, null, fields);
 
         assertEquals(ptmMockData.get("ENST00000288602"),
             annotation1.getPtmAnnotation().getAnnotation().get(0));
 
         VariantAnnotation annotation2 = variantAnnotationService.getAnnotation(
-            "12:g.25398285C>A", null, fields);
+            "12:g.25398285C>A", null, null, fields);
 
         assertEquals(ptmMockData.get("ENST00000256078"),
             annotation2.getPtmAnnotation().getAnnotation().get(0));
@@ -235,13 +235,13 @@ public class VariantAnnotationServiceTest
         fields.add("hotspots");
 
         VariantAnnotation annotation1 = variantAnnotationService.getAnnotation(
-            "7:g.140453136A>T", null, fields);
+            "7:g.140453136A>T", null, null, fields);
 
         assertEquals(hotspotMockData.get("ENST00000288602"),
             annotation1.getHotspotAnnotation().getAnnotation().get(0));
 
         VariantAnnotation annotation2 = variantAnnotationService.getAnnotation(
-            "12:g.25398285C>A", null, fields);
+            "12:g.25398285C>A", null, null, fields);
 
         assertEquals(hotspotMockData.get("ENST00000256078"),
             annotation2.getHotspotAnnotation().getAnnotation().get(0));
@@ -259,14 +259,14 @@ public class VariantAnnotationServiceTest
         this.mockIsoformOverrideServiceMethods(isoformOverrideMockData);
 
         VariantAnnotation annotation1 = variantAnnotationService.getAnnotation(
-            "7:g.140453136A>T", "mskcc", null);
+            "7:g.140453136A>T", "mskcc", null, null);
 
         // first transcript of this annotation should be marked as canonical, the second one should NOT be marked
         assertEquals("1", annotation1.getTranscriptConsequences().get(0).getCanonical());
         assertEquals(null, annotation1.getTranscriptConsequences().get(1).getCanonical());
 
         VariantAnnotation annotation2 = variantAnnotationService.getAnnotation(
-            "7:g.140453136A>T", "uniprot", null);
+            "7:g.140453136A>T", "uniprot", null, null);
 
         // second transcript of this annotation should be marked as canonical, the first one should NOT be marked
         assertEquals(null, annotation2.getTranscriptConsequences().get(0).getCanonical());

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -12,14 +12,7 @@
     <artifactId>genome-nexus</artifactId>
     <version>1.1.1-SNAPSHOT</version>
   </parent>
-
-  <repositories>
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
-  </repositories>
-
+  
   <profiles>
     <profile>
       <id>war</id>
@@ -82,7 +75,7 @@
     <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.mongo</artifactId>
-      <version>1.50.5</version>
+      <version>2.2.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -121,7 +114,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>2.0.1.RELEASE</version>
+        <version>2.2.1.RELEASE</version>
         <executions>
           <execution>
             <goals>
@@ -143,8 +136,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20.1</version>
+        <version>3.0.0-M3</version>
         <configuration>
+          <forkCount>3</forkCount>
+          <reuseForks>true</reuseForks>
+          <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
           <systemPropertyVariables>
             <projectVersion>1.0</projectVersion>
           </systemPropertyVariables>

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
@@ -59,7 +59,7 @@ public class ApiObjectMapper extends ObjectMapper
         mixinMap.put(AlleleFrequency.class, AlleleFrequencyMixin.class);
         mixinMap.put(IntergenicConsequences.class, IntergenicConsequencesMixin.class);
         mixinMap.put(SignalMutation.class, SignalMutationMixin.class);
-        mixinMap.put(CountByTumorType.class, CountByTumorType.class);
+        mixinMap.put(CountByTumorType.class, CountByTumorTypeMixin.class);
         super.setMixIns(mixinMap);
     }
 }

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationMixin.java
@@ -75,6 +75,10 @@ public class VariantAnnotationMixin {
     @ApiModelProperty(value = "Post Translational Modifications", required = false)
     private PtmAnnotation ptmAnnotation;
 
+    @JsonProperty(value="oncokb", required = true)
+    @ApiModelProperty(value = "Oncokb", required = false)
+    private OncokbAnnotation oncokbAnnotation;
+
     @JsonProperty(value="annotation_summary", required = true)
     @ApiModelProperty(value = "Variant Annotation Summary", required = false)
     private VariantAnnotationSummary annotationSummary;

--- a/web/src/main/resources/application.properties.EXAMPLE
+++ b/web/src/main/resources/application.properties.EXAMPLE
@@ -48,3 +48,10 @@ server.max-http-header-size=10000000
 
 # include full git info in /actuator/info endpoint
 management.info.git.mode=full
+
+# oncokb
+oncokb.url=https://www.oncokb.org/api/v1/annotate/mutations/byProteinChange?PROTEINCHANGE
+
+# For testing use same embeded mongo version as genome-nexus-importer
+# https://github.com/genome-nexus/genome-nexus-importer/blob/master/Dockerfile#L1
+spring.mongodb.embedded.version=3.6.2


### PR DESCRIPTION
query OncoKB in the annotation endpoints. 
Adding `oncokb` in `fields` and add token in the format of `{"oncokb":"put-your-token-here"}`

- [x] update http header with token
- [x] use oncokb protein change endpoint
- [x] do not cache the oncokb data
- [x] add token field
- [x] cache curated gene list from oncokb
- [x] use OncoKB model directly from the APIc(use https://github.com/leexgh/oncokb-java-api-client now, will use the client hosted in Oncokb later)
- [x] include API generating code as module in genome-nexus/genome-nexus (copy from genome-nexus-annotation-pipeline).(use https://github.com/leexgh/oncokb-java-api-client now, will use the client hosted in Oncokb later)
- [x] add tests (will do in github actions)
- [x] update genome nexus importer(https://github.com/genome-nexus/genome-nexus-importer/pull/30)
![image](https://user-images.githubusercontent.com/16869603/74267720-9bddbf00-4cd4-11ea-9135-b23fe6474ace.png)

fix: https://github.com/genome-nexus/genome-nexus/issues/17