### PR TITLE
handle hgvs to region conversion with inserts

### DIFF
--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
@@ -15,8 +15,7 @@ import java.util.Map;
 
 
 @Component
-public class NotationConverter
-{
+public class NotationConverter {
     public static final String DEFAULT_DELIMITER = ",";
 
     public String hgvsNormalizer(String hgvs) {
@@ -47,31 +46,24 @@ public class NotationConverter
     }
 
     @Nullable
-    public GenomicLocation parseGenomicLocation(String genomicLocation)
-    {
-        return this.parseGenomicLocation(genomicLocation, DEFAULT_DELIMITER);
+    public GenomicLocation parseGenomicLocation(String genomicLocation) {
+        return parseGenomicLocation(genomicLocation, DEFAULT_DELIMITER);
     }
 
     @Nullable
-    public GenomicLocation parseGenomicLocation(String genomicLocation, String delimiter)
-    {
+    public GenomicLocation parseGenomicLocation(String genomicLocation, String delimiter) {
         if (genomicLocation == null) {
             return null;
         }
-
         String[] parts = genomicLocation.split(delimiter);
         GenomicLocation location = null;
-
-        if (parts.length >= 5)
-        {
+        if (parts.length >= 5) {
             // trim all parts
             for (int i = 0; i < parts.length; i++) {
                 parts[i] = parts[i].trim();
             }
-
             location = new GenomicLocation();
-
-            location.setChromosome(this.chromosomeNormalizer(parts[0]));
+            location.setChromosome(chromosomeNormalizer(parts[0]));
             location.setStart(Integer.parseInt(parts[1]));
             location.setEnd(Integer.parseInt(parts[2]));
             location.setReferenceAllele(parts[3]);
@@ -82,15 +74,13 @@ public class NotationConverter
     }
 
     @Nullable
-    public String genomicToHgvs(String genomicLocation)
-    {
-        return this.genomicToHgvs(this.parseGenomicLocation(genomicLocation));
+    public String genomicToHgvs(String genomicLocation) {
+        return genomicToHgvs(parseGenomicLocation(genomicLocation));
     }
 
     @Nullable
-    public String genomicToEnsemblRestRegion(String genomicLocation)
-    {
-        return this.genomicToEnsemblRestRegion(this.parseGenomicLocation(genomicLocation));
+    public String genomicToEnsemblRestRegion(String genomicLocation) {
+        return genomicToEnsemblRestRegion(parseGenomicLocation(genomicLocation));
     }
 
     /*
@@ -104,7 +94,7 @@ public class NotationConverter
         GenomicLocation normalizedGenomicLocation = new GenomicLocation();
 
         // normalize chromosome name
-        String chr = this.chromosomeNormalizer(genomicLocation.getChromosome().trim());
+        String chr = chromosomeNormalizer(genomicLocation.getChromosome().trim());
         normalizedGenomicLocation.setChromosome(chr);
 
         // convert vcf style start,end,ref,alt to MAF style
@@ -115,249 +105,193 @@ public class NotationConverter
 
         String prefix = "";
 
-        if(!ref.equals(var)) {
+        if (!ref.equals(var)) {
             prefix = longestCommonPrefix(ref, var);
         }
-
-        if(!ref.equals(var)) {
-            prefix = longestCommonPrefix(ref, var);
-        }
-//        else {
-//            log.warn("Warning: Reference allele extracted from " + chr + ":" + start + "-" + end + " matches alt allele.");
-//        }
 
         // Remove common prefix and adjust variant position accordingly
-        if (prefix.length() > 0)
-        {
+        if (prefix.length() > 0) {
             ref = ref.substring(prefix.length());
             var = var.substring(prefix.length());
-
-            int nStart = start;
-
-            nStart += prefix.length();
-
+            int nStart = start + prefix.length();
             if (ref.length() == 0) {
                 nStart -= 1;
             }
-
             start = nStart;
         }
-
         normalizedGenomicLocation.setStart(start);
         normalizedGenomicLocation.setEnd(end);
         normalizedGenomicLocation.setReferenceAllele(ref);
         normalizedGenomicLocation.setVariantAllele(var);
-
         return normalizedGenomicLocation;
     }
 
     @Nullable
-    public String genomicToHgvs(GenomicLocation genomicLocation)
-    {
+    public String genomicToHgvs(GenomicLocation genomicLocation) {
         if (genomicLocation == null) {
             return null;
         }
-
         GenomicLocation normalizedGenomicLocation = normalizeGenomicLocation(genomicLocation);
         String chr = normalizedGenomicLocation.getChromosome();
         Integer start = normalizedGenomicLocation.getStart();
         Integer end = normalizedGenomicLocation.getEnd();
         String ref = normalizedGenomicLocation.getReferenceAllele().trim();
         String var = normalizedGenomicLocation.getVariantAllele().trim();
-
         String hgvs;
-
-        // cannot convert invalid locations
-        // Ensembl uses a one-based coordinate system
         if (start < 1) {
+            // cannot convert invalid locations
+            // Ensembl uses a one-based coordinate system
             hgvs = null;
-        }
-        /*
-         Process Insertion
-         Example insertion: 17 36002277 36002278 - A
-         Example output: 17:g.36002277_36002278insA
-         */
-        else if (ref.equals("-") || ref.length() == 0 || ref.equals("NA") || ref.contains("--"))
-        {
+        } else if (ref.equals("-") || ref.length() == 0 || ref.equals("NA") || ref.contains("--")) {
+            /*
+            Process Insertion
+            Example insertion: 17 36002277 36002278 - A
+            Example output: 17:g.36002277_36002278insA
+            */
             try {
                 hgvs = chr + ":g." + start + "_" + String.valueOf(start + 1) + "ins" + var;
-            }
-            catch (NumberFormatException e) {
+            } catch (NumberFormatException e) {
                 return null;
             }
-        }
-        /*
-         Process Deletion
-         Example deletion: 1 206811015 206811016  AC -
-         Example output:   1:g.206811015_206811016delAC
-         */
-        else if(var.equals("-") || var.length() == 0) {
+        } else if (var.equals("-") || var.length() == 0) {
+            /*
+            Process Deletion
+            Example deletion: 1 206811015 206811016  AC -
+            Example output:   1:g.206811015_206811016delAC
+            */
             hgvs = chr + ":g." + start + "_" + end + "del" + ref;
-        }
-        /*
-         Process ONP
-         Example SNP   : 2 216809708 216809709 CA T
-         Example output: 2:g.216809708_216809709delCAinsT
-         */
-        else if (ref.length() > 1 || var.length() > 1) {
+        } else if (ref.length() > 1 || var.length() > 1) {
+            /*
+            Process ONP
+            Example SNP   : 2 216809708 216809709 CA T
+            Example output: 2:g.216809708_216809709delCAinsT
+            */
             hgvs = chr + ":g." + start + "_" + end + "del" + ref + "ins" + var;
-        }
-        /*
-         Process SNV
-         Example SNP   : 2 216809708 216809708 C T
-         Example output: 2:g.216809708C>T
-         */
-        else {
+        } else {
+            /*
+            Process SNV
+            Example SNP   : 2 216809708 216809708 C T
+            Example output: 2:g.216809708C>T
+            */
             hgvs = chr + ":g." + start + ref + ">" + var;
         }
-
         return hgvs;
     }
 
     @Nullable
-    public String genomicToEnsemblRestRegion(GenomicLocation genomicLocation)
-    {
+    public String genomicToEnsemblRestRegion(GenomicLocation genomicLocation) {
         if (genomicLocation == null) {
             return null;
         }
-
         GenomicLocation normalizedGenomicLocation = normalizeGenomicLocation(genomicLocation);
         String chr = normalizedGenomicLocation.getChromosome();
         Integer start = normalizedGenomicLocation.getStart();
         Integer end = normalizedGenomicLocation.getEnd();
         String ref = normalizedGenomicLocation.getReferenceAllele().trim();
         String var = normalizedGenomicLocation.getVariantAllele().trim();
-
         String region;
-
         // cannot convert invalid locations
         // Ensembl uses a one-based coordinate system
         if (start < 1) {
             region = null;
-        }
-        /*
-         Process Insertion
-         Example insertion: 17 36002277 36002278 - A
-         Example output: 17:36002278-36002277:1/A
-         */
-        else if (ref.equals("-") || ref.length() == 0 || ref.equals("NA") || ref.contains("--"))
-        {
+        } else if (ref.equals("-") || ref.length() == 0 || ref.equals("NA") || ref.contains("--")) {
+            /*
+            Process Insertion
+            Example insertion: 17 36002277 36002278 - A
+            Example output: 17:36002278-36002277:1/A
+            */
             try {
                 region = chr + ":" + String.valueOf(start + 1) + "-" + start  + ":1/" + var;
             }
             catch (NumberFormatException e) {
                 return null;
             }
-        }
-        /*
-         Process Deletion
-         Example deletion: 1 206811015 206811016  AC -
-         Example output:   1:206811015-206811016:1/-
-         */
-        else if(var.equals("-") || var.length() == 0) {
+        } else if (var.equals("-") || var.length() == 0) {
+            /*
+            Process Deletion
+            Example deletion: 1 206811015 206811016  AC -
+            Example output:   1:206811015-206811016:1/-
+            */
             region = chr + ":" + start + "-" + end + ":1/-";
-        }
-        /*
-         Process ONP
-         Example SNP   : 2 216809708 216809709 CA T
-         Example output: 2:216809708-216809709:1/T
-         */
-        else if (ref.length() > 1 || var.length() > 1) {
+        } else if (ref.length() > 1 || var.length() > 1) {
+            /*
+            Process ONP
+            Example SNP   : 2 216809708 216809709 CA T
+            Example output: 2:216809708-216809709:1/T
+            */
             region = chr + ":" + start + "-" + end + ":1/" + var;
-        }
-        /*
-         Process SNV
-         Example SNP   : 2 216809708 216809708 C T
-         Example output: 2:216809708-216809708:1/T
-         */
-        else {
+        } else {
+            /*
+            Process SNV
+            Example SNP   : 2 216809708 216809708 C T
+            Example output: 2:216809708-216809708:1/T
+            */
             region = chr + ":" + start + "-" + start + ":1/" + var;
         }
-
         return region;
     }
 
     @NotNull
-    public Map<String, GenomicLocation> genomicToHgvsMap(List<GenomicLocation> genomicLocations)
-    {
+    public Map<String, GenomicLocation> genomicToHgvsMap(List<GenomicLocation> genomicLocations) {
         Map<String, GenomicLocation> variantToGenomicLocation = new LinkedHashMap<>();
-
         // convert genomic location to hgvs notation (there is always 1-1 mapping)
         for (GenomicLocation location : genomicLocations) {
-            String hgvs = this.genomicToHgvs(location);
-
+            String hgvs = genomicToHgvs(location);
             if (hgvs != null) {
                 variantToGenomicLocation.put(hgvs, location);
             }
         }
-
         return variantToGenomicLocation;
     }
 
-    public List<String> genomicToHgvs(List<GenomicLocation> genomicLocations)
-    {
+    public List<String> genomicToHgvs(List<GenomicLocation> genomicLocations) {
         List<String> hgvsList = new ArrayList<>();
-        
         for (GenomicLocation location : genomicLocations) { 
-            String hgvs = this.genomicToHgvs(location);
+            String hgvs = genomicToHgvs(location);
             if (hgvs != null) {
                 hgvsList.add(hgvs);
             }
         }
-        
         return hgvsList;
     }
 
     @NotNull
-    public Map<String, GenomicLocation> genomicToEnsemblRestRegionMap(List<GenomicLocation> genomicLocations)
-    {
+    public Map<String, GenomicLocation> genomicToEnsemblRestRegionMap(List<GenomicLocation> genomicLocations) {
         Map<String, GenomicLocation> variantToGenomicLocation = new LinkedHashMap<>();
-
         // convert genomic location to ensembl rest region notation (there is always 1-1 mapping)
         for (GenomicLocation location : genomicLocations) {
-            String ensemblRestRegion = this.genomicToEnsemblRestRegion(location);
-
+            String ensemblRestRegion = genomicToEnsemblRestRegion(location);
             if (ensemblRestRegion != null) {
                 variantToGenomicLocation.put(ensemblRestRegion, location);
             }
         }
-
         return variantToGenomicLocation;
     }
 
-    public List<String> genomicToEnsemblRestRegion(List<GenomicLocation> genomicLocations)
-    {
+    public List<String> genomicToEnsemblRestRegion(List<GenomicLocation> genomicLocations) {
         List<String> ensemblRestRegionsList = new ArrayList<>();
         for (GenomicLocation location : genomicLocations) { 
-            String ensemblRestRegion = this.genomicToEnsemblRestRegion(location);
+            String ensemblRestRegion = genomicToEnsemblRestRegion(location);
             if (ensemblRestRegion != null) {
                 ensemblRestRegionsList.add(ensemblRestRegion);
             }
         }
-
         return ensemblRestRegionsList;
     }
 
     // TODO factor out to a utility class as a static method if needed
     @NotNull
-    public String longestCommonPrefix(String str1, String str2)
-    {
+    public String longestCommonPrefix(String str1, String str2) {
         if (str1 == null || str2 == null) {
             return "";
         }
-
-        for (int prefixLen = 0; prefixLen < str1.length(); prefixLen++)
-        {
+        for (int prefixLen = 0; prefixLen < str1.length(); prefixLen++) {
             char c = str1.charAt(prefixLen);
-
-            if (prefixLen >= str2.length() ||
-                str2.charAt(prefixLen) != c)
-            {
+            if (prefixLen >= str2.length() || str2.charAt(prefixLen) != c) {
                 // mismatch found
                 return str2.substring(0, prefixLen);
             }
         }
-
         return str1;
     }
 }

--- a/component/src/main/java/org/cbioportal/genome_nexus/util/GenomicVariant.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/util/GenomicVariant.java
@@ -1,34 +1,46 @@
 package org.cbioportal.genome_nexus.util;
 
-enum Type {
-    SUBSTITUTION, INSERTION, DELETION, INDEL
-}
-
-enum RefType {
-    GENOMIC, MITOCHONDRIAL
-}
 public class GenomicVariant {
+
+    static enum Type {
+        SUBSTITUTION,
+        INSERTION,
+        DELETION,
+        INDEL
+        // hgvs DUPLICATION is not supported in this model
+    }
+
+    static enum RefType {
+        GENOMIC,
+        MITOCHONDRIAL // for future development (not yet implemented)
+    }
+
     private String chromosome;
-    private RefType ref_type;
+    private RefType refType;
     private Integer start;
     private Integer end;
     private Type type;
     private String ref;
     private String alt;
 
-    public GenomicVariant (String chromosome, RefType ref_type, Integer start, Integer end, Type type, String ref, String alt) {
+    public GenomicVariant() {
+        this.chromosome = null;
+        this.refType = null;
+        this.start = null;
+        this.end = null;
+        this.type = null;
+        this.ref = null;
+        this.alt = null;
+    }
+
+    public GenomicVariant (String chromosome, RefType refType, Integer start, Integer end, Type type, String ref, String alt) {
         this.chromosome = chromosome;
-        this.ref_type = ref_type;
+        this.refType = refType;
         this.start = start;
         this.end = end;
         this.type = type;
         this.ref = ref;
         this.alt = alt;
-    }
-
-    public GenomicVariant() {
-        this.chromosome = this.ref = this.alt = null;
-        this.start = this.end = null;
     }
 
     public String getChromosome() {
@@ -40,11 +52,11 @@ public class GenomicVariant {
     }
 
     public RefType getRefType() {
-        return this.ref_type;
+        return this.refType;
     }
 
-    public void setRefType(RefType ref_type) {
-        this.ref_type = ref_type;
+    public void setRefType(RefType refType) {
+        this.refType = refType;
     }
 
     public Integer getStart() {

--- a/component/src/main/java/org/cbioportal/genome_nexus/util/GenomicVariantUtil.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/util/GenomicVariantUtil.java
@@ -2,10 +2,8 @@ package org.cbioportal.genome_nexus.util;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.util.ArrayList;
-import java.util.Scanner;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.*;
+import java.util.regex.*;
 
 import org.cbioportal.genome_nexus.util.exception.InvalidHgvsException;
 import org.cbioportal.genome_nexus.util.exception.RefTypeNotSupportedException;
@@ -14,35 +12,60 @@ import org.cbioportal.genome_nexus.util.exception.TypeNotSupportedException;
 public class GenomicVariantUtil {
 
     public static GenomicVariant fromHgvs(String hgvs) {
-        if (!isHgvs(hgvs)) {
-            throw new InvalidHgvsException();
-        }
-        String chr = getPattern("^.+(?=:)", hgvs);
-        RefType ref_type = getRefTypeFromHgvs(hgvs);
-        Integer start = Integer.parseInt(getPattern("(?<=\\.)\\d+(?=[_ATGC])", hgvs));
+        GenomicVariant.RefType refType = getRefTypeFromHgvs(hgvs);
+        String chr = getChrFromHgvs(hgvs);
+        Integer start = getStartFromHgvs(hgvs);
         Integer end = getEndFromHgvs(hgvs, start);
-        Type type = getTypeFromHgvs(hgvs);
+        GenomicVariant.Type type = getTypeFromHgvs(hgvs);
+        if (type == GenomicVariant.Type.INSERTION && end != start + 1) {
+            throw new InvalidHgvsException("insertion encountered where end position did not equal start position plus 1");
+        }
         String ref = getRefFromHgvs(hgvs, type);
         String alt = getAltFromHgvs(hgvs, type);
-        return new GenomicVariant(chr, ref_type, start, end, type, ref, alt);
+        return new GenomicVariant(chr, refType, start, end, type, ref, alt);
     }
+
+/* The following (fromRegion) code is invalid
+ * The problem is that the relative size of the start and end members
+ * in a region string determine the type and appropriate alleles for
+ * the GenomicVariant format. When the start is more than the end in
+ * region format, the end should always be equal to (start - 1). The
+ * meaning of this pattern is that an insertion is denoted with the
+ * alt allele nucleotides being added in the observed allele between
+ * the two nucleotide positions given in the reference allele. When
+ * the start is less than the end, it means that the nucleotides
+ * in the reference allele from position start to end (inclusive) are
+ * no longer present in the observed allele and the alt alelle nucleotides
+ * (if any) are present in that location instead.
+ * see : https://m.ensembl.org/info/docs/tools/vep/vep_formats.html#input
+ */
 
     public static GenomicVariant fromRegion(String region) {
         if (!isRegion(region)) {
             throw new IllegalArgumentException("region is invalid");
         }
+        GenomicVariant.RefType refType = null; // WARNING : refType must be determined in order for other utility functions to work correctly - perhaps this should alwyas be GENOMIC unless "M" is a valid chromosome
         String chr = getPattern("^\\d{1,2}(?=:)", region);
-        RefType ref_type = null;
         Integer start = Integer.parseInt(getPattern("(?<=:)\\d+(?=-)", region));
         Integer end = Integer.parseInt(getPattern("(?<=-)\\d+(?=:)", region));
-        Type type = null;
+        GenomicVariant.Type type = null; // WARNING : type must be determined in order for other utility functions to work correctly
         String ref = null;
         String alt = getPattern("(?<=:-?1/)[ATCG]+|-$", region);
-        return new GenomicVariant(chr, ref_type, start, end, type, ref, alt);
+        return new GenomicVariant(chr, refType, start, end, type, ref, alt);
     }
 
     public static String toRegion(GenomicVariant variant) {
-        return variant.getChromosome() + ":" + variant.getStart() + "-" + variant.getEnd() + ":1/" + variant.getAlt();
+        switch (variant.getType()) {
+            case SUBSTITUTION:
+            case INDEL:
+                return variant.getChromosome() + ":" + variant.getStart() + "-" + variant.getEnd() + ":1/" + variant.getAlt();
+            case INSERTION:
+                return variant.getChromosome() + ":" + variant.getEnd() + "-" + variant.getStart() + ":1/" + variant.getAlt();
+            case DELETION:
+                return variant.getChromosome() + ":" + variant.getStart() + "-" + variant.getEnd() + ":1/-";
+            default:
+                throw new InvalidHgvsException(); // Never reached
+        }
     }
 
     public static ArrayList<String> getMafs(String maf_file) {
@@ -67,10 +90,10 @@ public class GenomicVariantUtil {
         return list;
     }
 
+    // WARNING : the Genomic Variant returned by this function has an undetermined type (null). This prevents proper function of other utility functions in this class.
     public static GenomicVariant fromMaf(String maf, String[] key) {
         String[] arr = maf.split("\\s");
-        // [Chromosome, Start_Position, End_Position, Reference_Allele,
-        // Tumor_Seq_Allele]
+        // [Chromosome, Start_Position, End_Position, Reference_Allele, Tumor_Seq_Allele]
         int chr_index = 0;
         int start_index = 0;
         int end_index = 0;
@@ -96,21 +119,19 @@ public class GenomicVariantUtil {
                     break;
             }
         }
-
-        return new GenomicVariant(arr[chr_index], null, Integer.parseInt(arr[start_index]),
-                Integer.parseInt(arr[end_index]), null, arr[ref_index], arr[alt_index]);
-    }
-
-    public static boolean isHgvs(String variant) {
-        // TODO this pattern does not include MT, just check whether g is included
-        // return Pattern.matches("^[1-9][0-9]?:[cgmrp]\\.\\d+[ATCG_]\\d*[a-z>]*[ATCG]*$", variant);
-        return variant.contains("g.");
+        return new GenomicVariant(arr[chr_index],
+                null,
+                Integer.parseInt(arr[start_index]),
+                Integer.parseInt(arr[end_index]),
+                null,
+                arr[ref_index],
+                arr[alt_index]);
     }
 
     public static boolean isRegion(String variant) {
-        // TODO this pattern does not include MT, just check whether / is included
-        // return Pattern.matches("^\\d{1,2}:\\d+-\\d+:-?1/([ATCG]+|-)$", variant);
         return variant.contains("/");
+        // TODO : do fuller validation of region format, such as below (however, the line below does not cover X and Y chromosomes)
+        // return Pattern.matches("^\\d{1,2}:\\d+-\\d+:-?1/([ATCG]+|-)$", variant);
     }
 
     public static boolean isMafFile(String file) {
@@ -121,75 +142,145 @@ public class GenomicVariantUtil {
     private static String getPattern(String regex, String hgvs) {
         Pattern p = Pattern.compile(regex);
         Matcher m = p.matcher(hgvs);
-        if (m.find()) { 
+        if (m.find()) {
             return hgvs.substring(m.start(), m.end());
         }
         return null;
     }
 
-    private static Integer getEndFromHgvs(String hgvs, Integer start) {
+    private static GenomicVariant.RefType getRefTypeFromHgvs(String hgvs) {
+        String refTypeString = getPattern("(?<=:)[cgmnopr](?=.)", hgvs);
+        if (refTypeString == null || refTypeString.trim().length() == 0) {
+            throw new InvalidHgvsException();
+        }
+        switch (refTypeString.trim()) {
+            case "g":
+                return GenomicVariant.RefType.GENOMIC;
+            case "m":
+                // MITOCHONDRIAL ref type not yet supported
+            case "c":
+            case "n":
+            case "o":
+            case "p":
+            case "r":
+            default:
+                // GenomicVariant representation does not accept other HGVS types (coding_dna, non_coding_dna, circular_genomic_reference, protein, rna_transcript)
+                throw new RefTypeNotSupportedException();
+        }
+    }
+
+    private static String getChrFromHgvs(String hgvs) {
+        String chr = getPattern("^.+(?=:)", hgvs);
+        if (chr == null || chr.trim().length() == 0) {
+            throw new InvalidHgvsException();
+        }
+        // valid chromosomes are "X", "Y", or any positive integer
+        if (!chr.equalsIgnoreCase("X") && !chr.equalsIgnoreCase("Y")) {
+            try {
+                if (Integer.parseInt(chr) <= 0) {
+                    throw new InvalidHgvsException("Chromosome reference is negative or zero");
+                }
+            } catch (NumberFormatException e) {
+                throw new InvalidHgvsException(e);
+            }
+        }
+        return chr;
+    }
+
+    private static Integer getStartFromHgvs(String hgvs) {
+        String startString = getPattern("(?<=\\.)\\d+(?=[_ATGC])", hgvs);
+        if (startString == null || startString.trim().length() == 0) {
+            throw new InvalidHgvsException("Start position could not be parsed");
+        }
         try {
-            return Integer.parseInt(getPattern("(?<=_)\\d+(?=[a-z]+)", hgvs));
+            return Integer.parseInt(startString);
         } catch (NumberFormatException e) {
+            // position is out of range for Integer
+            throw new InvalidHgvsException(e);
+        }
+    }
+
+    private static Integer getEndFromHgvs(String hgvs, Integer start) {
+        String endString = getPattern("(?<=_)\\d+(?=[a-z]+)", hgvs);
+        if (endString == null || endString.trim().length() == 0) {
             return start;
         }
+        try {
+            return Integer.parseInt(endString);
+        } catch (NumberFormatException e) {
+            // position is out of range for Integer
+            throw new InvalidHgvsException(e);
+        }
     }
 
-    private static String getRefFromHgvs(String hgvs, Type type) {
-        if (type.equals(Type.DELETION)) {
-            String ref = getPattern("(?<=[a-z+>])[ATCG]*$", hgvs);
-            if (ref.equals(null)) {
-                return "";
-            }
-            return ref;
-        } else if (type.equals(Type.SUBSTITUTION)) {
-            return getPattern("(?<=\\d+)[ATCG]+(?=>)", hgvs);
-        }
-        String ans = "";
-        while (ans.length() < getPattern("(?<=[a-z+>])[ATCG]+$", hgvs).length()) {
-            ans += "X";
-        }
-        return ans;
-    }
-
-    private static String getAltFromHgvs(String hgvs, Type type) {
-        if (!type.equals(Type.DELETION)) {
-            return getPattern("(?<=[a-z+>])[ATCG]+$", hgvs);
-        }
-        String alt = getPattern("(?<=[a-z+>])[ATCG]*$", hgvs);
-        if (alt.equals(null)) {
-            return "";
-        }
-        String ans = "";
-        while (ans.length() < alt.length()) {
-            ans += "X";
-        }
-        return ans;
-    }
-
-    private static RefType getRefTypeFromHgvs (String hgvs) {
-        String ref_type = getPattern("(?<=:)[cgmrp](?=.)", hgvs);
-        switch(ref_type) {
-            case "g":
-                return RefType.GENOMIC;
-            case "m":
-                return RefType.MITOCHONDRIAL;
-        }
-        throw new RefTypeNotSupportedException();
-    }
-
-    private static Type getTypeFromHgvs(String hgvs) {
+    private static GenomicVariant.Type getTypeFromHgvs(String hgvs) {
         String type = getPattern("(?<=\\d+[ATGC]?)[a-z>]+(?=[ATCG]*)", hgvs);
+        if (type == null || type.trim().length() == 0) {
+            throw new InvalidHgvsException("variant type could not be parsed");
+        }
         switch(type) {
             case ">":
-                return Type.SUBSTITUTION;
+                return GenomicVariant.Type.SUBSTITUTION;
             case "ins":
-                return Type.INSERTION;
+                return GenomicVariant.Type.INSERTION;
             case "del":
-                return Type.DELETION;
+                return GenomicVariant.Type.DELETION;
             case "delins":
-                return Type.INDEL;
+                return GenomicVariant.Type.INDEL;
         }
         throw new TypeNotSupportedException();
+    }
+
+    private static String sameLengthUnknownNucleotideString(String s) {
+        if (s == null || s.trim().length() == 0) {
+            return "";
+        }
+        return String.join("", Collections.nCopies(s.trim().length(), "X"));
+    }
+
+    private static String getRefFromHgvs(String hgvs, GenomicVariant.Type type) {
+        String s;
+        switch(type) {
+            case SUBSTITUTION:
+                s = getPattern("(?<=\\d+)[ATCG]+(?=>)", hgvs);
+                if (s == null || s.trim().length() == 0) {
+                    throw new InvalidHgvsException("reference allele in substitution could not be parsed");
+                }
+                return s.trim();
+            case INSERTION:
+                return "";
+            case DELETION:
+                s = getPattern("(?<=[a-z+>])[ATCG]*$", hgvs);
+                if (s == null || s.trim().length() == 0) {
+                    return "";
+                }
+                return s.trim();
+            case INDEL:
+                // use a string of "X" equal to length of alt allele TODO : check if this is used anywhere and drop this if not .. also check if this is needed above for DELETION
+                s = getPattern("(?<=[a-z+>])[ATCG]+$", hgvs);
+                return sameLengthUnknownNucleotideString(s);
+            default:
+                throw new InvalidHgvsException(); // Never reached
+        }
+    }
+
+    private static String getAltFromHgvs(String hgvs, GenomicVariant.Type type) {
+        String s;
+        switch(type) {
+            case SUBSTITUTION:
+            case INSERTION:
+            case INDEL:
+                s  = getPattern("(?<=[a-z+>])[ATCG]+$", hgvs);
+                if (s == null || s.trim().length() == 0) {
+                    return "";
+                }
+                return s.trim();
+            case DELETION:
+                // TODO : here, the deleted nucleotids are optional .. but we convert them into a string of "X" if they are present. Is this correct?
+                s = getPattern("(?<=[a-z+>])[ATCG]*$", hgvs);
+                return sameLengthUnknownNucleotideString(s);
+            default:
+                throw new InvalidHgvsException(); // Never reached
+        }
     }
 }

--- a/component/src/main/java/org/cbioportal/genome_nexus/util/exception/InvalidHgvsException.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/util/exception/InvalidHgvsException.java
@@ -1,7 +1,16 @@
 package org.cbioportal.genome_nexus.util.exception;
 
 public class InvalidHgvsException extends IllegalArgumentException {
+
     public InvalidHgvsException() {
         super("hgvs is invalid");
+    }
+
+    public InvalidHgvsException(String msg) {
+        super(msg);
+    }
+
+    public InvalidHgvsException(Throwable e) {
+        super(e);
     }
 }

--- a/component/src/main/java/org/cbioportal/genome_nexus/util/exception/RefTypeNotSupportedException.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/util/exception/RefTypeNotSupportedException.java
@@ -2,6 +2,6 @@ package org.cbioportal.genome_nexus.util.exception;
 
 public class RefTypeNotSupportedException extends IllegalArgumentException {
     public RefTypeNotSupportedException() {
-        super("coding dna, protein, and rna hgvs sequences are not supported");
+        super("coding dna, protein, mitochondrial, and rna hgvs sequences are not supported");
     }
 }

--- a/service/src/test/java/org/cbioportal/genome_nexus/util/GenomicVariantTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/util/GenomicVariantTest.java
@@ -7,16 +7,16 @@ import java.util.ArrayList;
 import org.junit.Test;
 
 public class GenomicVariantTest {
-    @Test    
+    @Test
     public void testHgvsSubstitutionToGenomicVariant() {
         GenomicVariant variant = GenomicVariantUtil.fromHgvs("7:g.140453136A>T");
 
         assertEquals("7", variant.getChromosome());
-        assertEquals(RefType.GENOMIC, variant.getRefType());
+        assertEquals(GenomicVariant.RefType.GENOMIC, variant.getRefType());
         assertEquals((Integer) 140453136, variant.getStart());
         assertEquals((Integer) 140453136,variant.getEnd());
         assertEquals("A", variant.getRef());
-        assertEquals(Type.SUBSTITUTION, variant.getType());
+        assertEquals(GenomicVariant.Type.SUBSTITUTION, variant.getType());
         assertEquals("T", variant.getAlt());
     }
 
@@ -25,11 +25,11 @@ public class GenomicVariantTest {
         GenomicVariant variant = GenomicVariantUtil.fromHgvs("10:g.32867861_32867862insT");
 
         assertEquals("10", variant.getChromosome());
-        assertEquals(RefType.GENOMIC, variant.getRefType());
+        assertEquals(GenomicVariant.RefType.GENOMIC, variant.getRefType());
         assertEquals((Integer) 32867861, variant.getStart());
         assertEquals((Integer) 32867862, variant.getEnd());
-        assertEquals("X", variant.getRef());
-        assertEquals(Type.INSERTION, variant.getType());
+        assertEquals("", variant.getRef());
+        assertEquals(GenomicVariant.Type.INSERTION, variant.getType());
         assertEquals("T", variant.getAlt());
     }
 
@@ -38,11 +38,11 @@ public class GenomicVariantTest {
         GenomicVariant variant = GenomicVariantUtil.fromHgvs("1:g.4849848_4849857del");
 
         assertEquals("1", variant.getChromosome());
-        assertEquals(RefType.GENOMIC, variant.getRefType());
+        assertEquals(GenomicVariant.RefType.GENOMIC, variant.getRefType());
         assertEquals((Integer) 4849848, variant.getStart());
         assertEquals((Integer) 4849857, variant.getEnd());
         assertEquals("", variant.getRef());
-        assertEquals(Type.DELETION, variant.getType());
+        assertEquals(GenomicVariant.Type.DELETION, variant.getType());
         assertEquals("", variant.getAlt());
     }
 
@@ -51,11 +51,11 @@ public class GenomicVariantTest {
         GenomicVariant variant = GenomicVariantUtil.fromHgvs("23:g.88778_88784delinsTAGATAG");
 
         assertEquals("23", variant.getChromosome());
-        assertEquals(RefType.GENOMIC, variant.getRefType());
+        assertEquals(GenomicVariant.RefType.GENOMIC, variant.getRefType());
         assertEquals((Integer) 88778, variant.getStart());
         assertEquals((Integer) 88784,variant.getEnd());
         assertEquals("XXXXXXX", variant.getRef());
-        assertEquals(Type.INDEL, variant.getType());
+        assertEquals(GenomicVariant.Type.INDEL, variant.getType());
         assertEquals("TAGATAG", variant.getAlt());
     }
 
@@ -64,7 +64,7 @@ public class GenomicVariantTest {
         GenomicVariant variant = GenomicVariantUtil.fromRegion("5:140532-140532:1/C");
 
         assertEquals("5", variant.getChromosome());
-        assertEquals(null, variant.getRefType());
+        assertEquals(null, variant.getRefType()); // WARNING : null RefType probably should not be allowed
         assertEquals((Integer) 140532, variant.getStart());
         assertEquals((Integer) 140532, variant.getEnd());
         assertEquals(null, variant.getRef());
@@ -77,7 +77,7 @@ public class GenomicVariantTest {
         GenomicVariant variant = GenomicVariantUtil.fromRegion("14:19584687-19584687:-1/T");
 
         assertEquals("14", variant.getChromosome());
-        assertEquals(null, variant.getRefType());
+        assertEquals(null, variant.getRefType()); // WARNING : null RefType probably should not be allowed
         assertEquals((Integer) 19584687, variant.getStart());
         assertEquals((Integer) 19584687, variant.getEnd());
         assertEquals(null, variant.getRef());
@@ -90,7 +90,7 @@ public class GenomicVariantTest {
         GenomicVariant variant = GenomicVariantUtil.fromRegion("1:881907-881906:1/C");
 
         assertEquals("1", variant.getChromosome());
-        assertEquals(null, variant.getRefType());
+        assertEquals(null, variant.getRefType()); // WARNING : null RefType probably should not be allowed
         assertEquals((Integer) 881907, variant.getStart());
         assertEquals((Integer) 881906, variant.getEnd());
         assertEquals(null, variant.getRef());
@@ -103,6 +103,7 @@ public class GenomicVariantTest {
         GenomicVariant variant = GenomicVariantUtil.fromRegion("2:946507-946511:1/-");
 
         assertEquals("2", variant.getChromosome());
+        assertEquals(null, variant.getRefType()); // WARNING : null RefType probably should not be allowed
         assertEquals((Integer) 946507, variant.getStart());
         assertEquals((Integer) 946511, variant.getEnd());
         assertEquals(null, variant.getRef());
@@ -112,18 +113,35 @@ public class GenomicVariantTest {
 
     @Test
     public void testGenomicVariantToRegion() {
-        GenomicVariant variant = new GenomicVariant("5", null, 140532, 140532, null, null, "C");
+        GenomicVariant variant = new GenomicVariant("5", GenomicVariant.RefType.GENOMIC, 140532, 140532, GenomicVariant.Type.SUBSTITUTION, null, "C");
 
         assertEquals("5:140532-140532:1/C", GenomicVariantUtil.toRegion(variant));
     }
+
+    @Test
+    public void testGenomicVariantInsertToRegion() {
+        GenomicVariant variant = new GenomicVariant("5", GenomicVariant.RefType.GENOMIC, 140532, 140533, GenomicVariant.Type.INSERTION, null, "C");
+
+        assertEquals("5:140533-140532:1/C", GenomicVariantUtil.toRegion(variant));
+    }
+
+    // TODO: add conversion test cases from hgvs delete and indel (maybe dup?)
 
     @Test
     public void testHgvsToGenomicVariantToRegion() {
         String region = GenomicVariantUtil.toRegion(GenomicVariantUtil.fromHgvs("12:g.25398285C>A"));
 
         assertEquals("12:25398285-25398285:1/A", region);
-
     }
+
+    @Test
+    public void testHgvsInsertToGenomicVariantToRegion() {
+        String region = GenomicVariantUtil.toRegion(GenomicVariantUtil.fromHgvs("12:g.25398285_25398286insA"));
+
+        assertEquals("12:25398286-25398285:1/A", region);
+    }
+
+    // TODO: add conversion test cases from hgvs delete and indel (maybe dup?)
 
     @Test
     public void testMafToGenomicVariant() {
@@ -140,7 +158,7 @@ public class GenomicVariantTest {
         GenomicVariant two = list.get(1);
 
         assertEquals("3", one.getChromosome());
-        assertEquals(null, one.getRefType());
+        assertEquals(null, one.getRefType()); // WARNING : null RefType probably should not be allowed
         assertEquals((Integer) 178916927, one.getStart());
         assertEquals((Integer) 178916939, one.getEnd());
         assertEquals(null, one.getType());
@@ -148,11 +166,11 @@ public class GenomicVariantTest {
         assertEquals("G", one.getAlt());
 
         assertEquals("7", two.getChromosome());
-        assertEquals(null, two.getRefType());
+        assertEquals(null, two.getRefType()); // WARNING : null RefType probably should not be allowed
         assertEquals((Integer) 55220240, two.getStart());
         assertEquals((Integer) 55220240, two.getEnd());
         assertEquals(null, two.getType());
         assertEquals("G", two.getRef());
         assertEquals("T", two.getAlt());
     }
-} 
+}


### PR DESCRIPTION
fixes #391
    - RefType field set to GENOMIC for HGVS "g." references. Other types not supported.
    - enum RefType and enum Type for GenomicVariant moved within class
    - do extra validity checks when parsing hgvs - throw appropriate exceptions
        - ref_type is GENOMIC
        - inserts always have pos, pos+1 for positions
        - all required fields are present
    - comment added to code explaining faults in fromRegion()
    - inserts (when converting hgvs to region) now represented with "reversed" pos+1,pos positions
    - unit tests adjusted - type set to SUBSTITUTION where needed, reference allele set to "" instead of "X" for insert (in MAF file, insert reference should be '-')
    - unit test for conversion from hgvs insertion format added (deletion and indel left for future work)
    standardize style in NotationConverter and drop double call to subroutine