### PR TITLE
Fix #390 KIT annotation issue

### DIFF
--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/ProteinChangeResolver.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/ProteinChangeResolver.java
@@ -133,7 +133,7 @@ public class ProteinChangeResolver
                 String variantClassification = this.variantClassificationResolver.resolve(
                     variantAnnotation, transcriptConsequence);
 
-                hgvspShort = "*" + String.valueOf(pPos);
+                hgvspShort = "p.*" + String.valueOf(pPos);
 
                 if (variantClassification != null && variantClassification.toLowerCase().startsWith("frame_shift")) {
                     hgvspShort += "fs*";
@@ -167,13 +167,26 @@ public class ProteinChangeResolver
                 if (transcriptConsequence.getHgvsc() != null &&
                     transcriptConsequence.getHgvsc().contains("dup"))
                 {
-                    hgvspShort = aaParts[1].substring(0,1) +
-                        String.valueOf(transcriptConsequence.getProteinStart() - 1) +
-                        "dup";
+                    if (aaParts[1].length() == 1) {
+                        hgvspShort = "p." + aaParts[1].substring(0,1) +
+                            String.valueOf(transcriptConsequence.getProteinStart() - 1) +
+                            "dup";
+                    } else {
+                        // e.g for KIT p.Q575_G592dup
+                        // 4:g.55593656_55593657insCAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT
+                        hgvspShort = "p." + aaParts[1].substring(0,1) +
+                            String.valueOf(transcriptConsequence.getProteinStart() + 1) +
+                            "_" +
+                            aaParts[1].substring(aaParts[1].length() - 1) +
+                            // protein end for an instertion will be protein start + 1, so use length of amino acid insted
+                            String.valueOf(transcriptConsequence.getProteinStart() + aaParts[1].length()) +
+                            "dup";
+
+                    }
                 }
                 else
                 {
-                    hgvspShort = "X" +
+                    hgvspShort = "p.X" +
                         transcriptConsequence.getProteinStart() + "_X" +
                         transcriptConsequence.getProteinEnd() + "ins" +
                         aaParts[1];
@@ -182,11 +195,11 @@ public class ProteinChangeResolver
             else if (transcriptConsequence.getConsequenceTerms() != null &&
                 transcriptConsequence.getConsequenceTerms().get(0).toLowerCase().contains("inframe_deletion"))
             {
-                hgvspShort = aaParts[0] + "del";
+                hgvspShort = "p." + aaParts[0] + "del";
             }
             else
             {
-                hgvspShort = aaParts[0] + transcriptConsequence.getProteinStart();
+                hgvspShort = "p." + aaParts[0] + transcriptConsequence.getProteinStart();
 
                 if (transcriptConsequence.getConsequenceTerms() != null &&
                     transcriptConsequence.getConsequenceTerms().get(0).toLowerCase().contains("frameshift_variant"))

--- a/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/CanonicalTranscriptResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/CanonicalTranscriptResolverTest.java
@@ -124,5 +124,10 @@ public class CanonicalTranscriptResolverTest
             variantMockData.get("22:g.36689419_36689421delCCT").getTranscriptConsequences().get(0),
             this.canonicalTranscriptResolver.resolve(variantMockData.get("22:g.36689419_36689421delCCT"))
         );
+
+        assertEquals(
+            variantMockData.get("4:g.55593656_55593657insCAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT").getTranscriptConsequences().get(0),
+            this.canonicalTranscriptResolver.resolve(variantMockData.get("4:g.55593656_55593657insCAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT"))
+        );
     }
 }

--- a/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/CodonChangeResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/CodonChangeResolverTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.Map;
@@ -15,7 +15,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class CodonChangeResolverTest
 {
     @InjectMocks
@@ -125,6 +125,13 @@ public class CodonChangeResolverTest
         assertEquals(
             "gAGGcc/gcc",
             this.codonChangeResolver.resolve(variantMockData.get("22:g.36689419_36689421delCCT"))
+        );
+
+        assertEquals(
+            "-/CAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT",
+            this.codonChangeResolver.resolve(
+                variantMockData.get("4:g.55593656_55593657insCAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT").getTranscriptConsequences().get(0)
+            )
         );
     }
 

