### PR TITLE
MyVariantInfo annotation bug fix

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
@@ -263,6 +263,7 @@ public class VariantAnnotation
         this.mutationAssessorAnnotation = mutationAssessorAnnotation;
     }
 
+    @Field(value="my_variant_info")
     public MyVariantInfoAnnotation getMyVariantInfoAnnotation() {
         return myVariantInfoAnnotation;
     }

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
@@ -263,7 +263,6 @@ public class VariantAnnotation
         this.mutationAssessorAnnotation = mutationAssessorAnnotation;
     }
 
-    @Field(value="my_variant_info")
     public MyVariantInfoAnnotation getMyVariantInfoAnnotation() {
         return myVariantInfoAnnotation;
     }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/BaseVariantAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/BaseVariantAnnotationServiceImpl.java
@@ -229,7 +229,7 @@ public abstract class BaseVariantAnnotationServiceImpl implements VariantAnnotat
                 postEnrichmentService.enrichAnnotations(variantAnnotations);
             }
         } catch (VariantAnnotationWebServiceException e) {
-            LOG.warn(e.getLocalizedMessage());
+            LOG.warn(e.getLocalizedMessage(), e);
         }
 
         return variantAnnotations;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/MyVariantInfoServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/MyVariantInfoServiceImpl.java
@@ -65,7 +65,7 @@ public class MyVariantInfoServiceImpl implements MyVariantInfoService
             myVariantInfos = this.getMyVariantInfoByMyVariantInfoVariant(queryVariants);
             // manually set the original hgvs variant field
             for (MyVariantInfo myVariantInfo: myVariantInfos) {
-                myVariantInfo.setHgvs(queryToVariant.get(myVariantInfo.getQuery()));
+                myVariantInfo.setHgvs(queryToVariant.get(myVariantInfo.getVariant()));
             }
         } catch (MyVariantInfoWebServiceException e) {
             LOG.warn(e.getResponseBody());


### PR DESCRIPTION
The map constructed during POST requests was using the `query` field instead of `variant` field which is what should have been used to match with the appropriate `MyVariantInfo` objects and `VariantAnnotation` objects.

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>

Co-authored-by: Avery Wang <18199796+averyniceday@users.noreply.github.com>
Co-authored-by: Robert Sheridan <7747489+sheridancbio@users.noreply.github.com>
Co-authored-by: Manda Wilson <1458628+mandawilson@users.noreply.github.com>