### PR TITLE
Retain original query input in annotation JSON response

### DIFF
--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
@@ -34,6 +34,7 @@ public class NotationConverter {
         gl.setEnd(gv.getEnd());
         gl.setReferenceAllele(gv.getRef());
         gl.setVariantAllele(gv.getAlt());
+        gl.setOriginalInput(hgvsg);
         return gl;
     }
 
@@ -68,6 +69,7 @@ public class NotationConverter {
             location.setEnd(Integer.parseInt(parts[2]));
             location.setReferenceAllele(parts[3]);
             location.setVariantAllele(parts[4]);
+            location.setOriginalInput(genomicLocation);
         }
 
         return location;
@@ -92,6 +94,14 @@ public class NotationConverter {
      */
     public GenomicLocation normalizeGenomicLocation(GenomicLocation genomicLocation) {
         GenomicLocation normalizedGenomicLocation = new GenomicLocation();
+        // if original input is set in the incoming genomic location object then use the same value
+        // for the normalized genomic location object returned, otherwise set it to the
+        // string representation of the incoming genomic location object
+        if(genomicLocation.getOriginalInput() != null && !genomicLocation.getOriginalInput().isEmpty()) {
+            normalizedGenomicLocation.setOriginalInput(genomicLocation.getOriginalInput());
+        } else {
+            normalizedGenomicLocation.setOriginalInput(genomicLocation.toString());
+        }
 
         // normalize chromosome name
         String chr = chromosomeNormalizer(genomicLocation.getChromosome().trim());
@@ -246,7 +256,7 @@ public class NotationConverter {
 
     public List<String> genomicToHgvs(List<GenomicLocation> genomicLocations) {
         List<String> hgvsList = new ArrayList<>();
-        for (GenomicLocation location : genomicLocations) { 
+        for (GenomicLocation location : genomicLocations) {
             String hgvs = genomicToHgvs(location);
             if (hgvs != null) {
                 hgvsList.add(hgvs);
@@ -270,7 +280,7 @@ public class NotationConverter {
 
     public List<String> genomicToEnsemblRestRegion(List<GenomicLocation> genomicLocations) {
         List<String> ensemblRestRegionsList = new ArrayList<>();
-        for (GenomicLocation location : genomicLocations) { 
+        for (GenomicLocation location : genomicLocations) {
             String ensemblRestRegion = genomicToEnsemblRestRegion(location);
             if (ensemblRestRegion != null) {
                 ensemblRestRegionsList.add(ensemblRestRegion);

--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
@@ -97,7 +97,7 @@ public class NotationConverter {
         // if original input is set in the incoming genomic location object then use the same value
         // for the normalized genomic location object returned, otherwise set it to the
         // string representation of the incoming genomic location object
-        if(genomicLocation.getOriginalInput() != null && !genomicLocation.getOriginalInput().isEmpty()) {
+        if (genomicLocation.getOriginalInput() != null && !genomicLocation.getOriginalInput().isEmpty()) {
             normalizedGenomicLocation.setOriginalInput(genomicLocation.getOriginalInput());
         } else {
             normalizedGenomicLocation.setOriginalInput(genomicLocation.toString());

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -26,6 +26,12 @@
             <artifactId>univocity-parsers</artifactId>
             <version>2.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.9.5</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
 
 </project>

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/GenomicLocation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/GenomicLocation.java
@@ -1,5 +1,7 @@
 package org.cbioportal.genome_nexus.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public class GenomicLocation
 {
     private String chromosome;
@@ -7,6 +9,8 @@ public class GenomicLocation
     private Integer end;
     private String referenceAllele;
     private String variantAllele;
+    @JsonIgnore
+    private String originalInput;
 
     public String getChromosome() {
         return chromosome;
@@ -46,6 +50,14 @@ public class GenomicLocation
 
     public void setVariantAllele(String variantAllele) {
         this.variantAllele = variantAllele;
+    }
+
+    public String getOriginalInput() {
+        return originalInput;
+    }
+
+    public void setOriginalInput(String originalInput) {
+        this.originalInput = originalInput;
     }
 
     public String toString() {

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
@@ -73,7 +73,7 @@ public class VariantAnnotation
     private OncokbAnnotation oncokbAnnotation;
     private VariantAnnotationSummary annotationSummary;
     private SignalAnnotation signalAnnotation;
-
+    private String originalVariantQuery;
     private Map<String, Object> dynamicProps;
 
     public VariantAnnotation()
@@ -326,6 +326,14 @@ public class VariantAnnotation
 
     public Boolean isSuccessfullyAnnotated() {
         return successfullyAnnotated;
+    }
+
+    public void setOriginalVariantQuery(String originalVariantQuery) {
+        this.originalVariantQuery = originalVariantQuery;
+    }
+
+    public String getOriginalVariantQuery() {
+        return this.originalVariantQuery;
     }
 
     public void setDynamicProp(String key, Object value)

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/VariantAnnotationMixin.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/VariantAnnotationMixin.java
@@ -14,6 +14,9 @@ public class VariantAnnotationMixin
     @JsonProperty(value="input", required = true)
     private String variant;
 
+    @JsonProperty(value="original_variant_query", required = true)
+    private String originalVariantQuery;
+
     @JsonProperty(required = true)
     private String annotationJSON;
 

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationMixin.java
@@ -15,6 +15,10 @@ public class VariantAnnotationMixin {
     @ApiModelProperty(value = "Variant key", required = true)
     private String variant;
 
+    @JsonProperty(required = true)
+    @ApiModelProperty(value = "Original variant query", required = true)
+    private String originalVariantQuery;
+
     @JsonProperty(required = false)
     @ApiModelProperty(value = "Annotation data as JSON string", required = false)
     private String annotationJSON;
@@ -66,7 +70,7 @@ public class VariantAnnotationMixin {
     @JsonProperty(value="successfully_annotated", required = true)
     @ApiModelProperty(value = "Status flag indicating whether variant was succesfully annotated", required = false)
     private Boolean successfullyAnnotated;
-    
+
     @JsonProperty(value="mutation_assessor", required = true)
     @ApiModelProperty(value = "Mutation Assessor Annotation", required = false)
     private MutationAssessorAnnotation mutationAssessorAnnotation;

--- a/web/src/test/java/org/cbioportal/genome_nexus/web/AnnotationIntegrationTest.java
+++ b/web/src/test/java/org/cbioportal/genome_nexus/web/AnnotationIntegrationTest.java
@@ -270,6 +270,18 @@ public class AnnotationIntegrationTest
         assertEquals("CAC", seq);
     }
 
+    @Test
+    public void testVariantAnnotationOriginalQuery() {
+        String expectedConvertedVariant = "4:g.55152096_55152107delTCATGCATGATT";
+        String genomicLocationString = "4,55152095,55152107,ATCATGCATGATT,A";
+        GenomicLocation[] genomicLocations = {
+            genomicLocationStringToGenomicLocation(genomicLocationString)
+        };
+        List<Map<String, Object>> response = this.fetchVariantAnnotationByGenomicLocationPOST(genomicLocations);
+        assertEquals(genomicLocationString, response.get(0).get("originalVariantQuery"));
+        assertEquals(expectedConvertedVariant, response.get(0).get("variant"));
+    }
+
     private GenomicLocation genomicLocationStringToGenomicLocation(String genomicLocation) {
         return new GenomicLocation() {{
             setChromosome(genomicLocation.split(",")[0]);
@@ -277,6 +289,7 @@ public class AnnotationIntegrationTest
             setEnd(Integer.parseInt(genomicLocation.split(",")[2]));
             setReferenceAllele(genomicLocation.split(",")[3]);
             setVariantAllele(genomicLocation.split(",")[4]);
+            setOriginalInput(genomicLocation);
         }};
     }
 }


### PR DESCRIPTION
This commit addresses an issue where the original input query did not
match the 'input' field in the JSON annotation response due to a shift in
the value of 'start_position' for certain types of genomic variants when
converting genomic locations to HGVSg format strings.

As a result some variants submitted for annotation through the Genome
Nexus annotation pipeline were considered failed annotations since the
input query did not match the 'variant' field exactly in the JSON
response which is how the client matches the queries back to the records
submitted for annotation.

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>