--- a/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/ConsequenceTermsResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/ConsequenceTermsResolverTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -15,7 +15,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ConsequenceTermsResolverTest
 {
     @InjectMocks

--- a/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/HugoGeneSymbolResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/HugoGeneSymbolResolverTest.java
@@ -7,14 +7,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class HugoGeneSymbolResolverTest
 {
     @InjectMocks

--- a/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/ProteinChangeResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/ProteinChangeResolverTest.java
@@ -133,6 +133,11 @@ public class ProteinChangeResolverTest
             "p.E1350del",
             this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("22:g.36689419_36689421delCCT"))
         );
+
+        assertEquals(
+            "p.Q575_G592dup",
+            this.proteinChangeResolver.resolveHgvspShort(variantMockData.get("4:g.55593656_55593657insCAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT"))
+        );
     }
 
     @Test

--- a/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/RefSeqResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/RefSeqResolverTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.Map;
@@ -15,7 +15,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class RefSeqResolverTest
 {
     @InjectMocks

--- a/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/TranscriptIdResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/TranscriptIdResolverTest.java
@@ -7,14 +7,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class TranscriptIdResolverTest
 {
     @InjectMocks

--- a/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/VariantClassificationResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/VariantClassificationResolverTest.java
@@ -9,14 +9,14 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class VariantClassificationResolverTest
 {
     @InjectMocks

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/CanonicalTranscriptResolverMocker.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/CanonicalTranscriptResolverMocker.java
@@ -124,5 +124,11 @@ public class CanonicalTranscriptResolverMocker
         ).thenReturn(
             variantMockData.get("22:g.36689419_36689421delCCT").getTranscriptConsequences().get(0)
         );
+
+        Mockito.when(
+            canonicalTranscriptResolver.resolve(variantMockData.get("4:g.55593656_55593657insCAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT"))
+        ).thenReturn(
+            variantMockData.get("4:g.55593656_55593657insCAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT").getTranscriptConsequences().get(0)
+        );
     }
 }

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantAnnotationMockData.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantAnnotationMockData.java
@@ -65,6 +65,8 @@ public class VariantAnnotationMockData implements MockData<VariantAnnotation>
             this.objectMapper.readVariantAnnotation("X_g.41242962_41242963insGA.json"));
         mockData.put("Y:g.41242962_41242963insGA",
             this.objectMapper.readVariantAnnotation("Y_g.41242962_41242963insGA.json"));
+        mockData.put("4:g.55593656_55593657insCAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT",
+            this.objectMapper.readVariantAnnotation("4_g.55593656_55593657insCAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT.json"));
 
         return mockData;
     }

