### PR TITLE
Pull mvn project version from git

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -12,7 +12,9 @@
     <parent>
         <groupId>org.cbioportal.genome_nexus</groupId>
         <artifactId>genome-nexus</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <!-- project version is generated through git or can be passed as
+             PROJECT_VERSION env variable (see version.sh) -->
+        <version>0-unknown-version-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -11,7 +11,9 @@
     <parent>
         <groupId>org.cbioportal.genome_nexus</groupId>
         <artifactId>genome-nexus</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <!-- project version is generated through git or can be passed as
+             PROJECT_VERSION env variable (see version.sh) -->
+        <version>0-unknown-version-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -11,7 +11,9 @@
     <parent>
         <groupId>org.cbioportal.genome_nexus</groupId>
         <artifactId>genome-nexus</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <!-- project version is generated through git or can be passed as
+             PROJECT_VERSION env variable (see version.sh) -->
+        <version>0-unknown-version-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,9 @@
     <artifactId>genome-nexus</artifactId>
     <packaging>pom</packaging>
     <name>Genome Nexus Master</name>
-    <version>1.1.1-SNAPSHOT</version>
+    <!-- project version is generated through git or can be passed as
+         PROJECT_VERSION env variable (see version.sh) -->
+    <version>0-unknown-version-SNAPSHOT</version>
     <description>Genome Nexus Master Module</description>
     <url>https://github.com/cBioPortal/genome-nexus/</url>
 
@@ -17,11 +19,17 @@
       <module>web</module>
     </modules>
     <repositories>
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
-  </repositories>
+      <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+      </repository>
+    </repositories>
+    <pluginRepositories>
+      <pluginRepository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+      </pluginRepository>
+    </pluginRepositories>
     <!-- inherit defaults from spring boot -->
     <parent>
       <groupId>org.springframework.boot</groupId>
@@ -53,6 +61,17 @@
 
     <build>
     <plugins>
+        <plugin>
+          <groupId>com.github.cbioportal.maven-external-version</groupId>
+          <artifactId>maven-external-version-plugin</artifactId>
+          <version>f09c2b9608744881111f24e55d55a91e54e6cb5f</version>
+          <extensions>true</extensions>
+          <configuration>
+            <strategy hint="script">
+              <script>./version.sh</script>
+            </strategy>
+          </configuration>
+        </plugin>
         <plugin>
          <groupId>org.jacoco</groupId>
          <artifactId>jacoco-maven-plugin</artifactId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -12,7 +12,9 @@
     <parent>
         <groupId>org.cbioportal.genome_nexus</groupId>
         <artifactId>genome-nexus</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <!-- project version is generated through git or can be passed as
+             PROJECT_VERSION env variable (see version.sh) -->
+        <version>0-unknown-version-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+if [ -n "$PROJECT_VERSION" ]; then
+    # use env variable PROJECT_VERSION if defined
+    echo $PROJECT_VERSION
+elif ! [ -x "$(command -v git)" ] || ! [ -d .git ]; then
+    # git is not installed, or not in a git repo
+    echo '0-unknown-version'
+else
+    # fetch all tags silently
+    git fetch --tags --quiet > /dev/null 2> /dev/null
+    # get human readable commit id from git
+    git describe --tags --always --dirty | sed 's/^v//'
+fi

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -10,7 +10,9 @@
   <parent>
     <groupId>org.cbioportal.genome_nexus</groupId>
     <artifactId>genome-nexus</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <!-- project version is generated through git or can be passed as
+         PROJECT_VERSION env variable (see version.sh) -->
+    <version>0-unknown-version-SNAPSHOT</version>
   </parent>
   
   <profiles>


### PR DESCRIPTION
It's a hassle to keep updating the pom.xml versions. Similar to
cBioPortal/cbioportal we would like to tag the github repo and have the
maven project version update automatically. See also:
https://github.com/cBioPortal/cbioportal/pull/5403. The source of truth of the version should be git, not mvn.

As a side note, we are already mostly just use the actuator endpoint to find the real version which includes the git commit: https://www.genomenexus.org/actuator/info. The pom version isn't updated much