### PR TITLE
Map All Variants in POST Request to a Response VariantAnnotation Object 

### DIFF
--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
@@ -297,8 +297,14 @@ public class NotationConverter
     public List<String> genomicToHgvs(List<GenomicLocation> genomicLocations)
     {
         List<String> hgvsList = new ArrayList<>();
-        hgvsList.addAll(this.genomicToHgvsMap(genomicLocations).keySet());
-
+        
+        for (GenomicLocation location : genomicLocations) { 
+            String hgvs = this.genomicToHgvs(location);
+            if (hgvs != null) {
+                hgvsList.add(hgvs);
+            }
+        }
+        
         return hgvsList;
     }
 
@@ -322,7 +328,12 @@ public class NotationConverter
     public List<String> genomicToEnsemblRestRegion(List<GenomicLocation> genomicLocations)
     {
         List<String> ensemblRestRegionsList = new ArrayList<>();
-        ensemblRestRegionsList.addAll(this.genomicToEnsemblRestRegionMap(genomicLocations).keySet());
+        for (GenomicLocation location : genomicLocations) { 
+            String ensemblRestRegion = this.genomicToEnsemblRestRegion(location);
+            if (ensemblRestRegion != null) {
+                ensemblRestRegionsList.add(ensemblRestRegion);
+            }
+        }
 
         return ensemblRestRegionsList;
     }

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
@@ -63,6 +63,7 @@ public class VariantAnnotation
     private List<ColocatedVariant> colocatedVariants;
     private List<IntergenicConsequences> intergenicConsequences;
     private List<TranscriptConsequence> transcriptConsequences;
+    private Boolean successfullyAnnotated;
 
     private MutationAssessorAnnotation mutationAssessorAnnotation;
     private MyVariantInfoAnnotation myVariantInfoAnnotation;
@@ -88,6 +89,7 @@ public class VariantAnnotation
         this.variant = variant;
         this.annotationJSON = annotationJSON;
         this.dynamicProps = new LinkedHashMap<>();
+        this.successfullyAnnotated = !(annotationJSON == null);
     }
 
     public String getVariant()
@@ -272,20 +274,18 @@ public class VariantAnnotation
     }
 
     public String getHgvsg() {
-        if (this.getVariantId().contains("g."))
+        if (this.getVariantId() != null && this.getVariantId().contains("g."))
         {
             return this.getVariantId();
-        }
-        // id is not of hgvsg format
-        else {
-            // determine hgvsg from VEP output
+        } else if (this.getTranscriptConsequences() == null) {
+            return null;
+        } else {
+            // id is not of hgvsg format
             for (TranscriptConsequence ts : this.getTranscriptConsequences()) {
                 if (ts.getHgvsg() != null && !ts.getHgvsg().isEmpty()) {
                     return ts.getHgvsg();
                 }
-
             }
-            // TODO: check intergenic if still no hgvsg
             return null;
         }
     }
@@ -300,6 +300,14 @@ public class VariantAnnotation
 
     public void setOncokbAnnotation(OncokbAnnotation oncokbAnnotation) {
         this.oncokbAnnotation = oncokbAnnotation;
+    }
+
+    public void setSuccessfullyAnnotated(Boolean successfullyAnnotated) {
+        this.successfullyAnnotated = successfullyAnnotated;
+    }
+
+    public Boolean isSuccessfullyAnnotated() {
+        return successfullyAnnotated;
     }
 
     public void setDynamicProp(String key, Object value)

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/CachedExternalResourceFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/CachedExternalResourceFetcher.java
@@ -3,9 +3,11 @@ package org.cbioportal.genome_nexus.service;
 import org.cbioportal.genome_nexus.service.exception.ResourceMappingException;
 
 import java.util.List;