--- a/service/src/test/resources/variant/4_g.55593656_55593657insCAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT.json
+++ b/service/src/test/resources/variant/4_g.55593656_55593657insCAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT.json
@@ -1,0 +1,139 @@
+{
+    "allele_string": "-/CAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT",
+    "assembly_name": "GRCh37",
+    "end": 55593656,
+    "id": "4:g.55593656_55593657insCAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT",
+    "input": "4:g.55593656_55593657insCAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT",
+    "most_severe_consequence": "inframe_insertion",
+    "seq_region_name": "4",
+    "start": 55593657,
+    "strand": 1,
+    "transcript_consequences": [
+        {
+            "amino_acids": "-/QLPYDHKWEFPRNRLSFG",
+            "biotype": "protein_coding",
+            "canonical": 1,
+            "ccds": "CCDS3496.1",
+            "cdna_end": 1820,
+            "cdna_start": 1819,
+            "cds_end": 1723,
+            "cds_start": 1722,
+            "codons": "-/CAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT",
+            "consequence_terms": [
+                "inframe_insertion"
+            ],
+            "domains": [
+                {
+                    "db": "hmmpanther",
+                    "name": "PTHR24416"
+                },
+                {
+                    "db": "hmmpanther",
+                    "name": "PTHR24416"
+                },
+                {
+                    "db": "Gene3D",
+                    "name": 3
+                },
+                {
+                    "db": "PIRSF_domain",
+                    "name": "PIRSF000615"
+                },
+                {
+                    "db": "PIRSF_domain",
+                    "name": "PIRSF500951"
+                },
+                {
+                    "db": "Superfamily_domains",
+                    "name": "SSF56112"
+                }
+            ],
+            "exon": "11/21",
+            "gene_id": "ENSG00000157404",
+            "gene_symbol": "KIT",
+            "gene_symbol_source": "HGNC",
+            "hgnc_id": 6342,
+            "hgvs_offset": 56,
+            "hgvsc": "ENST00000288135.5:c.1725_1774+4dup",
+            "impact": "MODERATE",
+            "protein_end": 575,
+            "protein_id": "ENSP00000288135",
+            "protein_start": 574,
+            "refseq_transcript_ids": [
+                "NM_000222.2",
+                "NM_001093772.1"
+            ],
+            "strand": 1,
+            "transcript_id": "ENST00000288135",
+            "variant_allele": "CAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT"
+        },
+        {
+            "amino_acids": "-/QLPYDHKWEFPRNRLSFG",
+            "biotype": "protein_coding",
+            "ccds": "CCDS47058.1",
+            "cdna_end": 1808,
+            "cdna_start": 1807,
+            "cds_end": 1711,
+            "cds_start": 1710,
+            "codons": "-/CAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT",
+            "consequence_terms": [
+                "inframe_insertion"
+            ],
+            "domains": [
+                {
+                    "db": "hmmpanther",
+                    "name": "PTHR24416"
+                },
+                {
+                    "db": "hmmpanther",
+                    "name": "PTHR24416"
+                },
+                {
+                    "db": "Gene3D",
+                    "name": 3
+                },
+                {
+                    "db": "PIRSF_domain",
+                    "name": "PIRSF000615"
+                },
+                {
+                    "db": "PIRSF_domain",
+                    "name": "PIRSF500951"
+                },
+                {
+                    "db": "Superfamily_domains",
+                    "name": "SSF56112"
+                }
+            ],
+            "exon": "11/21",
+            "gene_id": "ENSG00000157404",
+            "gene_symbol": "KIT",
+            "gene_symbol_source": "HGNC",
+            "hgnc_id": 6342,
+            "hgvs_offset": 56,
+            "hgvsc": "ENST00000412167.2:c.1713_1762+4dup",
+            "impact": "MODERATE",
+            "protein_end": 571,
+            "protein_id": "ENSP00000390987",
+            "protein_start": 570,
+            "strand": 1,
+            "transcript_id": "ENST00000412167",
+            "variant_allele": "CAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT"
+        },
+        {
+            "biotype": "retained_intron",
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ],
+            "distance": 1801,
+            "gene_id": "ENSG00000157404",
+            "gene_symbol": "KIT",
+            "gene_symbol_source": "HGNC",
+            "hgnc_id": 6342,
+            "impact": "MODIFIER",
+            "strand": 1,
+            "transcript_id": "ENST00000512959",
+            "variant_allele": "CAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT"
+        }
+    ]
+}


### PR DESCRIPTION
When hgvsp is missing from VEP output and hgvsc contains "dup", use the
entire amino_acids field instead of just the first one. This is in accordance with what CVR is reporting for:

4:g.55593656_55593657insCAACTTCCTTATGATCACAAATGGGAGTTTCCCAGAAACAGGCTGAGTTTTGGT

p.Q575_G592dup

Given the cDNA change it is actually slightly more complicated because it seems to duplicate beyond the exon:

ENST00000288135.5:c.1725_1774+4dup

but maybe `p.Q575_G592dup` is ok

Other changes:
- Unrelated: it seems that we sometimes return hgvspShort without the p.
prefix. I believe that is an error, so fixed those as well.
- Because of reuse of the mock classes, mockito complains about mocking
certain methods that aren't used. In this case I would say reusing the
initialized mocks is useful but not all mock data is useful for testing
all resolvers. So I added the "Silent" runner, we have already been
using this in some places after upgrading to the latest mockito. We
might want to revisit this at a later point, but seemed out of the scope
for this PR