### PR TITLE
Update VariantClassificationResolver variant map

### DIFF
--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/VariantClassificationResolver.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/VariantClassificationResolver.java
@@ -197,6 +197,8 @@ public class VariantClassificationResolver
         variantMap.put("nmd_transcript_variant",        "Silent");
         variantMap.put("mature_mirna_variant",          "RNA");
         variantMap.put("non_coding_exon_variant",       "RNA");
+        variantMap.put("non_coding_exon",               "RNA");
+        variantMap.put("non-coding-exon",               "RNA");
         variantMap.put("non_coding_transcript_exon_variant", "RNA");
         variantMap.put("non_coding_transcript_variant", "RNA");
         variantMap.put("nc_transcript_variant",         "RNA");


### PR DESCRIPTION
Both of the cases desribed below are a result of issues in the VEP annotation code itself and not from Genome Nexus. Therefore there are 2 new entries in this pull request for the Variant Classification map to capture both such cases.

Note: VEP variant map consequence terms are defined: http://useast.ensembl.org/info/genome/variation/prediction/predicted_data.html

1. Often there are variations of these consequence terms that are returned by VEP that clearly refer to one of the defined consequence terms from the resource above. Example: "non_coding_transcript_exon" (a consequence term that is not defined in the above resource) can be assumed to mean "non_coding_transcript_exon_variant" which *is* defined as a valid consequence term.

2. In other cases the words describing a consequence term might be separated by "-" (dashes) instead of "_" (underscores).

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>