### PR TITLE
Fix #387 Add nucelotide context

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/NucleotideContext.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/NucleotideContext.java
@@ -1,0 +1,69 @@
+
+package org.cbioportal.genome_nexus.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Document(collection = "ensembl.nucleotide_context")
+public class NucleotideContext
+{
+    // query e.g. 17:37880219..37880221:1
+    @Id
+    private String query;
+
+    // molecule e.g DNA
+    private String molecule;
+    // id e.g. chromosome:GRCh37:17:37880219:37880221:1
+    private String id;
+    // seq e.g. TTG
+    private String seq;
+
+    // added by genome nexus for convenience
+    // similar to mutation assessor
+    private String hgvs;
+
+    @Field("query")
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    @Field("seq")
+    public String getSeq() {
+        return seq;
+    }
+
+    public void setSeq(String seq) {
+        this.seq = seq;
+    }
+
+    @Field("id")
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Field("molecule")
+    public String getMolecule() {
+        return molecule;
+    }
+
+    public void setMolecule(String molecule) {
+        this.molecule = molecule;
+    }
+
+    public void setHgvs(String hgvs) {
+        this.hgvs = hgvs;
+    }
+    
+    public String getHgvs() {
+        return this.hgvs;
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/NucleotideContextAnnotation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/NucleotideContextAnnotation.java
@@ -1,0 +1,39 @@
+
+package org.cbioportal.genome_nexus.model;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+public class NucleotideContextAnnotation
+{
+
+    @Field(value = "license")
+    private String license;
+
+    @Field(value = "annotation")
+    private NucleotideContext annotation;
+
+    public NucleotideContextAnnotation() { 
+        this.annotation = new NucleotideContext();
+    }
+
+    public String getLicense()
+    {
+        return license;
+    }
+
+    public void setLicense(String license)
+    {
+        this.license = license;
+    }
+
+    public NucleotideContext getAnnotation()
+    {
+        return annotation;
+    }
+
+    public void setAnnotation(NucleotideContext annotation)
+    {
+        this.annotation = annotation;
+    }
+
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
@@ -66,6 +66,7 @@ public class VariantAnnotation
     private Boolean successfullyAnnotated;
 
     private MutationAssessorAnnotation mutationAssessorAnnotation;
+    private NucleotideContextAnnotation nucleotideContextAnnotation;
     private MyVariantInfoAnnotation myVariantInfoAnnotation;
     private HotspotAnnotation hotspotAnnotation;
     private PtmAnnotation ptmAnnotation;
@@ -243,6 +244,14 @@ public class VariantAnnotation
     public String toString()
     {
         return annotationJSON;
+    }
+
+    public NucleotideContextAnnotation getNucleotideContextAnnotation() {
+        return nucleotideContextAnnotation;
+    }
+
+    public void setNucleotideContextAnnotation(NucleotideContextAnnotation nucleotideContextAnnotation) {
+        this.nucleotideContextAnnotation = nucleotideContextAnnotation;
     }
 
     public MutationAssessorAnnotation getMutationAssessorAnnotation() {

--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/NucleotideContextRepository.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/NucleotideContextRepository.java
@@ -1,0 +1,9 @@
+
+package org.cbioportal.genome_nexus.persistence;
+
+import org.cbioportal.genome_nexus.model.NucleotideContext;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+
+public interface NucleotideContextRepository
+    extends MongoRepository<NucleotideContext, String>, GenericMongoRepository {}

--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/internal/NucleotideContextRepositoryImpl.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/internal/NucleotideContextRepositoryImpl.java
@@ -1,0 +1,17 @@
+package org.cbioportal.genome_nexus.persistence.internal;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class NucleotideContextRepositoryImpl extends JsonMongoRepositoryImpl
+{
+    public static final String COLLECTION = "ensembl.nucleotide_context";
+
+    @Autowired
+    public NucleotideContextRepositoryImpl(MongoTemplate mongoTemplate)
+    {
+        super(mongoTemplate);
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/NucleotideContextService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/NucleotideContextService.java
@@ -1,0 +1,28 @@
+package org.cbioportal.genome_nexus.service;
+
+import org.cbioportal.genome_nexus.model.NucleotideContext;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.exception.NucleotideContextNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.NucleotideContextWebServiceException;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
+
+import java.util.List;
+
+public interface NucleotideContextService
+{
+    // variant: hgvs variant (ex: 7:g.140453136A>T)
+    NucleotideContext getNucleotideContext(String variant)
+        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException,
+            NucleotideContextNotFoundException, NucleotideContextWebServiceException;
+
+    // variant: mutation assessor variant (e.g. 17:37880219..37880221:1)
+    NucleotideContext getNucleotideContextByEnsembleSequenceQuery(String sequenceQuery)
+        throws NucleotideContextNotFoundException, NucleotideContextWebServiceException;
+
+    // variant: hgvs variant (ex: 7:g.140453136A>T)
+    List<NucleotideContext> getNucleotideContext(List<String> variants);
+
+    NucleotideContext getNucleotideContext(VariantAnnotation annotation)
+        throws NucleotideContextNotFoundException, NucleotideContextWebServiceException;
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/cached/CachedNucleotideContextFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/cached/CachedNucleotideContextFetcher.java
@@ -1,0 +1,25 @@
+package org.cbioportal.genome_nexus.service.cached;
+
+import org.cbioportal.genome_nexus.model.NucleotideContext;
+import org.cbioportal.genome_nexus.persistence.NucleotideContextRepository;
+import org.cbioportal.genome_nexus.persistence.internal.NucleotideContextRepositoryImpl;
+import org.cbioportal.genome_nexus.service.remote.NucleotideContextDataFetcher;
+import org.cbioportal.genome_nexus.service.transformer.ExternalResourceTransformer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CachedNucleotideContextFetcher extends BaseCachedExternalResourceFetcher<NucleotideContext, NucleotideContextRepository>
+{
+    @Autowired
+    public CachedNucleotideContextFetcher(ExternalResourceTransformer<NucleotideContext> transformer,
+                                         NucleotideContextRepository repository,
+                                         NucleotideContextDataFetcher fetcher)
+    {
+        super(NucleotideContextRepositoryImpl.COLLECTION,
+            repository,
+            NucleotideContext.class,
+            fetcher,
+            transformer);
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/config/ExternalResourceObjectMapper.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/config/ExternalResourceObjectMapper.java
@@ -24,6 +24,7 @@ public class ExternalResourceObjectMapper extends ObjectMapper
 
         mixinMap.put(GeneXref.class, GeneXrefMixin.class);
         mixinMap.put(MutationAssessor.class, MutationAssessorMixin.class);
+        mixinMap.put(NucleotideContext.class, NucleotideContextMixin.class);
         mixinMap.put(TranscriptConsequence.class, TranscriptConsequenceMixin.class);
         mixinMap.put(VariantAnnotation.class, VariantAnnotationMixin.class);
         mixinMap.put(MyVariantInfo.class, MyVariantInfoMixin.class);

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/NucleotideContextAnnotationEnricher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/NucleotideContextAnnotationEnricher.java
@@ -1,0 +1,48 @@
+package org.cbioportal.genome_nexus.service.enricher;
+
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.cbioportal.genome_nexus.model.NucleotideContext;
+import org.cbioportal.genome_nexus.model.NucleotideContextAnnotation;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.AnnotationEnricher;
+import org.cbioportal.genome_nexus.service.NucleotideContextService;
+import org.cbioportal.genome_nexus.service.exception.NucleotideContextNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.NucleotideContextWebServiceException;
+
+public class NucleotideContextAnnotationEnricher implements AnnotationEnricher
+{
+    private static final Log LOG = LogFactory.getLog(NucleotideContextAnnotationEnricher.class);
+
+    private NucleotideContextService nucleotideContextService;
+
+    public NucleotideContextAnnotationEnricher(NucleotideContextService nucleotideContextService) {
+        this.nucleotideContextService = nucleotideContextService;
+    }
+
+    @Override
+    public void enrich(VariantAnnotation annotation) {
+        if (annotation != null)
+        {
+            NucleotideContext nucleotideContext = null;
+
+            try {
+                nucleotideContext = nucleotideContextService.getNucleotideContext(annotation);
+            } catch (NucleotideContextWebServiceException e) {
+                LOG.warn(e.getLocalizedMessage());
+            } catch (NucleotideContextNotFoundException e) {
+                // fail silently for this variant annotation
+            }
+
+            if (nucleotideContext != null)
+            {
+                NucleotideContextAnnotation nucleotideContextAnnotation = new NucleotideContextAnnotation();
+                nucleotideContextAnnotation.setAnnotation(nucleotideContext);
+
+                annotation.setNucleotideContextAnnotation(nucleotideContextAnnotation);
+            }
+        }
+    }
+
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/exception/NucleotideContextNotFoundException.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/exception/NucleotideContextNotFoundException.java
@@ -1,0 +1,25 @@
+package org.cbioportal.genome_nexus.service.exception;
+
+public class NucleotideContextNotFoundException extends Exception
+{
+    private String variant;
+
+    public NucleotideContextNotFoundException(String variant)
+    {
+        super();
+        this.variant = variant;
+    }
+
+    public String getVariant() {
+        return variant;
+    }
+
+    public void sethugoSymbol(String variant) {
+        this.variant = variant;
+    }
+
+    @Override
+    public String getMessage() {
+        return "NucleotideContext not found: " + this.getVariant();
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/exception/NucleotideContextWebServiceException.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/exception/NucleotideContextWebServiceException.java
@@ -1,0 +1,14 @@
+package org.cbioportal.genome_nexus.service.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NucleotideContextWebServiceException extends DefaultWebServiceException
+{
+    public NucleotideContextWebServiceException(String responseBody) {
+        super(responseBody);
+    }
+
+    public NucleotideContextWebServiceException(String responseBody, HttpStatus statusCode) {
+        super(responseBody, statusCode);
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/BaseVariantAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/BaseVariantAnnotationServiceImpl.java
@@ -63,6 +63,7 @@ public abstract class BaseVariantAnnotationServiceImpl implements VariantAnnotat
     private final MutationAssessorService mutationAssessorService;
     private final VariantAnnotationSummaryService variantAnnotationSummaryService;
     private final MyVariantInfoService myVariantInfoService;
+    private final NucleotideContextService nucleotideContextService;
     private final PostTranslationalModificationService postTranslationalModificationService;
     private final OncokbService oncokbService;
 
@@ -71,6 +72,7 @@ public abstract class BaseVariantAnnotationServiceImpl implements VariantAnnotat
                                             CancerHotspotService hotspotService,
                                             MutationAssessorService mutationAssessorService,
                                             MyVariantInfoService myVariantInfoService,
+                                            NucleotideContextService nucleotideContextService,
                                             VariantAnnotationSummaryService variantAnnotationSummaryService,
                                             PostTranslationalModificationService postTranslationalModificationService,
                                             OncokbService oncokbService)
@@ -79,6 +81,7 @@ public abstract class BaseVariantAnnotationServiceImpl implements VariantAnnotat
         this.isoformOverrideService = isoformOverrideService;
         this.hotspotService = hotspotService;
         this.mutationAssessorService = mutationAssessorService;
+        this.nucleotideContextService = nucleotideContextService;
         this.variantAnnotationSummaryService = variantAnnotationSummaryService;
         this.myVariantInfoService = myVariantInfoService;
         this.postTranslationalModificationService = postTranslationalModificationService;
@@ -258,6 +261,12 @@ public abstract class BaseVariantAnnotationServiceImpl implements VariantAnnotat
         {
             AnnotationEnricher enricher = new MutationAssessorAnnotationEnricher(mutationAssessorService);
             postEnrichmentService.registerEnricher("mutation_assessor", enricher);
+        }
+
+        if (fields != null && fields.contains("nucleotide_context"))
+        {
+            AnnotationEnricher enricher = new NucleotideContextAnnotationEnricher(nucleotideContextService);
+            postEnrichmentService.registerEnricher("nucleotide_context", enricher);
         }
 
         if (fields != null && fields.contains("my_variant_info"))

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/DbsnpVariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/DbsnpVariantAnnotationService.java
@@ -54,6 +54,7 @@ public class DbsnpVariantAnnotationService extends BaseVariantAnnotationServiceI
                                          @Lazy CancerHotspotService hotspotService,
                                          @Lazy MutationAssessorService mutationAssessorService,
                                          @Lazy MyVariantInfoService myVariantInfoService,
+                                         @Lazy NucleotideContextService nucleotideContextService,
                                          @Lazy VariantAnnotationSummaryService variantAnnotationSummaryService,
                                          @Lazy PostTranslationalModificationService postTranslationalModificationService,
                                          @Lazy OncokbService oncokbService)
@@ -63,6 +64,7 @@ public class DbsnpVariantAnnotationService extends BaseVariantAnnotationServiceI
             hotspotService,
             mutationAssessorService,
             myVariantInfoService,
+            nucleotideContextService,
             variantAnnotationSummaryService,
             postTranslationalModificationService,
             oncokbService);

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HgvsVariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HgvsVariantAnnotationService.java
@@ -56,6 +56,7 @@ public class HgvsVariantAnnotationService extends BaseVariantAnnotationServiceIm
                                         @Lazy CancerHotspotService hotspotService,
                                         @Lazy MutationAssessorService mutationAssessorService,
                                         @Lazy MyVariantInfoService myVariantInfoService,
+                                        @Lazy NucleotideContextService nucleotideContextService,
                                         @Lazy VariantAnnotationSummaryService variantAnnotationSummaryService,
                                         @Lazy PostTranslationalModificationService postTranslationalModificationService,
                                         @Lazy OncokbService oncokbService)
@@ -65,6 +66,7 @@ public class HgvsVariantAnnotationService extends BaseVariantAnnotationServiceIm
             hotspotService,
             mutationAssessorService,
             myVariantInfoService,
+            nucleotideContextService,
             variantAnnotationSummaryService,
             postTranslationalModificationService,
             oncokbService);

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/NucleotideContextServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/NucleotideContextServiceImpl.java
@@ -1,0 +1,140 @@
+
+package org.cbioportal.genome_nexus.service.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.cbioportal.genome_nexus.model.NucleotideContext;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.NucleotideContextService;
+import org.cbioportal.genome_nexus.service.VariantAnnotationService;
+import org.cbioportal.genome_nexus.service.cached.CachedNucleotideContextFetcher;
+import org.cbioportal.genome_nexus.service.exception.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+@Service
+public class NucleotideContextServiceImpl implements NucleotideContextService
+{
+    private static final Log LOG = LogFactory.getLog(NucleotideContextServiceImpl.class);
+
+    private final CachedNucleotideContextFetcher cachedExternalResourceFetcher;
+    private final VariantAnnotationService variantAnnotationService;
+
+    @Autowired
+    public NucleotideContextServiceImpl(CachedNucleotideContextFetcher cachedExternalResourceFetcher,
+                                       VariantAnnotationService hgvsVariantAnnotationService)
+    {
+        this.cachedExternalResourceFetcher = cachedExternalResourceFetcher;
+        this.variantAnnotationService = hgvsVariantAnnotationService;
+    }
+
+    /**
+     * @param variant   hgvs variant (ex: 7:g.140453136A>T)
+     */
+    public NucleotideContext getNucleotideContext(String variant)
+        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException,
+        NucleotideContextNotFoundException, NucleotideContextWebServiceException
+    {
+        VariantAnnotation variantAnnotation = this.variantAnnotationService.getAnnotation(variant);
+
+        return this.getNucleotideContextByVariantAnnotation(variantAnnotation);
+    }
+
+    /**
+     * @param variants   hgvs variants (ex: 7:g.140453136A>T)
+     */
+    public List<NucleotideContext> getNucleotideContext(List<String> variants)
+    {
+        List<NucleotideContext> nucleotideContexts = new ArrayList<>();
+        List<VariantAnnotation> variantAnnotations = this.variantAnnotationService.getAnnotations(variants);
+
+        for (VariantAnnotation variantAnnotation : variantAnnotations)
+        {
+            try {
+                nucleotideContexts.add(this.getNucleotideContextByVariantAnnotation(variantAnnotation));
+            } catch (NucleotideContextWebServiceException e) {
+                LOG.warn(e.getLocalizedMessage());
+            } catch (NucleotideContextNotFoundException e) {
+                // fail silently for this variant
+            }
+        }
+
+        return nucleotideContexts;
+    }
+
+    public NucleotideContext getNucleotideContext(VariantAnnotation annotation)
+        throws NucleotideContextNotFoundException, NucleotideContextWebServiceException
+    {
+        // checks annotation is SNP
+        if (annotation.getStart() == null
+            || !annotation.getStart().equals(annotation.getEnd())
+            || !annotation.getAlleleString().matches("[A-Z]/[A-Z]"))
+        {
+            throw new NucleotideContextNotFoundException(annotation.getVariant());
+        }
+
+        NucleotideContext nucleotideContext = this.getNucleotideContextByEnsembleSequenceQuery(buildRequest(annotation));
+
+        // add original hgvs variant value too
+        nucleotideContext.setHgvs(annotation.getVariant());
+
+        return nucleotideContext;
+    }
+
+    /**
+     * @param variant   mutation assessor variant (ex: 7,140453136,A,T)
+     */
+    public NucleotideContext getNucleotideContextByEnsembleSequenceQuery(String sequenceQuery)
+        throws NucleotideContextNotFoundException, NucleotideContextWebServiceException
+    {
+        Optional<NucleotideContext> nucleotideContext = null;
+
+        try {
+            // get the annotation from the web service and save it to the DB
+            nucleotideContext = Optional.of(cachedExternalResourceFetcher.fetchAndCache(sequenceQuery));
+        } catch (ResourceMappingException e) {
+            throw new NucleotideContextWebServiceException(e.getMessage());
+        } catch (HttpClientErrorException e) {
+            throw new NucleotideContextWebServiceException(e.getResponseBodyAsString(), e.getStatusCode());
+        } catch (ResourceAccessException e) {
+            throw new NucleotideContextWebServiceException(e.getMessage());
+        }
+
+        try {
+            return nucleotideContext.get();
+        } catch (NoSuchElementException e) {
+            throw new NucleotideContextNotFoundException(sequenceQuery);
+        }
+    }
+
+    private NucleotideContext getNucleotideContextByVariantAnnotation(VariantAnnotation variantAnnotation)
+        throws NucleotideContextWebServiceException, NucleotideContextNotFoundException
+    {
+        NucleotideContext nucleotideContextObj = this.getNucleotideContext(variantAnnotation);
+
+        if (nucleotideContextObj != null)
+        {
+            return nucleotideContextObj;
+        }
+        else {
+            throw new NucleotideContextNotFoundException(variantAnnotation.getVariant());
+        }
+    }
+
+    private String buildRequest(VariantAnnotation annotation)
+    {
+        // e.g. 17:37880219..37880221:1
+        StringBuilder sb = new StringBuilder(annotation.getSeqRegionName() + ":");
+        sb.append((annotation.getStart() - 1) + "..");
+        sb.append(annotation.getStart() + 1 + ":1");
+
+        return sb.toString();
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/RegionVariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/RegionVariantAnnotationService.java
@@ -54,6 +54,7 @@ public class RegionVariantAnnotationService extends BaseVariantAnnotationService
                                           @Lazy CancerHotspotService hotspotService,
                                           @Lazy MutationAssessorService mutationAssessorService,
                                           @Lazy MyVariantInfoService myVariantInfoService,
+                                          @Lazy NucleotideContextService nucleotideContextService,
                                           @Lazy VariantAnnotationSummaryService variantAnnotationSummaryService,
                                           @Lazy PostTranslationalModificationService postTranslationalModificationService,
                                           @Lazy OncokbService oncokbService)
@@ -63,6 +64,7 @@ public class RegionVariantAnnotationService extends BaseVariantAnnotationService
             hotspotService,
             mutationAssessorService,
             myVariantInfoService,
+            nucleotideContextService,
             variantAnnotationSummaryService,
             postTranslationalModificationService,
             oncokbService);

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/NucleotideContextMixin.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/NucleotideContextMixin.java
@@ -1,0 +1,11 @@
+package org.cbioportal.genome_nexus.service.mixin;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NucleotideContextMixin
+{
+    @JsonProperty("seq")
+    private String seq;
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/remote/NucleotideContextDataFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/remote/NucleotideContextDataFetcher.java
@@ -1,0 +1,61 @@
+package org.cbioportal.genome_nexus.service.remote;
+
+import org.cbioportal.genome_nexus.model.GeneXref;
+import org.cbioportal.genome_nexus.model.NucleotideContext;
+import org.cbioportal.genome_nexus.service.exception.ResourceMappingException;
+import org.cbioportal.genome_nexus.service.transformer.ExternalResourceTransformer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+
+@Component
+public class NucleotideContextDataFetcher extends BaseExternalResourceFetcher<NucleotideContext>
+{
+    private static final String MAIN_QUERY_PARAM = "query";
+    private static final String PLACEHOLDER = "QUERY";
+
+    private final ExternalResourceTransformer<NucleotideContext> transformer;
+
+    @Autowired
+    public NucleotideContextDataFetcher(ExternalResourceTransformer<NucleotideContext> transformer,
+                               @Value("${ensembl.sequence.url:https://grch37.rest.ensembl.org/sequence/region/human/QUERY?content-type=application/json'}") String ensemblSequenceUrl)
+    {
+        super(ensemblSequenceUrl, MAIN_QUERY_PARAM, PLACEHOLDER);
+        this.transformer = transformer;
+    }
+
+    @Override
+    public List<NucleotideContext> fetchInstances(Map<String, String> queryParams)
+        throws HttpClientErrorException, ResourceAccessException, ResourceMappingException
+    {
+        return this.transformer.transform(this.fetchRawValue(queryParams), NucleotideContext.class);
+    }
+
+    @Override
+    public List<NucleotideContext> fetchInstances(Object requestBody)
+        throws HttpClientErrorException, ResourceAccessException, ResourceMappingException
+    {
+        return this.transformer.transform(this.fetchRawValue(requestBody), NucleotideContext.class);
+    }
+
+    @Override
+    protected DBObject getForObject(String uri, Map<String, String> queryParams) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        return restTemplate.getForObject(uri, BasicDBObject.class);
+    }
+
+
+    public ExternalResourceTransformer getTransformer() {
+        return transformer;
+    }
+}

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/NucleotideContextController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/NucleotideContextController.java
@@ -1,0 +1,62 @@
+package org.cbioportal.genome_nexus.web;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.cbioportal.genome_nexus.model.NucleotideContext;
+import org.cbioportal.genome_nexus.service.NucleotideContextService;
+import org.cbioportal.genome_nexus.service.exception.NucleotideContextNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.NucleotideContextWebServiceException;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
+import org.cbioportal.genome_nexus.web.config.InternalApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@InternalApi
+@RestController // shorthand for @Controller, @ResponseBody
+@CrossOrigin(origins="*") // allow all cross-domain requests
+@RequestMapping(value= "/")
+@Api(tags = "nucleotide-context-controller", description = "Nucleotide Context Controller")
+public class NucleotideContextController
+{
+    private final NucleotideContextService nucleotideContextService;
+
+    @Autowired
+    public NucleotideContextController(NucleotideContextService nucleotideContextService)
+    {
+        this.nucleotideContextService = nucleotideContextService;
+    }
+
+    @ApiOperation(value = "Retrieves nucleotide context information for the provided list of variants",
+        nickname = "fetchNucleotideContextAnnotationGET")
+    @RequestMapping(value = "/nucleotide_context/{variant:.+}",
+        method = RequestMethod.GET,
+        produces = "application/json")
+    public NucleotideContext fetchNucleotideContextAnnotationGET(
+        @ApiParam(value="A variant. For example 7:g.140453136A>T",
+            required = true,
+            allowMultiple = true)
+        @PathVariable String variant)
+        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException,
+        NucleotideContextWebServiceException, NucleotideContextNotFoundException
+    {
+        return this.nucleotideContextService.getNucleotideContext(variant);
+    }
+
+    @ApiOperation(value = "Retrieves nucleotide context information for the provided list of variants",
+        nickname = "postNucleotideContextAnnotation")
+    @RequestMapping(value = "/nucleotide_context",
+        method = RequestMethod.POST,
+        produces = "application/json")
+    public List<NucleotideContext> fetchNucleotideContextAnnotationPOST(
+        @ApiParam(value="List of variants. For example [\"7:g.140453136A>T\",\"12:g.25398285C>A\"]",
+            required = true,
+            allowMultiple = true)
+        @RequestBody List<String> variants)
+    {
+        return this.nucleotideContextService.getNucleotideContext(variants);
+    }
+}

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
@@ -24,6 +24,7 @@ public class ApiObjectMapper extends ObjectMapper
         mixinMap.put(Hotspot.class, HotspotMixin.class);
         mixinMap.put(IsoformOverride.class, IsoformOverrideMixin.class);
         mixinMap.put(MutationAssessor.class, MutationAssessorMixin.class);
+        mixinMap.put(NucleotideContext.class, NucleotideContextMixin.class);
         mixinMap.put(PfamDomain.class, PfamDomainMixin.class);
         mixinMap.put(PdbHeader.class, PdbHeaderMixin.class);
         mixinMap.put(TranscriptConsequence.class, TranscriptConsequenceMixin.class);

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/NucleotideContextMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/NucleotideContextMixin.java
@@ -1,0 +1,12 @@
+package org.cbioportal.genome_nexus.web.mixin;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModelProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class NucleotideContextMixin
+{
+    @ApiModelProperty(value = "Nucleotide context sequence", required = true)
+    private String seq;
+}

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationMixin.java
@@ -71,6 +71,10 @@ public class VariantAnnotationMixin {
     @ApiModelProperty(value = "Mutation Assessor Annotation", required = false)
     private MutationAssessorAnnotation mutationAssessorAnnotation;
 
+    @JsonProperty(value="nucleotide_context", required = true)
+    @ApiModelProperty(value = "Nucleotide Context Annotation", required = false)
+    private NucleotideContextAnnotation nucleotideContextAnnotation;
+
     @JsonProperty(value="hotspots", required = true)
     @ApiModelProperty(value = "Hotspot Annotation", required = false)
     private HotspotAnnotation hotspotAnnotation;

--- a/web/src/test/java/org/cbioportal/genome_nexus/web/NucleotideContextIntegrationTest.java
+++ b/web/src/test/java/org/cbioportal/genome_nexus/web/NucleotideContextIntegrationTest.java
@@ -1,0 +1,66 @@
+package org.cbioportal.genome_nexus.web;
+
+import org.cbioportal.genome_nexus.model.NucleotideContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = {
+        "spring.data.mongodb.uri=mongodb://localhost/integration",
+        "server.port=38894"
+    }
+)
+public class NucleotideContextIntegrationTest
+{
+    private final static String BASE_URL = "http://localhost:38894/nucleotide_context/";
+
+    private RestTemplate restTemplate = new RestTemplate();
+
+    private NucleotideContext fetchAnnotationGET(String variant)
+    {
+        return this.restTemplate.getForObject(BASE_URL + variant, NucleotideContext.class);
+    }
+
+    private NucleotideContext[] fetchAnnotationsPOST(String[] variants)
+    {
+        return this.restTemplate.postForObject(BASE_URL, variants, NucleotideContext[].class);
+    }
+
+    @Test
+    public void testVariantAnnotationById()
+    {
+        String[] variants = {
+            "7:g.140453136A>T",
+            "12:g.25398285C>A",
+            "17:g.41242962_41242963insGA" // no context for indels
+        };
+
+        //////////////////
+        // GET requests //
+        //////////////////
+
+        NucleotideContext ann0 = this.fetchAnnotationGET(variants[0]);
+
+        assertEquals("CAC", ann0.getSeq());
+
+        //////////////////
+        // POST request //
+        //////////////////
+
+        NucleotideContext[] anns = this.fetchAnnotationsPOST(variants);
+
+        // for each snv we should have one matching NucelotideContext instance
+        // and none for the indel
+        assertEquals(variants.length - 1, anns.length);
+
+        assertEquals("CAC", anns[0].getSeq());
+        assertEquals("CCA", anns[1].getSeq());
+    }
+}


### PR DESCRIPTION
Add another annotation service called nucleotide context that uses
ensembl to pull one base 5' and 3' around a SNV. This is useful for
calculating e.g. signatures and hotspot analyses.