### PR TITLE
add amino acids to annotation summary

### DIFF
--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/AminoAcidsResolver.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/AminoAcidsResolver.java
@@ -1,0 +1,76 @@
+package org.cbioportal.genome_nexus.component.annotation;
+
+import org.cbioportal.genome_nexus.model.TranscriptConsequence;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AminoAcidsResolver
+{
+    private final CanonicalTranscriptResolver canonicalTranscriptResolver;
+
+    @Autowired
+    public AminoAcidsResolver(CanonicalTranscriptResolver canonicalTranscriptResolver)
+    {
+        this.canonicalTranscriptResolver = canonicalTranscriptResolver;
+    }
+
+    @Nullable
+    public String resolve(TranscriptConsequence transcriptConsequence)
+    {
+        String aminoAcids = null;
+
+        if(transcriptConsequence != null) {
+            aminoAcids = transcriptConsequence.getAminoAcids();
+        }
+
+        return aminoAcids;
+    }
+
+    @Nullable
+    private String[] getSplitAminoAcids(String aminoAcids) {
+        if (aminoAcids != null) {
+            if (aminoAcids.contains("/")) {
+                return aminoAcids.split("/");
+            } else {
+                // is silent mutation e.g. E -> E
+                String[] splitAAs = { aminoAcids, aminoAcids };
+                return splitAAs;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    @Nullable
+    public String getRefAminoAcid(TranscriptConsequence transcriptConsequence)
+    {
+        String[] aminoAcids = this.getSplitAminoAcids(this.resolve(transcriptConsequence));
+
+        if (aminoAcids != null) {
+            return aminoAcids[0];
+        } else {
+            return null;
+        }
+    }
+
+    @Nullable
+    public String getAltAminoAcid(TranscriptConsequence transcriptConsequence)
+    {
+        String[] aminoAcids = this.getSplitAminoAcids(this.resolve(transcriptConsequence));
+
+        if (aminoAcids != null) {
+            return aminoAcids[1];
+        } else {
+            return null;
+        }
+    }
+
+    public String resolve(VariantAnnotation variantAnnotation)
+    {
+        return this.resolve(this.canonicalTranscriptResolver.resolve(variantAnnotation));
+    }
+
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/TranscriptConsequenceSummary.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/TranscriptConsequenceSummary.java
@@ -4,6 +4,9 @@ public class TranscriptConsequenceSummary
 {
     private String transcriptId;
     private String codonChange;
+    private String aminoAcids;
+    private String aminoAcidRef;
+    private String aminoAcidAlt;
     private String entrezGeneId;
     private String consequenceTerms;
     private String hugoGeneSymbol;
@@ -19,7 +22,23 @@ public class TranscriptConsequenceSummary
         return transcriptId;
     }
 
-    public void setTranscriptId(String transcriptId) {
+    public String getAminoAcidAlt() {
+		return aminoAcidAlt;
+	}
+
+	public void setAminoAcidAlt(String aminoAcidAlt) {
+		this.aminoAcidAlt = aminoAcidAlt;
+	}
+
+	public String getAminoAcidRef() {
+		return aminoAcidRef;
+	}
+
+	public void setAminoAcidRef(String aminoAcidRef) {
+		this.aminoAcidRef = aminoAcidRef;
+	}
+
+	public void setTranscriptId(String transcriptId) {
         this.transcriptId = transcriptId;
     }
 
@@ -29,6 +48,14 @@ public class TranscriptConsequenceSummary
 
     public void setCodonChange(String codonChange) {
         this.codonChange = codonChange;
+    }
+
+    public String getAminoAcids() {
+        return aminoAcids;
+    }
+
+    public void setAminoAcids(String aminoAcids) {
+        this.aminoAcids = aminoAcids;
     }
 
     public String getEntrezGeneId() {

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
@@ -24,6 +24,7 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
     private final VariantAnnotationService variantAnnotationService;
     private final CanonicalTranscriptResolver canonicalTranscriptResolver;
     private final CodonChangeResolver codonChangeResolver;
+    private final AminoAcidsResolver aminoAcidsResolver;
     private final ConsequenceTermsResolver consequenceTermsResolver;
     private final EntrezGeneIdResolver entrezGeneIdResolver;
     private final GenomicLocationResolver genomicLocationResolver;
@@ -40,6 +41,7 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
     @Autowired
     public VariantAnnotationSummaryServiceImpl(VariantAnnotationService hgvsVariantAnnotationService,
                                                CanonicalTranscriptResolver canonicalTranscriptResolver,
+                                               AminoAcidsResolver aminoAcidsResolver,
                                                CodonChangeResolver codonChangeResolver,
                                                ConsequenceTermsResolver consequenceTermsResolver,
                                                EntrezGeneIdResolver entrezGeneIdResolver,
@@ -57,6 +59,7 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
         this.variantAnnotationService = hgvsVariantAnnotationService;
         this.canonicalTranscriptResolver = canonicalTranscriptResolver;
         this.codonChangeResolver = codonChangeResolver;
+        this.aminoAcidsResolver = aminoAcidsResolver;
         this.consequenceTermsResolver = consequenceTermsResolver;
         this.entrezGeneIdResolver = entrezGeneIdResolver;
         this.genomicLocationResolver = genomicLocationResolver;
@@ -202,6 +205,9 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
 
             summary.setTranscriptId(this.transcriptIdResolver.resolve(transcriptConsequence));
             summary.setCodonChange(this.codonChangeResolver.resolve(transcriptConsequence));
+            summary.setAminoAcids(this.aminoAcidsResolver.resolve(transcriptConsequence));
+            summary.setAminoAcidRef(this.aminoAcidsResolver.getRefAminoAcid(transcriptConsequence));
+            summary.setAminoAcidAlt(this.aminoAcidsResolver.getAltAminoAcid(transcriptConsequence));
             summary.setEntrezGeneId(this.resolveEntrezGeneId(transcriptConsequence));
             summary.setConsequenceTerms(this.consequenceTermsResolver.resolve(transcriptConsequence));
             summary.setHugoGeneSymbol(this.hugoGeneSymbolResolver.resolve(transcriptConsequence));

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/TranscriptConsequenceSummaryMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/TranscriptConsequenceSummaryMixin.java
@@ -15,6 +15,15 @@ public class TranscriptConsequenceSummaryMixin
     @ApiModelProperty(value = "Codon change")
     private String codonChange;
 
+    @ApiModelProperty(value = "Amino acids change")
+    private String aminoAcids;
+
+    @ApiModelProperty(value = "Reference Amino Acid")
+    private String aminoAcidRef;
+
+    @ApiModelProperty(value = "Alt Amino Acid")
+    private String aminoAcidAlt;
+
     @ApiModelProperty(value = "Entrez gene id")
     private String entrezGeneId;
 


### PR DESCRIPTION
VEP has a useful field called `amino_acids`, see also:

https://www.genomenexus.org/annotation/7:g.55249071C%3ET?fields=annotation_summary

It's currently not part of annotation_summary. To avoid having to parse ref and alt amino acids on frontend or in the cli this adds the already parsed fields as well, so one gets:

```
aminoAcids: "T/M"
aminoAcidRef: "T"
aminoAcidAlt: "M"
```

Background: these fields are used by the hotspots algorithm, so would be nice to have these in the MAFs annotated by genome nexus