+import java.util.Map;
 
 public interface CachedExternalResourceFetcher<T>
 {
     T fetchAndCache(String id) throws ResourceMappingException;
+    Map<String, T> constructFetchedMap(List<String> ids) throws ResourceMappingException;
     List<T> fetchAndCache(List<String> id) throws ResourceMappingException;
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/cached/BaseCachedVariantAnnotationFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/cached/BaseCachedVariantAnnotationFetcher.java
@@ -1,0 +1,102 @@
+package org.cbioportal.genome_nexus.service.cached;
+
+import com.mongodb.DBObject;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.persistence.VariantAnnotationRepository;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.cbioportal.genome_nexus.persistence.GenericMongoRepository;
+import org.cbioportal.genome_nexus.service.CachedExternalResourceFetcher;
+import org.cbioportal.genome_nexus.service.ExternalResourceFetcher;
+import org.cbioportal.genome_nexus.service.ResourceTransformer;
+import org.cbioportal.genome_nexus.service.exception.ResourceMappingException;
+import org.cbioportal.genome_nexus.util.NaturalOrderComparator;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public abstract class BaseCachedVariantAnnotationFetcher
+    extends BaseCachedExternalResourceFetcher<VariantAnnotation, VariantAnnotationRepository>
+{
+    private static final Log LOG = LogFactory.getLog(BaseCachedVariantAnnotationFetcher.class);
+
+    protected String collection;
+    protected VariantAnnotationRepository repository;
+    protected Class<VariantAnnotation> type;
+    protected ExternalResourceFetcher<VariantAnnotation> fetcher;
+    protected ResourceTransformer<VariantAnnotation> transformer;
+    protected Integer maxPageSize;
+
+    public BaseCachedVariantAnnotationFetcher(String collection,
+                                             VariantAnnotationRepository repository,
+                                             Class<VariantAnnotation> type,
+                                             ExternalResourceFetcher<VariantAnnotation> fetcher,
+                                             ResourceTransformer<VariantAnnotation> transformer)
+    {
+        super(collection, repository, type, fetcher, transformer, Integer.MAX_VALUE);
+    }
+
+    public BaseCachedVariantAnnotationFetcher(String collection,
+                                             VariantAnnotationRepository repository,
+                                             Class<VariantAnnotation> type,
+                                             ExternalResourceFetcher<VariantAnnotation> fetcher,
+                                             ResourceTransformer<VariantAnnotation> transformer,
+                                             Integer maxPageSize)
+    {
+        super(collection, repository, type, fetcher, transformer, maxPageSize);
+    }
+   
+    @Override
+    protected String extractId(VariantAnnotation instance)
+    {
+        return instance.getVariantId();
+    }
+
+    @Override
+    protected String extractId(DBObject dbObject)
+    {
+        return (String)dbObject.get("input");
+    }
+
+    @Override 
+    public VariantAnnotation fetchAndCache(String id) throws ResourceMappingException
+    {
+        VariantAnnotation variantAnnotation = null;
+        try {
+            variantAnnotation = super.fetchAndCache(id);
+            if (variantAnnotation == null) {
+                variantAnnotation = new VariantAnnotation(id);
+            } else {
+                variantAnnotation.setSuccessfullyAnnotated(true);
+            }
+        } catch (Exception e) {
+            return new VariantAnnotation(id);
+        }
+        return variantAnnotation;
+    }
+    
+    @Override
+    public List<VariantAnnotation> fetchAndCache(List<String> ids) throws ResourceMappingException
+    {
+        Map<String, VariantAnnotation> variantResponse = this.constructFetchedMap(ids); 
+        for (String variantId : variantResponse.keySet()) {
+            if (variantResponse.get(variantId) == null) {
+                VariantAnnotation variantAnnotation = new VariantAnnotation(variantId);
+                variantResponse.put(variantId, variantAnnotation);
+            } else {
+                variantResponse.get(variantId).setSuccessfullyAnnotated(true);
+            }
+        }
+        // some util function to return response (values) with duplicates
+        // need to pass in a list representing indexes of original request
+        List<VariantAnnotation> values = new ArrayList();
+        for (String id : ids) {
+           values.add(variantResponse.get(id));
+        } 
+        return values;
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/cached/CachedVariantAnnotationFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/cached/CachedVariantAnnotationFetcher.java
@@ -15,7 +15,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Component
-public class CachedVariantAnnotationFetcher extends BaseCachedExternalResourceFetcher<VariantAnnotation, VariantAnnotationRepository>
+public class CachedVariantAnnotationFetcher extends BaseCachedVariantAnnotationFetcher
 {
 
     @Autowired
@@ -35,18 +35,6 @@ public class CachedVariantAnnotationFetcher extends BaseCachedExternalResourceFe
     @Override
     protected Boolean isValidId(String id) {
         return !id.contains("N") && !id.contains("-") && !id.contains("undefined") && !id.contains("g.0") && id.contains(":") && id.split(":")[1].matches(".*\\d+.*");
-    }
-
-    @Override
-    protected String extractId(VariantAnnotation instance)
-    {
-        return instance.getVariantId();
-    }
-
-    @Override
-    protected String extractId(DBObject dbObject)
-    {
-        return (String)dbObject.get("input");
     }
 
     @Override

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/cached/CachedVariantIdAnnotationFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/cached/CachedVariantIdAnnotationFetcher.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 import java.util.*;
 
 @Component
-public class CachedVariantIdAnnotationFetcher extends BaseCachedExternalResourceFetcher<VariantAnnotation, VariantAnnotationRepository>
+public class CachedVariantIdAnnotationFetcher extends BaseCachedVariantAnnotationFetcher
 {
     @Autowired
     public CachedVariantIdAnnotationFetcher(ExternalResourceTransformer<VariantAnnotation> transformer,
@@ -34,25 +34,6 @@ public class CachedVariantIdAnnotationFetcher extends BaseCachedExternalResource
     protected Boolean isValidId(String id) 
     {
         return id.matches("rs\\d+") || id.matches("COSM\\d+");
-    }
-
-    @Override
-    protected String extractId(VariantAnnotation instance)
-    {
-        return instance.getVariantId();
-    }
-
-    @Override
-    protected String extractId(DBObject dbObject)
-    {
-        return (String)dbObject.get("input");
-    }
-
-    @Override
-    public List<VariantAnnotation> fetchAndCache(List<String> ids) throws ResourceMappingException
-    {
-        List<VariantAnnotation> annotations = super.fetchAndCache(ids);
-        return annotations;
     }
 
     @Override

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/cached/CachedVariantRegionAnnotationFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/cached/CachedVariantRegionAnnotationFetcher.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 import java.util.*;
 
 @Component
-public class CachedVariantRegionAnnotationFetcher extends BaseCachedExternalResourceFetcher<VariantAnnotation, VariantAnnotationRepository>
+public class CachedVariantRegionAnnotationFetcher extends BaseCachedVariantAnnotationFetcher
 {
     @Autowired
     public CachedVariantRegionAnnotationFetcher(ExternalResourceTransformer<VariantAnnotation> transformer,
@@ -53,22 +53,4 @@ public class CachedVariantRegionAnnotationFetcher extends BaseCachedExternalReso
         );
     }
 
-    @Override
-    protected String extractId(VariantAnnotation instance)
-    {
-        return instance.getVariantId();
-    }
-
-    @Override
-    protected String extractId(DBObject dbObject)
-    {
-        return (String)dbObject.get("input");
-    }
-
-    @Override
-    public List<VariantAnnotation> fetchAndCache(List<String> ids) throws ResourceMappingException
-    {
-        List<VariantAnnotation> annotations = super.fetchAndCache(ids);
-        return annotations;
-    }
 }

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationController.java
@@ -235,7 +235,7 @@ public class AnnotationController
     public VariantAnnotation fetchVariantAnnotationByGenomicLocationGET(
         @ApiParam(value="A genomic location. For example 7,140453136,140453136,A,T",
             required = true)
-        @PathVariable @ValidGenomicLocation String genomicLocation,
+        @PathVariable String genomicLocation,
         @ApiParam(value="Isoform override source. For example uniprot",
             required = false)
         @RequestParam(required = false) String isoformOverrideSource,

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationMixin.java
@@ -63,6 +63,10 @@ public class VariantAnnotationMixin {
     @ApiModelProperty(value = "List of transcripts", required = false)
     private List<TranscriptConsequence> transcriptConsequences;
 
+    @JsonProperty(value="successfully_annotated", required = true)
+    @ApiModelProperty(value = "Status flag indicating whether variant was succesfully annotated", required = false)
+    private Boolean successfullyAnnotated;
+    
     @JsonProperty(value="mutation_assessor", required = true)
     @ApiModelProperty(value = "Mutation Assessor Annotation", required = false)
     private MutationAssessorAnnotation mutationAssessorAnnotation;

--- a/web/src/test/java/org/cbioportal/genome_nexus/web/AnnotationIntegrationTest.java
+++ b/web/src/test/java/org/cbioportal/genome_nexus/web/AnnotationIntegrationTest.java
@@ -67,12 +67,17 @@ public class AnnotationIntegrationTest
         //////////////////
 
         // for each variant we should have one matching instance, except the invalid one 
-        assertEquals(variants.length - 1, this.fetchVariantAnnotationPOST(variants).size());
+        assertEquals(variants.length, this.fetchVariantAnnotationPOST(variants).size());
 
         String variantAllele0 = ((HashMap)((ArrayList) this.fetchVariantAnnotationPOST(variants).get(0).get("intergenic_consequences")).get(0)).get("variantAllele").toString();
         // the Get and Post should have same result
         assertEquals(variantAllele, variantAllele0);
-
+        
+        Boolean validAnnotatedFlag = ((Boolean) this.fetchVariantAnnotationPOST(variants).get(1).get("successfully_annotated"));
+        assertEquals(validAnnotatedFlag, true);
+        
+        Boolean invalidAnnotatedFlag = ((Boolean) this.fetchVariantAnnotationPOST(variants).get(2).get("successfully_annotated"));
+        assertEquals(invalidAnnotatedFlag, false);
     }
 
     @Test

--- a/web/src/test/java/org/cbioportal/genome_nexus/web/VEPIdIntegrationTest.java
+++ b/web/src/test/java/org/cbioportal/genome_nexus/web/VEPIdIntegrationTest.java
@@ -59,7 +59,7 @@ public class VEPIdIntegrationTest
 
         // for each dbsnpid we should have one matching variantannotation
         // instance, except the invalid one
-        assertEquals(dbSNPIds.length -1, anns.length);
+        assertEquals(dbSNPIds.length, anns.length);
 
         // GET and POST requests should return exact same dbsnp ids
         assertEquals(dbSNPIds[0], anns[0].getVariant());


### PR DESCRIPTION
- expand model for annotation success flag
- change logic to include failed variants for post
- change logic to return response including duplicates
- (e.g POST request w/ same variant twice, will return both in returned list)
- change logic to include failed variant for GET
- remove validation for path variable for GET