### PR TITLE
Enable search by alteration for signal mutations

### DIFF
--- a/component/src/main/java/org/cbioportal/genome_nexus/component/search/SignalIndexBuilder.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/search/SignalIndexBuilder.java
@@ -1,0 +1,126 @@
+package org.cbioportal.genome_nexus.component.search;
+
+import org.cbioportal.genome_nexus.component.annotation.NotationConverter;
+import org.cbioportal.genome_nexus.component.annotation.ProteinChangeResolver;
+import org.cbioportal.genome_nexus.model.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class SignalIndexBuilder
+{
+    private final NotationConverter notationConverter;
+    private final ProteinChangeResolver proteinChangeResolver;
+
+    @Autowired
+    public SignalIndexBuilder(
+        NotationConverter notationConverter,
+        ProteinChangeResolver proteinChangeResolver
+    ) {
+        this.notationConverter = notationConverter;
+        this.proteinChangeResolver = proteinChangeResolver;
+    }
+
+    public List<SignalQuery> buildQueryIndex(
+        List<SignalMutation> mutations,
+        List<VariantAnnotation> annotations
+    )
+    {
+        Map<String, String> genomicLocationToVariant = this.genomicLocationToVariant(mutations);
+        Map<String, String> variantToProteinChange = this.variantToProteinChange(annotations);
+
+        return mutations
+            .stream()
+            .map(m -> this.mapMutationToExactQuery(m, genomicLocationToVariant, variantToProteinChange))
+            .collect(Collectors.toList());
+    }
+
+    public List<String> findUniqueVariants(List<SignalMutation> mutations)
+    {
+        return this.genomicLocationToVariant(mutations).values().stream().distinct().collect(Collectors.toList());
+    }
+
+    public Map<String, String> genomicLocationToVariant(List<SignalMutation> mutations)
+    {
+        return mutations
+            .stream()
+            .filter(m -> m.getChromosome() != null && m.getVariantAllele() != null && m.getReferenceAllele() != null)
+            .map(this::generateGenomicLocation)
+            .collect(Collectors.toMap(
+                // key
+                GenomicLocation::toString,
+                // value
+                gl -> {
+                    String variant = this.notationConverter.genomicToHgvs(gl);
+                    return variant == null ? "" : variant;
+                },
+                // this is to ignore duplicates
+                (v1, v2) -> v1
+            ));
+    }
+
+    public Map<String, String> variantToProteinChange(List<VariantAnnotation> annotations)
+    {
+        return annotations
+            .stream()
+            .collect(Collectors.toMap(
+                VariantAnnotation::getVariantId,
+                annotation -> this.normalizeAlteration(this.proteinChangeResolver.resolveHgvspShort(annotation))
+            ));
+    }
+
+    public SignalQuery mapMutationToExactQuery(
+        SignalMutation mutation,
+        Map<String, String> genomicLocationToVariant,
+        Map<String, String> variantToProteinChange
+    ) {
+        String region = this.generateRegion(mutation);
+        String variant = genomicLocationToVariant.get(generateGenomicLocation(mutation).toString());
+        String alteration = variantToProteinChange.get(variant);
+
+        SignalQuery query = new SignalQuery();
+
+        query.setMatchType(SignalMatchType.EXACT);
+        query.setHugoSymbol(mutation.getHugoGeneSymbol());
+        query.setRegion(region);
+        query.setVariant(variant);
+
+        if (alteration != null && alteration.length() > 0) {
+            query.setAlteration(alteration);
+        }
+
+        return query;
+    }
+
+    public String generateRegion(SignalMutation mutation) {
+        return mutation.getChromosome() + ":" + mutation.getStartPosition() + "-" + mutation.getEndPosition();
+    }
+
+    public GenomicLocation generateGenomicLocation(SignalMutation mutation) {
+        GenomicLocation gl = new GenomicLocation();
+
+        gl.setChromosome(mutation.getChromosome());
+        gl.setStart(mutation.getStartPosition().intValue());
+        gl.setEnd(mutation.getEndPosition().intValue());
+        gl.setReferenceAllele(mutation.getReferenceAllele());
+        gl.setVariantAllele(mutation.getVariantAllele());
+
+        return gl;
+    }
+
+    private String normalizeAlteration(String proteinChange) {
+        if (proteinChange == null) {
+            return "";
+        }
+
+        if (proteinChange.contains("p.")) {
+            return proteinChange.replace("p.", "");
+        }
+
+        return proteinChange;
+    }
+}

--- a/component/src/main/java/org/cbioportal/genome_nexus/component/search/SignalSearchEngine.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/search/SignalSearchEngine.java
@@ -1,0 +1,180 @@
+package org.cbioportal.genome_nexus.component.search;
+
+import org.cbioportal.genome_nexus.model.*;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Component
+public class SignalSearchEngine
+{
+    private static final Comparator<SignalQuery> QUERY_COMPARATOR =
+        (o1, o2) -> o1.getMatchType().ordinal() - o2.getMatchType().ordinal();
+
+    public List<SignalQuery> searchByHugoSymbol(
+        List<SignalQuery> signalIndex,
+        String queryString
+    ) {
+        return signalIndex
+            .stream()
+            .filter(m -> filterByHugoSymbol(m, queryString))
+            .map(SignalQuery::getHugoSymbol)
+            .distinct()
+            .map(gene -> this.mapHugoSymbolToQuery(gene, queryString, signalIndex))
+            .sorted(QUERY_COMPARATOR)
+            .collect(Collectors.toList());
+    }
+
+    public List<SignalQuery> searchByRegion(
+        List<SignalQuery> signalIndex,
+        String queryString
+    ) {
+        return signalIndex
+            .stream()
+            .filter(m -> this.filterByRegion(m, queryString))
+            .map(m -> this.mapToVariantQuery(m, SignalQueryType.REGION, queryString))
+            .sorted(QUERY_COMPARATOR)
+            .collect(Collectors.toList());
+    }
+
+    public List<SignalQuery> searchByVariant(
+        List<SignalQuery> signalIndex,
+        String queryString
+    ) {
+        return signalIndex
+            .stream()
+            .filter(m -> this.filterByVariant(m, queryString))
+            .map(m -> this.mapToVariantQuery(m, SignalQueryType.VARIANT, queryString))
+            .sorted(QUERY_COMPARATOR)
+            .collect(Collectors.toList());
+    }
+
+    public List<SignalQuery> searchByAlteration(
+        List<SignalQuery> signalIndex,
+        String queryString
+    ) {
+        // special case: we allow hugo gene symbol as a prefix
+        // in case of multiple keywords assume that first one is hugo symbol
+        String[] parts = queryString.split("\\s+");
+        String geneKeyword = parts.length > 1 ? parts[0]: null;
+        String alterationKeyword = parts.length > 1 ? parts[1]: queryString;
+
+        // filter the index by hugo symbol (if keyword exists)
+        List<SignalQuery> filteredIndex = geneKeyword == null ? signalIndex:
+            signalIndex
+                .stream()
+                .filter(m -> filterByHugoSymbol(m, geneKeyword))
+                .collect(Collectors.toList());
+
+        return filteredIndex
+            .stream()
+            .filter(m -> this.filterByAlteration(m, alterationKeyword))
+            .map(m -> this.mapToVariantQuery(m, SignalQueryType.ALTERATION, alterationKeyword))
+            .sorted(QUERY_COMPARATOR)
+            .collect(Collectors.toList());
+    }
+
+    public SignalQuery mapToVariantQuery(
+        SignalQuery indexedQuery,
+        SignalQueryType queryType,
+        String queryString
+    ) {
+        String actualString = null;
+
+        if (queryType.equals(SignalQueryType.REGION)) {
+            actualString = indexedQuery.getRegion();
+        }
+        else if (queryType.equals(SignalQueryType.VARIANT)) {
+            actualString = indexedQuery.getVariant();
+        }
+        else if (queryType.equals(SignalQueryType.ALTERATION)) {
+            actualString = indexedQuery.getAlteration();
+        }
+
+        SignalQuery query = new SignalQuery();
+
+        query.setHugoSymbol(indexedQuery.getHugoSymbol());
+        query.setRegion(indexedQuery.getRegion());
+        query.setVariant(indexedQuery.getVariant());
+        query.setAlteration(indexedQuery.getAlteration());
+        query.setQueryType(queryType);
+        query.setMatchType(this.findMatchType(actualString, queryString));
+
+        return query;
+    }
+
+    public SignalQuery mapHugoSymbolToQuery(
+        String hugoSymbol,
+        String queryString,
+        List<SignalQuery> signalIndex
+    ) {
+        long mutationCount = signalIndex.stream().filter(m -> this.filterByHugoSymbol(m, hugoSymbol)).count();
+
+        SignalQuery query = new SignalQuery();
+        query.setQueryType(SignalQueryType.GENE);
+        query.setMatchType(this.findMatchType(hugoSymbol, queryString));
+        query.setHugoSymbol(hugoSymbol);
+        query.setDescription(mutationCount + " unique mutations");
+
+        return query;
+    }
+
+    public boolean filterByHugoSymbol(
+        SignalQuery query,
+        String queryString
+    ) {
+        return (
+            query.getHugoSymbol() != null &&
+                query.getHugoSymbol().contains(queryString.toUpperCase())
+        );
+    }
+
+    public boolean filterByRegion(
+        SignalQuery query,
+        String queryString
+    ) {
+        return query.getRegion().contains(queryString);
+    }
+
+    public boolean filterByVariant(
+        SignalQuery query,
+        String queryString
+    ) {
+        return query.getVariant() != null && query.getVariant().toLowerCase().contains(queryString.toLowerCase());
+    }
+
+    public boolean filterByAlteration(
+        SignalQuery query,
+        String queryString
+    ) {
+        return query.getAlteration() != null && query.getAlteration().toLowerCase().contains(queryString.toLowerCase());
+    }
+
+    public SignalMatchType findMatchType(
+        String actualString,
+        String queryString
+    ) {
+        if (actualString == null) {
+            return SignalMatchType.NO_MATCH;
+        }
+
+        String actualLowerCase = actualString.toLowerCase();
+        String queryLowerCase = queryString.toLowerCase();
+
+        if (actualLowerCase.equals(queryLowerCase)) {
+            return SignalMatchType.EXACT;
+        }
+        else if (actualLowerCase.startsWith(queryLowerCase)) {
+            return SignalMatchType.STARTS_WITH;
+        }
+        else if (actualLowerCase.contains(queryLowerCase)) {
+            return SignalMatchType.PARTIAL;
+        }
+        else {
+            return SignalMatchType.NO_MATCH;
+        }
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/SignalQuery.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/SignalQuery.java
@@ -4,11 +4,11 @@ public class SignalQuery
 {
     private SignalQueryType queryType;
     private SignalMatchType matchType;
-    private String hugoSymbol; // e.g: BRCA2, BRAF
-    private String alteration; // e.g: V600E
-    private String region; // e.g: 13:32968940-32968940
-    private String variant; // e.g: 17:g.37880220T>C
-    private String description; // optional free-form info
+    private String hugoSymbol;
+    private String alteration;
+    private String region;
+    private String variant;
+    private String description;
 
     public SignalQueryType getQueryType() {
         return queryType;

--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/VariantAnnotationRepository.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/VariantAnnotationRepository.java
@@ -35,8 +35,12 @@ package org.cbioportal.genome_nexus.persistence;
 import org.cbioportal.genome_nexus.model.VariantAnnotation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.List;
+
 /**
  * @author Benjamin Gross
  */
 public interface VariantAnnotationRepository
-    extends MongoRepository<VariantAnnotation, String>, GenericMongoRepository {}
+    extends MongoRepository<VariantAnnotation, String>, GenericMongoRepository {
+    List<VariantAnnotation> findByVariantIn(List<String> variants);
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/SignalQueryServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/SignalQueryServiceImpl.java
@@ -2,17 +2,17 @@ package org.cbioportal.genome_nexus.service.internal;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.cbioportal.genome_nexus.component.annotation.NotationConverter;
+import org.cbioportal.genome_nexus.component.search.SignalIndexBuilder;
+import org.cbioportal.genome_nexus.component.search.SignalSearchEngine;
 import org.cbioportal.genome_nexus.model.*;
 import org.cbioportal.genome_nexus.persistence.SignalMutationRepository;
+import org.cbioportal.genome_nexus.persistence.VariantAnnotationRepository;
 import org.cbioportal.genome_nexus.service.SignalQueryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class SignalQueryServiceImpl implements SignalQueryService
@@ -22,23 +22,27 @@ public class SignalQueryServiceImpl implements SignalQueryService
     public static final Integer DEFAULT_RETURN_SIZE = 10;
     public static final Integer QUERY_MIN_LENGTH = 2;
 
-    private static final Comparator<SignalQuery> QUERY_COMPARATOR =
-        (o1, o2) -> o1.getMatchType().ordinal() - o2.getMatchType().ordinal();
-
     private final SignalMutationRepository signalMutationRepository;
-    private final NotationConverter notationConverter;
+    private final VariantAnnotationRepository variantAnnotationRepository;
+    private final SignalSearchEngine searchEngine;
+    private final SignalIndexBuilder indexBuilder;
+
     private final List<SignalQuery> signalIndex;
 
     @Autowired
     public SignalQueryServiceImpl(
         SignalMutationRepository signalMutationRepository,
-        NotationConverter notationConverter
+        VariantAnnotationRepository variantAnnotationRepository,
+        SignalSearchEngine searchEngine,
+        SignalIndexBuilder indexBuilder
     ) {
         this.signalMutationRepository = signalMutationRepository;
-        this.notationConverter = notationConverter;
+        this.variantAnnotationRepository = variantAnnotationRepository;
+        this.searchEngine = searchEngine;
+        this.indexBuilder = indexBuilder;
 
         LOG.info("Building Signal index");
-        this.signalIndex = this.processAllSignalMutations();
+        this.signalIndex = this.buildIndex();
         LOG.info("Finished building Signal index");
     }
 
@@ -52,19 +56,16 @@ public class SignalQueryServiceImpl implements SignalQueryService
     {
         List<SignalQuery> queries = new ArrayList<>();
 
-        // TODO support multiple keywords?
         String queryString = keyword.trim();
 
         if (queryString.length() >= QUERY_MIN_LENGTH)
         {
-            queries.addAll(this.searchByHugoSymbol(this.signalIndex, queryString));
-            queries.addAll(this.searchByRegion(this.signalIndex, queryString));
+            queries.addAll(this.searchEngine.searchByHugoSymbol(this.signalIndex, queryString));
+            queries.addAll(this.searchEngine.searchByRegion(this.signalIndex, queryString));
 
-            // TODO this may not be 100% accurate because we don't use annotated data yet
-            queries.addAll(this.searchByVariant(this.signalIndex, queryString));
-
-            // TODO we need annotated data to be able to search with protein change
-            // queries.addAll(this.searchAlterations(mutations, queryString));
+            // TODO these may not be 100% accurate because we don't use pre-annotated data yet
+            queries.addAll(this.searchEngine.searchByVariant(this.signalIndex, queryString));
+            queries.addAll(this.searchEngine.searchByAlteration(this.signalIndex, queryString));
         }
 
         int returnSize = limit == null || limit < 1 ? DEFAULT_RETURN_SIZE: limit.intValue();
@@ -73,168 +74,16 @@ public class SignalQueryServiceImpl implements SignalQueryService
         return queries.size() > 0 ? queries.subList(0, toIndex): queries;
     }
 
-    private List<SignalQuery> processAllSignalMutations() {
+    private List<SignalQuery> buildIndex()
+    {
         List<SignalMutation> mutations = this.signalMutationRepository.findAll();
 
-        return mutations
-            .stream()
-            .map(this::mapMutationToExactQuery)
-            .collect(Collectors.toList());
-    }
-
-    private List<SignalQuery> searchByHugoSymbol(
-        List<SignalQuery> signalIndex,
-        String queryString
-    ) {
-        return signalIndex
-            .stream()
-            .filter(m -> filterByHugoSymbol(m, queryString))
-            .map(SignalQuery::getHugoSymbol)
-            .distinct()
-            .map(gene -> this.mapHugoSymbolToQuery(gene, queryString, signalIndex))
-            .sorted(QUERY_COMPARATOR)
-            .collect(Collectors.toList());
-    }
-
-    private List<SignalQuery> searchByRegion(
-        List<SignalQuery> signalIndex,
-        String queryString
-    ) {
-        return signalIndex
-            .stream()
-            .filter(m -> this.filterByRegion(m, queryString))
-            .map(m -> this.mapToVariantQuery(m, SignalQueryType.REGION, queryString))
-            .sorted(QUERY_COMPARATOR)
-            .collect(Collectors.toList());
-    }
-
-    private List<SignalQuery> searchByVariant(
-        List<SignalQuery> signalIndex,
-        String queryString
-    ) {
-        return signalIndex
-            .stream()
-            .filter(m -> this.filterByVariant(m, queryString))
-            .map(m -> this.mapToVariantQuery(m, SignalQueryType.VARIANT, queryString))
-            .sorted(QUERY_COMPARATOR)
-            .collect(Collectors.toList());
-    }
-
-    private SignalQuery mapMutationToExactQuery(SignalMutation mutation) {
-        String region = this.generateRegion(mutation);
-        String variant = null;
-        GenomicLocation gl = generateGenomicLocation(mutation);
-
-        if (gl.getChromosome() != null &&
-            gl.getVariantAllele() != null &&
-            gl.getReferenceAllele() != null) {
-            variant = this.notationConverter.genomicToHgvs(gl);
-        }
-
-        SignalQuery query = new SignalQuery();
-
-        query.setMatchType(SignalMatchType.EXACT);
-        query.setHugoSymbol(mutation.getHugoGeneSymbol());
-        query.setRegion(region);
-        query.setVariant(variant);
-        // TODO query.setAlteration(alteration); // we need annotated data for this
-
-        return query;
-    }
-
-    private SignalQuery mapToVariantQuery(
-        SignalQuery indexedQuery,
-        SignalQueryType queryType,
-        String queryString
-    ) {
-        String actualString = queryType.equals(SignalQueryType.REGION) ?
-            indexedQuery.getRegion(): indexedQuery.getVariant();
-
-        SignalQuery query = new SignalQuery();
-
-        query.setHugoSymbol(indexedQuery.getHugoSymbol());
-        query.setRegion(indexedQuery.getRegion());
-        query.setVariant(indexedQuery.getVariant());
-        query.setQueryType(queryType);
-        query.setMatchType(this.findMatchType(actualString, queryString));
-
-        return query;
-    }
-
-    private SignalQuery mapHugoSymbolToQuery(
-        String hugoSymbol,
-        String queryString,
-        List<SignalQuery> signalIndex
-    ) {
-        long mutationCount = signalIndex.stream().filter(m -> this.filterByHugoSymbol(m, hugoSymbol)).count();
-
-        SignalQuery query = new SignalQuery();
-        query.setQueryType(SignalQueryType.GENE);
-        query.setMatchType(this.findMatchType(hugoSymbol, queryString.toUpperCase()));
-        query.setHugoSymbol(hugoSymbol);
-        query.setDescription(mutationCount + " unique mutations");
-
-        return query;
-    }
-
-    private boolean filterByHugoSymbol(
-        SignalQuery query,
-        String queryString
-    ) {
-        return (
-            query.getHugoSymbol() != null &&
-            query.getHugoSymbol().contains(queryString.toUpperCase())
+        // this only works if the variant has already been annotated and
+        // there is a corresponding entity in the DB.
+        List<VariantAnnotation> annotations = this.variantAnnotationRepository.findByVariantIn(
+            this.indexBuilder.findUniqueVariants(mutations)
         );
-    }
 
-    private boolean filterByRegion(
-        SignalQuery query,
-        String queryString
-    ) {
-        return query.getRegion().contains(queryString);
-    }
-
-    private boolean filterByVariant(
-        SignalQuery query,
-        String queryString
-    ) {
-        return query.getVariant() != null && query.getVariant().contains(queryString);
-    }
-
-    private SignalMatchType findMatchType(
-        String actualString,
-        String queryString
-    ) {
-        if (actualString == null) {
-            return SignalMatchType.NO_MATCH;
-        }
-        if (actualString.equals(queryString)) {
-            return SignalMatchType.EXACT;
-        }
-        else if (actualString.startsWith(queryString)) {
-            return SignalMatchType.STARTS_WITH;
-        }
-        else if (actualString.contains(queryString)) {
-            return SignalMatchType.PARTIAL;
-        }
-        else {
-            return SignalMatchType.NO_MATCH;
-        }
-    }
-
-    private String generateRegion(SignalMutation mutation) {
-        return mutation.getChromosome() + ":" + mutation.getStartPosition() + "-" + mutation.getEndPosition();
-    }
-
-    private GenomicLocation generateGenomicLocation(SignalMutation mutation) {
-        GenomicLocation gl = new GenomicLocation();
-
-        gl.setChromosome(mutation.getChromosome());
-        gl.setStart(mutation.getStartPosition().intValue());
-        gl.setEnd(mutation.getEndPosition().intValue());
-        gl.setReferenceAllele(mutation.getReferenceAllele());
-        gl.setVariantAllele(mutation.getVariantAllele());
-
-        return gl;
+        return this.indexBuilder.buildQueryIndex(mutations, annotations);
     }
 }

--- a/service/src/test/java/org/cbioportal/genome_nexus/component/search/SignalSearchEngineTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/component/search/SignalSearchEngineTest.java
@@ -1,0 +1,408 @@
+package org.cbioportal.genome_nexus.component.search;
+
+import org.cbioportal.genome_nexus.component.annotation.*;
+import org.cbioportal.genome_nexus.model.*;
+import org.cbioportal.genome_nexus.service.mock.SignalMockData;
+import org.cbioportal.genome_nexus.service.mock.VariantAnnotationMockData;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class SignalSearchEngineTest {
+
+    @InjectMocks
+    private SignalSearchEngine searchEngine;
+
+    @InjectMocks
+    private SignalIndexBuilder indexBuilder;
+
+    @Spy
+    private NotationConverter notationConverter;
+
+    @Mock
+    private ProteinChangeResolver proteinChangeResolver;
+
+    private final VariantAnnotationMockData variantAnnotationMockData = new VariantAnnotationMockData();
+    private final SignalMockData signalMockData = new SignalMockData();
+
+    private List<SignalQuery> signalIndex = new ArrayList<>();
+
+    @Before
+    public void setupTests() throws IOException
+    {
+        // only init once
+        if (signalIndex.size() == 0) {
+            Map<String, SignalMutation> signalMockData = this.signalMockData.generateData();
+            Map<String, VariantAnnotation> variantAnnotationMockData = this.variantAnnotationMockData.generateData();
+
+            Mockito
+                .when(proteinChangeResolver.resolveHgvspShort(variantAnnotationMockData.get("7:g.55241617G>A")))
+                .thenReturn("p.V689M");
+            Mockito
+                .when(proteinChangeResolver.resolveHgvspShort(variantAnnotationMockData.get("7:g.140453136A>T")))
+                .thenReturn("p.V600E");
+            Mockito
+                .when(proteinChangeResolver.resolveHgvspShort(variantAnnotationMockData.get("13:g.32914438_32914438delT")))
+                .thenReturn("p.S1982Rfs*22");
+            Mockito
+                .when(proteinChangeResolver.resolveHgvspShort(variantAnnotationMockData.get("17:g.41276045_41276046delCT")))
+                .thenReturn("p.E23Vfs*17");
+            Mockito
+                .when(proteinChangeResolver.resolveHgvspShort(variantAnnotationMockData.get("17:g.41276046_41276047insG")))
+                .thenReturn("p.E23Afs*18");
+
+            this.signalIndex = this.indexBuilder.buildQueryIndex(
+                new ArrayList<>(signalMockData.values()),
+                new ArrayList<>(variantAnnotationMockData.values())
+            );
+        }
+    }
+
+    @Test
+    public void searchByHugoSymbol() {
+        List<SignalQuery> brca1 = this.searchEngine.searchByHugoSymbol(this.signalIndex, "BRCA1");
+        List<SignalQuery> brca2 = this.searchEngine.searchByHugoSymbol(this.signalIndex, "brca2");
+        List<SignalQuery> brca = this.searchEngine.searchByHugoSymbol(this.signalIndex, "Brca");
+        List<SignalQuery> rca2 = this.searchEngine.searchByHugoSymbol(this.signalIndex, "RCA2");
+        List<SignalQuery> noSuchGene = this.searchEngine.searchByHugoSymbol(this.signalIndex, "no_such_gene");
+
+        // query string: BRCA1
+        // expected: 1 result, exact match
+        assertEquals(
+            "BRCA1 query should return only one gene",
+            1,
+            brca1.size()
+        );
+        assertEquals(
+            "BRCA1 query should be an exact match",
+            SignalMatchType.EXACT,
+            brca1.get(0).getMatchType()
+        );
+        assertEquals(
+            "BRCA1 query should be a gene query only",
+            SignalQueryType.GENE,
+            brca1.get(0).getQueryType()
+        );
+        assertEquals(
+            "BRCA1 query should match the hugo symbol",
+            "BRCA1",
+            brca1.get(0).getHugoSymbol()
+        );
+
+        // query string: brca2
+        // expected: 1 result, exact match
+        assertEquals(
+            "brca2 query should return only one gene",
+            1,
+            brca2.size()
+        );
+        assertEquals(
+            "brca2 query should be an exact match",
+            SignalMatchType.EXACT,
+            brca2.get(0).getMatchType()
+        );
+        assertEquals(
+            "brca2 query should be a gene query only",
+            SignalQueryType.GENE,
+            brca2.get(0).getQueryType()
+        );
+        assertEquals(
+            "brca2 query should match the hugo symbol",
+            "BRCA2",
+            brca2.get(0).getHugoSymbol()
+        );
+
+        // query string: Brca
+        // expected: 2 results, starts with
+        assertEquals(
+            "Brca query should return two genes",
+            2,
+            brca.size()
+        );
+        assertEquals(
+            "BRCA1 match should start with Brca",
+            SignalMatchType.STARTS_WITH,
+            brca.get(0).getMatchType()
+        );
+        assertEquals(
+            "BRCA2 match should start with Brca",
+            SignalMatchType.STARTS_WITH,
+            brca.get(1).getMatchType()
+        );
+
+        // query string: RCA2
+        // expected: 1 result, partial match
+        assertEquals(
+            "RCA2 query should only return one gene",
+            1,
+            rca2.size()
+        );
+        assertEquals(
+            "RCA2 query should be a partial match",
+            SignalMatchType.PARTIAL,
+            rca2.get(0).getMatchType()
+        );
+        assertEquals(
+            "RCA2 query should be a gene query only",
+            SignalQueryType.GENE,
+            rca2.get(0).getQueryType()
+        );
+        assertEquals(
+            "RCA2 query should match the hugo symbol",
+            "BRCA2",
+            rca2.get(0).getHugoSymbol()
+        );
+
+        // query string: no_such_gene
+        // expected: no result
+        assertEquals(
+            "no_such_gene query should NOT match anything",
+            0,
+            noSuchGene.size()
+        );
+    }
+
+    @Test
+    public void searchByVariant() {
+        List<SignalQuery> v7g55241617G_A = this.searchEngine.searchByVariant(this.signalIndex, "7:g.55241617G>A");
+        List<SignalQuery> v7g = this.searchEngine.searchByVariant(this.signalIndex, "7:g");
+        List<SignalQuery> noSuchVariant = this.searchEngine.searchByVariant(this.signalIndex, "no_such_variant");
+
+        // query string: 7:g.55241617G>A
+        // expected: 1 result, exact match
+        assertEquals(
+            "7:g.55241617G>A query should return only one variant",
+            1,
+            v7g55241617G_A.size()
+        );
+        assertEquals(
+            "7:g.55241617G>A query should be an exact match",
+            SignalMatchType.EXACT,
+            v7g55241617G_A.get(0).getMatchType()
+        );
+        assertEquals(
+            "7:g.55241617G>A query should be a variant query only",
+            SignalQueryType.VARIANT,
+            v7g55241617G_A.get(0).getQueryType()
+        );
+        assertEquals(
+            "7:g.55241617G>A query should match the variant",
+            "7:g.55241617G>A",
+            v7g55241617G_A.get(0).getVariant()
+        );
+
+        // query string: 7:g
+        // expected: 4 results, 2 starts with + 2 partial
+        // When there are multiple matches, the ones start with the query string
+        // has ranked higher compared to partial matches
+        assertEquals(
+            "7:g search should return 4 variants",
+            4,
+            v7g.size()
+        );
+        assertEquals(
+            "First match should start with the query",
+            SignalMatchType.STARTS_WITH,
+            v7g.get(0).getMatchType()
+        );
+        assertEquals(
+            "Second match should start with the query",
+            SignalMatchType.STARTS_WITH,
+            v7g.get(1).getMatchType()
+        );
+        assertEquals(
+            "Third match should be partial",
+            SignalMatchType.PARTIAL,
+            v7g.get(2).getMatchType()
+        );
+        assertEquals(
+            "Fourth match should be partial",
+            SignalMatchType.PARTIAL,
+            v7g.get(3).getMatchType()
+        );
+
+        // query string: no_such_variant
+        // expected: no result
+        assertEquals(
+            "no_such_variant query should NOT match anything",
+            0,
+            noSuchVariant.size()
+        );
+    }
+
+    @Test
+    public void searchByRegion() {
+        List<SignalQuery> r13_32914438_32914438 = this.searchEngine.searchByRegion(this.signalIndex, "13:32914438-32914438");
+        List<SignalQuery> r17_4127604 = this.searchEngine.searchByRegion(this.signalIndex, "17:4127604");
+        List<SignalQuery> noSuchRegion = this.searchEngine.searchByRegion(this.signalIndex, "no_such_region");
+
+        // query string: 13:32914438-32914438
+        // expected: 1 result, exact match
+        assertEquals(
+            "13:32914438-32914438 query should return only 1 region",
+            1,
+            r13_32914438_32914438.size()
+        );
+        assertEquals(
+            "13:32914438-32914438 query should be an exact match",
+            SignalMatchType.EXACT,
+            r13_32914438_32914438.get(0).getMatchType()
+        );
+        assertEquals(
+            "13:32914438-32914438 query should be a region query only",
+            SignalQueryType.REGION,
+            r13_32914438_32914438.get(0).getQueryType()
+        );
+        assertEquals(
+            "13:32914438-32914438 query should match the region",
+            "13:32914438-32914438",
+            r13_32914438_32914438.get(0).getRegion()
+        );
+
+        // query string: 17:4127604
+        // expected: 2 results, starts with
+        assertEquals(
+            "17:4127604 query should return 2 regions",
+            2,
+            r17_4127604.size()
+        );
+        assertEquals(
+            "17:41276045-41276046 should start with 17:4127604",
+            SignalMatchType.STARTS_WITH,
+            r17_4127604.get(0).getMatchType()
+        );
+        assertEquals(
+            "17:41276046-41276047 should start with 17:4127604",
+            SignalMatchType.STARTS_WITH,
+            r17_4127604.get(1).getMatchType()
+        );
+
+        // query string: no_such_region
+        // expected: no result
+        assertEquals(
+            "no_such_variant query should NOT match anything",
+            0,
+            noSuchRegion.size()
+        );
+    }
+
+    @Test
+    public void searchByAlteration() {
+        List<SignalQuery> v600e = this.searchEngine.searchByAlteration(this.signalIndex, "v600e");
+        List<SignalQuery> v6 = this.searchEngine.searchByAlteration(this.signalIndex, "V6");
+        List<SignalQuery> e23 = this.searchEngine.searchByAlteration(this.signalIndex, "E23");
+        List<SignalQuery> noSuchAlteration = this.searchEngine.searchByAlteration(this.signalIndex, "no_such_alteration");
+
+        // query string: v600e
+        // expected: 1 result, exact match
+        assertEquals(
+            "v600e query should return only 1 alteration",
+            1,
+            v600e.size()
+        );
+        assertEquals(
+            "v600e query should be an exact match",
+            SignalMatchType.EXACT,
+            v600e.get(0).getMatchType()
+        );
+        assertEquals(
+            "v600e query should be an alteration query only",
+            SignalQueryType.ALTERATION,
+            v600e.get(0).getQueryType()
+        );
+        assertEquals(
+            "v600e query should match the alteration",
+            "V600E",
+            v600e.get(0).getAlteration()
+        );
+
+        // query string: V6
+        // expected: 2 results, starts with
+        assertEquals(
+            "V6 query should return 2 alterations",
+            2,
+            v6.size()
+        );
+        assertEquals(
+            "V600E should start with V6",
+            SignalMatchType.STARTS_WITH,
+            v6.get(0).getMatchType()
+        );
+        assertEquals(
+            "V689M should start with V6",
+            SignalMatchType.STARTS_WITH,
+            v6.get(1).getMatchType()
+        );
+
+        // query string: e23
+        // expected: 2 results, starts with
+        assertEquals(
+            "e23 query should return 2 alterations",
+            2,
+            e23.size()
+        );
+        assertEquals(
+            "E23Vfs*17 should start with e23",
+            SignalMatchType.STARTS_WITH,
+            e23.get(0).getMatchType()
+        );
+        assertEquals(
+            "E23Afs*18 should start with e23",
+            SignalMatchType.STARTS_WITH,
+            e23.get(1).getMatchType()
+        );
+
+        // query string: no_such_alteration
+        // expected: no result
+        assertEquals(
+            "no_such_alteration query should NOT match anything",
+            0,
+            noSuchAlteration.size()
+        );
+    }
+
+    @Test
+    public void searchByGeneAndAlteration() {
+        List<SignalQuery> brafV600e = this.searchEngine.searchByAlteration(this.signalIndex, "braf v600e");
+        List<SignalQuery> brV6 = this.searchEngine.searchByAlteration(this.signalIndex, "Br V6");
+
+        // query string: braf v600e
+        // expected: 1 result, exact match
+        assertEquals(
+            "braf v600e query should return only 1 alteration",
+            1,
+            brafV600e.size()
+        );
+        assertEquals(
+            "braf v600e query should be an exact match",
+            SignalMatchType.EXACT,
+            brafV600e.get(0).getMatchType()
+        );
+
+        // query string: Br V6
+        // expected: 1 result, starts with
+        assertEquals(
+            "Br V6 query should return only 1 alteration",
+            1,
+            brV6.size()
+        );
+        assertEquals(
+            "V600E should start with V6",
+            SignalMatchType.STARTS_WITH,
+            brV6.get(0).getMatchType()
+        );
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/config/ExternalResourceObjectMapperTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/config/ExternalResourceObjectMapperTest.java
@@ -1,6 +1,7 @@
 package org.cbioportal.genome_nexus.service.config;
 
 import org.cbioportal.genome_nexus.model.GeneXref;
+import org.cbioportal.genome_nexus.model.SignalMutation;
 import org.cbioportal.genome_nexus.model.VariantAnnotation;
 import org.cbioportal.genome_nexus.service.mock.JsonToObjectMapper;
 import org.junit.Test;
@@ -64,6 +65,25 @@ public class ExternalResourceObjectMapperTest
             annotation.getTranscriptConsequences().get(1).getRefseqTranscriptIds());
 
         assertNull(annotation.getAnnotationSummary());
+    }
+
+    @Test
+    public void testSignalMutationMapping() throws IOException
+    {
+        SignalMutation mutation =
+            this.objectMapper.readSignalMutation("7_g.55241617G_A.json");
+
+        assertEquals("7", mutation.getChromosome());
+        assertEquals((Long)55241617L, mutation.getStartPosition());
+        assertEquals((Long)55241617L, mutation.getEndPosition());
+        assertEquals("G", mutation.getReferenceAllele());
+        assertEquals("A", mutation.getVariantAllele());
+        assertEquals("EGFR", mutation.getHugoGeneSymbol());
+        assertEquals("somatic", mutation.getMutationStatus());
+        assertEquals(45, mutation.getCountsByTumorType().size());
+
+        assertNull(mutation.getBiallelicCountsByTumorType());
+        assertNull(mutation.getQcPassCountsByTumorType());
     }
 
     @Test

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/JsonToObjectMapper.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/JsonToObjectMapper.java
@@ -1,6 +1,7 @@
 package org.cbioportal.genome_nexus.service.mock;
 
 import org.cbioportal.genome_nexus.model.GeneXref;
+import org.cbioportal.genome_nexus.model.SignalMutation;
 import org.cbioportal.genome_nexus.model.VariantAnnotation;
 import org.cbioportal.genome_nexus.service.config.ExternalResourceObjectMapper;
 import org.springframework.core.io.ClassPathResource;
@@ -30,6 +31,14 @@ public class JsonToObjectMapper
         return this.objectMapper.readValue(
             new ClassPathResource("xref/" + resourceName).getInputStream(),
             this.objectMapper.getTypeFactory().constructCollectionType(List.class, GeneXref.class)
+        );
+    }
+
+    public SignalMutation readSignalMutation(String resourceName) throws IOException
+    {
+        return this.objectMapper.readValue(
+            new ClassPathResource("signal/" + resourceName).getInputStream(),
+            SignalMutation.class
         );
     }
 }

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/SignalMockData.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/SignalMockData.java
@@ -1,0 +1,37 @@
+package org.cbioportal.genome_nexus.service.mock;
+
+import org.cbioportal.genome_nexus.model.SignalMutation;
+import org.cbioportal.genome_nexus.service.MockData;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class SignalMockData implements MockData<SignalMutation>
+{
+    private final JsonToObjectMapper objectMapper;
+
+    public SignalMockData()
+    {
+        this.objectMapper = new JsonToObjectMapper();
+    }
+
+    @Override
+    public Map<String, SignalMutation> generateData() throws IOException
+    {
+        Map<String, SignalMutation> mockData = new LinkedHashMap<>();
+
+        mockData.put("7:g.55241617G>A",
+            this.objectMapper.readSignalMutation("7_g.55241617G_A.json"));
+        mockData.put("7:g.140453136A>T",
+            this.objectMapper.readSignalMutation("7_g.140453136A_T.json"));
+        mockData.put("13:g.32914438_32914438delT",
+            this.objectMapper.readSignalMutation("13_g.32914438_32914438delT.json"));
+        mockData.put("17:g.41276045_41276046delCT",
+            this.objectMapper.readSignalMutation("17_g.41276045_41276046delCT.json"));
+        mockData.put("17:g.41276046_41276047insG",
+            this.objectMapper.readSignalMutation("17_g.41276046_41276047insG.json"));
+
+        return mockData;
+    }
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantAnnotationMockData.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantAnnotationMockData.java
@@ -39,6 +39,8 @@ public class VariantAnnotationMockData implements MockData<VariantAnnotation>
             this.objectMapper.readVariantAnnotation("6_g.137519505_137519506delCT.json"));
         mockData.put("7:g.55220240G>T",
             this.objectMapper.readVariantAnnotation("7_g.55220240G_T.json"));
+        mockData.put("7:g.55241617G>A",
+            this.objectMapper.readVariantAnnotation("7_g.55241617G_A.json"));
         mockData.put("7:g.140453136A>T",
             this.objectMapper.readVariantAnnotation("7_g.140453136A_T.json"));
         mockData.put("8:g.37696499_37696500insG",
@@ -53,8 +55,14 @@ public class VariantAnnotationMockData implements MockData<VariantAnnotation>
             this.objectMapper.readVariantAnnotation("12_g.25398285C_A.json"));
         mockData.put("13:g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG",
             this.objectMapper.readVariantAnnotation("13_g.28608258_28608275delCATATTCATATTCTCTGAinsGGGGTGGGGGGG.json"));
+        mockData.put("13:g.32914438_32914438delT",
+            this.objectMapper.readVariantAnnotation("13_g.32914438_32914438delT.json"));
         mockData.put("16:g.9057113_9057114insCTG",
             this.objectMapper.readVariantAnnotation("16_g.9057113_9057114insCTG.json"));
+        mockData.put("17:g.41276045_41276046delCT",
+            this.objectMapper.readVariantAnnotation("17_g.41276045_41276046delCT.json"));
+        mockData.put("17:g.41276046_41276047insG",
+            this.objectMapper.readVariantAnnotation("17_g.41276046_41276047insG.json"));
         mockData.put("19:g.46141892_46141893delTCinsAA",
             this.objectMapper.readVariantAnnotation("19_g.46141892_46141893delTCinsAA.json"));
         mockData.put("22:g.29091840_29091841delTGinsCA",

--- a/service/src/test/resources/signal/13_g.32914438_32914438delT.json
+++ b/service/src/test/resources/signal/13_g.32914438_32914438delT.json
@@ -1,0 +1,692 @@
+{
+    "hugoGeneSymbol": "BRCA2",
+    "chromosome": "13",
+    "startPosition": 32914438,
+    "endPosition": 32914438,
+    "referenceAllele": "T",
+    "variantAllele": "-",
+    "mutationStatus": "germline",
+    "pathogenic": "1",
+    "penetrance": "High",
+    "countsByTumorType": [
+        {
+            "tumorType": "Cholangiocarcinoma",
+            "tumorTypeCount": 288,
+            "variantCount": 3
+        },
+        {
+            "tumorType": "Embryonal Tumor",
+            "tumorTypeCount": 112,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Pancreatic Adenocarcinoma",
+            "tumorTypeCount": 758,
+            "variantCount": 18
+        },
+        {
+            "tumorType": "Non Glioma CNS Cancers",
+            "tumorTypeCount": 71,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Uterine Sarcoma",
+            "tumorTypeCount": 127,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Unknown",
+            "tumorTypeCount": 39,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Diffuse Glioma",
+            "tumorTypeCount": 836,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Ampullary Carcinoma",
+            "tumorTypeCount": 47,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Cervical Cancer",
+            "tumorTypeCount": 79,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Prostate Cancer",
+            "tumorTypeCount": 1042,
+            "variantCount": 20
+        },
+        {
+            "tumorType": "Invasive Breast Carcinoma",
+            "tumorTypeCount": 2422,
+            "variantCount": 12
+        },
+        {
+            "tumorType": "Thymic Tumor",
+            "tumorTypeCount": 44,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Skin Cancer, Non-Melanoma",
+            "tumorTypeCount": 196,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Mesothelioma",
+            "tumorTypeCount": 172,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Lung Neuroendocrine Tumor",
+            "tumorTypeCount": 97,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Anal Cancer",
+            "tumorTypeCount": 48,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Endometrial Carcinoma",
+            "tumorTypeCount": 547,
+            "variantCount": 3
+        },
+        {
+            "tumorType": "Non-Cholangio Hepatobiliary Cancer",
+            "tumorTypeCount": 236,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cancer of Unknown Primary",
+            "tumorTypeCount": 409,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Soft Tissue Sarcoma",
+            "tumorTypeCount": 666,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Appendiceal Adenocarcinoma",
+            "tumorTypeCount": 122,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Esophagogastric Cancer",
+            "tumorTypeCount": 429,
+            "variantCount": 4
+        },
+        {
+            "tumorType": "Nerve Sheath Tumor",
+            "tumorTypeCount": 33,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Ovarian Cancer",
+            "tumorTypeCount": 384,
+            "variantCount": 5
+        },
+        {
+            "tumorType": "Non-cutaneous Melanoma",
+            "tumorTypeCount": 197,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Renal Non-Clear Cell Carcinoma",
+            "tumorTypeCount": 190,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Retinoblastoma",
+            "tumorTypeCount": 12,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Sex Cord Stromal Tumor",
+            "tumorTypeCount": 27,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Thyroid Cancer",
+            "tumorTypeCount": 306,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Gastrointestinal Neuroendocrine Tumors",
+            "tumorTypeCount": 85,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Germ Cell Tumor",
+            "tumorTypeCount": 367,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Pancreatic Neuroendocrine Tumor",
+            "tumorTypeCount": 112,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Small Cell Lung Cancer",
+            "tumorTypeCount": 132,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Cutaneous Melanoma",
+            "tumorTypeCount": 322,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Gastrointestinal Stromal Tumor",
+            "tumorTypeCount": 211,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Salivary Carcinoma",
+            "tumorTypeCount": 149,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Other",
+            "tumorTypeCount": 475,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Bladder Cancer",
+            "tumorTypeCount": 548,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Small Bowel Cancer",
+            "tumorTypeCount": 59,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Colorectal Adenocarcinoma",
+            "tumorTypeCount": 1495,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Non-Small Cell Lung Cancer",
+            "tumorTypeCount": 2463,
+            "variantCount": 5
+        },
+        {
+            "tumorType": "Adrenocortical Carcinoma",
+            "tumorTypeCount": 41,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Bone Cancer",
+            "tumorTypeCount": 206,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Renal Clear Cell Carcinoma",
+            "tumorTypeCount": 272,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Head and Neck Cancer",
+            "tumorTypeCount": 279,
+            "variantCount": 1
+        }
+    ],
+    "biallelicCountsByTumorType": [
+        {
+            "tumorType": "Cholangiocarcinoma",
+            "tumorTypeCount": 251,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Embryonal Tumor",
+            "tumorTypeCount": 101,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Pancreatic Adenocarcinoma",
+            "tumorTypeCount": 649,
+            "variantCount": 15
+        },
+        {
+            "tumorType": "Non Glioma CNS Cancers",
+            "tumorTypeCount": 64,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Uterine Sarcoma",
+            "tumorTypeCount": 107,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Unknown",
+            "tumorTypeCount": 20,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Diffuse Glioma",
+            "tumorTypeCount": 790,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Ampullary Carcinoma",
+            "tumorTypeCount": 41,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Cervical Cancer",
+            "tumorTypeCount": 74,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Prostate Cancer",
+            "tumorTypeCount": 879,
+            "variantCount": 14
+        },
+        {
+            "tumorType": "Invasive Breast Carcinoma",
+            "tumorTypeCount": 2206,
+            "variantCount": 8
+        },
+        {
+            "tumorType": "Thymic Tumor",
+            "tumorTypeCount": 30,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Skin Cancer, Non-Melanoma",
+            "tumorTypeCount": 179,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Mesothelioma",
+            "tumorTypeCount": 141,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Lung Neuroendocrine Tumor",
+            "tumorTypeCount": 86,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Anal Cancer",
+            "tumorTypeCount": 45,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Endometrial Carcinoma",
+            "tumorTypeCount": 507,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Non-Cholangio Hepatobiliary Cancer",
+            "tumorTypeCount": 208,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cancer of Unknown Primary",
+            "tumorTypeCount": 349,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Soft Tissue Sarcoma",
+            "tumorTypeCount": 550,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Appendiceal Adenocarcinoma",
+            "tumorTypeCount": 92,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Esophagogastric Cancer",
+            "tumorTypeCount": 355,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Nerve Sheath Tumor",
+            "tumorTypeCount": 25,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Ovarian Cancer",
+            "tumorTypeCount": 333,
+            "variantCount": 4
+        },
+        {
+            "tumorType": "Non-cutaneous Melanoma",
+            "tumorTypeCount": 175,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Renal Non-Clear Cell Carcinoma",
+            "tumorTypeCount": 174,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Retinoblastoma",
+            "tumorTypeCount": 11,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Sex Cord Stromal Tumor",
+            "tumorTypeCount": 24,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Thyroid Cancer",
+            "tumorTypeCount": 269,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Gastrointestinal Neuroendocrine Tumors",
+            "tumorTypeCount": 77,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Germ Cell Tumor",
+            "tumorTypeCount": 317,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Pancreatic Neuroendocrine Tumor",
+            "tumorTypeCount": 99,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Small Cell Lung Cancer",
+            "tumorTypeCount": 118,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cutaneous Melanoma",
+            "tumorTypeCount": 298,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Gastrointestinal Stromal Tumor",
+            "tumorTypeCount": 193,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Salivary Carcinoma",
+            "tumorTypeCount": 125,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Other",
+            "tumorTypeCount": 382,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Bladder Cancer",
+            "tumorTypeCount": 498,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Small Bowel Cancer",
+            "tumorTypeCount": 52,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Colorectal Adenocarcinoma",
+            "tumorTypeCount": 1384,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Non-Small Cell Lung Cancer",
+            "tumorTypeCount": 2187,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Adrenocortical Carcinoma",
+            "tumorTypeCount": 36,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Bone Cancer",
+            "tumorTypeCount": 174,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Renal Clear Cell Carcinoma",
+            "tumorTypeCount": 262,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Head and Neck Cancer",
+            "tumorTypeCount": 258,
+            "variantCount": 0
+        }
+    ],
+    "qcPassCountsByTumorType": [
+        {
+            "tumorType": "Cholangiocarcinoma",
+            "tumorTypeCount": 251,
+            "variantCount": 3
+        },
+        {
+            "tumorType": "Embryonal Tumor",
+            "tumorTypeCount": 101,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Pancreatic Adenocarcinoma",
+            "tumorTypeCount": 649,
+            "variantCount": 15
+        },
+        {
+            "tumorType": "Non Glioma CNS Cancers",
+            "tumorTypeCount": 64,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Uterine Sarcoma",
+            "tumorTypeCount": 107,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Unknown",
+            "tumorTypeCount": 20,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Diffuse Glioma",
+            "tumorTypeCount": 790,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Ampullary Carcinoma",
+            "tumorTypeCount": 41,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Cervical Cancer",
+            "tumorTypeCount": 74,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Prostate Cancer",
+            "tumorTypeCount": 879,
+            "variantCount": 18
+        },
+        {
+            "tumorType": "Invasive Breast Carcinoma",
+            "tumorTypeCount": 2206,
+            "variantCount": 10
+        },
+        {
+            "tumorType": "Thymic Tumor",
+            "tumorTypeCount": 30,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Skin Cancer, Non-Melanoma",
+            "tumorTypeCount": 179,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Mesothelioma",
+            "tumorTypeCount": 141,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Lung Neuroendocrine Tumor",
+            "tumorTypeCount": 86,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Anal Cancer",
+            "tumorTypeCount": 45,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Endometrial Carcinoma",
+            "tumorTypeCount": 507,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Non-Cholangio Hepatobiliary Cancer",
+            "tumorTypeCount": 208,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cancer of Unknown Primary",
+            "tumorTypeCount": 349,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Soft Tissue Sarcoma",
+            "tumorTypeCount": 550,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Appendiceal Adenocarcinoma",
+            "tumorTypeCount": 92,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Esophagogastric Cancer",
+            "tumorTypeCount": 355,
+            "variantCount": 3
+        },
+        {
+            "tumorType": "Nerve Sheath Tumor",
+            "tumorTypeCount": 25,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Ovarian Cancer",
+            "tumorTypeCount": 333,
+            "variantCount": 5
+        },
+        {
+            "tumorType": "Non-cutaneous Melanoma",
+            "tumorTypeCount": 175,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Renal Non-Clear Cell Carcinoma",
+            "tumorTypeCount": 174,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Retinoblastoma",
+            "tumorTypeCount": 11,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Sex Cord Stromal Tumor",
+            "tumorTypeCount": 24,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Thyroid Cancer",
+            "tumorTypeCount": 269,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Gastrointestinal Neuroendocrine Tumors",
+            "tumorTypeCount": 77,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Germ Cell Tumor",
+            "tumorTypeCount": 317,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Pancreatic Neuroendocrine Tumor",
+            "tumorTypeCount": 99,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Small Cell Lung Cancer",
+            "tumorTypeCount": 118,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Cutaneous Melanoma",
+            "tumorTypeCount": 298,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Gastrointestinal Stromal Tumor",
+            "tumorTypeCount": 193,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Salivary Carcinoma",
+            "tumorTypeCount": 125,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Other",
+            "tumorTypeCount": 382,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Bladder Cancer",
+            "tumorTypeCount": 498,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Small Bowel Cancer",
+            "tumorTypeCount": 52,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Colorectal Adenocarcinoma",
+            "tumorTypeCount": 1384,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Non-Small Cell Lung Cancer",
+            "tumorTypeCount": 2187,
+            "variantCount": 5
+        },
+        {
+            "tumorType": "Adrenocortical Carcinoma",
+            "tumorTypeCount": 36,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Bone Cancer",
+            "tumorTypeCount": 174,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Renal Clear Cell Carcinoma",
+            "tumorTypeCount": 262,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Head and Neck Cancer",
+            "tumorTypeCount": 258,
+            "variantCount": 1
+        }
+    ]
+}

--- a/service/src/test/resources/signal/17_g.41276045_41276046delCT.json
+++ b/service/src/test/resources/signal/17_g.41276045_41276046delCT.json
@@ -1,0 +1,692 @@
+{
+    "hugoGeneSymbol": "BRCA1",
+    "chromosome": "17",
+    "startPosition": 41276045,
+    "endPosition": 41276046,
+    "referenceAllele": "CT",
+    "variantAllele": "-",
+    "mutationStatus": "germline",
+    "pathogenic": "1",
+    "penetrance": "High",
+    "countsByTumorType": [
+        {
+            "tumorType": "Cholangiocarcinoma",
+            "tumorTypeCount": 288,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Embryonal Tumor",
+            "tumorTypeCount": 112,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Pancreatic Adenocarcinoma",
+            "tumorTypeCount": 758,
+            "variantCount": 5
+        },
+        {
+            "tumorType": "Non Glioma CNS Cancers",
+            "tumorTypeCount": 71,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Uterine Sarcoma",
+            "tumorTypeCount": 127,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Unknown",
+            "tumorTypeCount": 39,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Diffuse Glioma",
+            "tumorTypeCount": 836,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Ampullary Carcinoma",
+            "tumorTypeCount": 47,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cervical Cancer",
+            "tumorTypeCount": 79,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Prostate Cancer",
+            "tumorTypeCount": 1042,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Invasive Breast Carcinoma",
+            "tumorTypeCount": 2422,
+            "variantCount": 15
+        },
+        {
+            "tumorType": "Thymic Tumor",
+            "tumorTypeCount": 44,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Skin Cancer, Non-Melanoma",
+            "tumorTypeCount": 196,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Mesothelioma",
+            "tumorTypeCount": 172,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Lung Neuroendocrine Tumor",
+            "tumorTypeCount": 97,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Anal Cancer",
+            "tumorTypeCount": 48,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Endometrial Carcinoma",
+            "tumorTypeCount": 547,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Non-Cholangio Hepatobiliary Cancer",
+            "tumorTypeCount": 236,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cancer of Unknown Primary",
+            "tumorTypeCount": 409,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Soft Tissue Sarcoma",
+            "tumorTypeCount": 666,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Appendiceal Adenocarcinoma",
+            "tumorTypeCount": 122,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Esophagogastric Cancer",
+            "tumorTypeCount": 429,
+            "variantCount": 3
+        },
+        {
+            "tumorType": "Nerve Sheath Tumor",
+            "tumorTypeCount": 33,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Ovarian Cancer",
+            "tumorTypeCount": 384,
+            "variantCount": 6
+        },
+        {
+            "tumorType": "Non-cutaneous Melanoma",
+            "tumorTypeCount": 197,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Renal Non-Clear Cell Carcinoma",
+            "tumorTypeCount": 190,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Retinoblastoma",
+            "tumorTypeCount": 12,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Sex Cord Stromal Tumor",
+            "tumorTypeCount": 27,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Thyroid Cancer",
+            "tumorTypeCount": 306,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Gastrointestinal Neuroendocrine Tumors",
+            "tumorTypeCount": 85,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Germ Cell Tumor",
+            "tumorTypeCount": 367,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Pancreatic Neuroendocrine Tumor",
+            "tumorTypeCount": 112,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Small Cell Lung Cancer",
+            "tumorTypeCount": 132,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cutaneous Melanoma",
+            "tumorTypeCount": 322,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Gastrointestinal Stromal Tumor",
+            "tumorTypeCount": 211,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Salivary Carcinoma",
+            "tumorTypeCount": 149,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Other",
+            "tumorTypeCount": 475,
+            "variantCount": 3
+        },
+        {
+            "tumorType": "Bladder Cancer",
+            "tumorTypeCount": 548,
+            "variantCount": 3
+        },
+        {
+            "tumorType": "Small Bowel Cancer",
+            "tumorTypeCount": 59,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Colorectal Adenocarcinoma",
+            "tumorTypeCount": 1495,
+            "variantCount": 3
+        },
+        {
+            "tumorType": "Non-Small Cell Lung Cancer",
+            "tumorTypeCount": 2463,
+            "variantCount": 8
+        },
+        {
+            "tumorType": "Adrenocortical Carcinoma",
+            "tumorTypeCount": 41,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Bone Cancer",
+            "tumorTypeCount": 206,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Renal Clear Cell Carcinoma",
+            "tumorTypeCount": 272,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Head and Neck Cancer",
+            "tumorTypeCount": 279,
+            "variantCount": 1
+        }
+    ],
+    "biallelicCountsByTumorType": [
+        {
+            "tumorType": "Cholangiocarcinoma",
+            "tumorTypeCount": 251,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Embryonal Tumor",
+            "tumorTypeCount": 101,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Pancreatic Adenocarcinoma",
+            "tumorTypeCount": 649,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Non Glioma CNS Cancers",
+            "tumorTypeCount": 64,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Uterine Sarcoma",
+            "tumorTypeCount": 107,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Unknown",
+            "tumorTypeCount": 20,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Diffuse Glioma",
+            "tumorTypeCount": 790,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Ampullary Carcinoma",
+            "tumorTypeCount": 41,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cervical Cancer",
+            "tumorTypeCount": 74,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Prostate Cancer",
+            "tumorTypeCount": 879,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Invasive Breast Carcinoma",
+            "tumorTypeCount": 2206,
+            "variantCount": 11
+        },
+        {
+            "tumorType": "Thymic Tumor",
+            "tumorTypeCount": 30,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Skin Cancer, Non-Melanoma",
+            "tumorTypeCount": 179,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Mesothelioma",
+            "tumorTypeCount": 141,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Lung Neuroendocrine Tumor",
+            "tumorTypeCount": 86,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Anal Cancer",
+            "tumorTypeCount": 45,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Endometrial Carcinoma",
+            "tumorTypeCount": 507,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Non-Cholangio Hepatobiliary Cancer",
+            "tumorTypeCount": 208,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cancer of Unknown Primary",
+            "tumorTypeCount": 349,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Soft Tissue Sarcoma",
+            "tumorTypeCount": 550,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Appendiceal Adenocarcinoma",
+            "tumorTypeCount": 92,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Esophagogastric Cancer",
+            "tumorTypeCount": 355,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Nerve Sheath Tumor",
+            "tumorTypeCount": 25,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Ovarian Cancer",
+            "tumorTypeCount": 333,
+            "variantCount": 4
+        },
+        {
+            "tumorType": "Non-cutaneous Melanoma",
+            "tumorTypeCount": 175,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Renal Non-Clear Cell Carcinoma",
+            "tumorTypeCount": 174,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Retinoblastoma",
+            "tumorTypeCount": 11,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Sex Cord Stromal Tumor",
+            "tumorTypeCount": 24,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Thyroid Cancer",
+            "tumorTypeCount": 269,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Gastrointestinal Neuroendocrine Tumors",
+            "tumorTypeCount": 77,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Germ Cell Tumor",
+            "tumorTypeCount": 317,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Pancreatic Neuroendocrine Tumor",
+            "tumorTypeCount": 99,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Small Cell Lung Cancer",
+            "tumorTypeCount": 118,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cutaneous Melanoma",
+            "tumorTypeCount": 298,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Gastrointestinal Stromal Tumor",
+            "tumorTypeCount": 193,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Salivary Carcinoma",
+            "tumorTypeCount": 125,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Other",
+            "tumorTypeCount": 382,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Bladder Cancer",
+            "tumorTypeCount": 498,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Small Bowel Cancer",
+            "tumorTypeCount": 52,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Colorectal Adenocarcinoma",
+            "tumorTypeCount": 1384,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Non-Small Cell Lung Cancer",
+            "tumorTypeCount": 2187,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Adrenocortical Carcinoma",
+            "tumorTypeCount": 36,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Bone Cancer",
+            "tumorTypeCount": 174,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Renal Clear Cell Carcinoma",
+            "tumorTypeCount": 262,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Head and Neck Cancer",
+            "tumorTypeCount": 258,
+            "variantCount": 0
+        }
+    ],
+    "qcPassCountsByTumorType": [
+        {
+            "tumorType": "Cholangiocarcinoma",
+            "tumorTypeCount": 251,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Embryonal Tumor",
+            "tumorTypeCount": 101,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Pancreatic Adenocarcinoma",
+            "tumorTypeCount": 649,
+            "variantCount": 5
+        },
+        {
+            "tumorType": "Non Glioma CNS Cancers",
+            "tumorTypeCount": 64,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Uterine Sarcoma",
+            "tumorTypeCount": 107,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Unknown",
+            "tumorTypeCount": 20,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Diffuse Glioma",
+            "tumorTypeCount": 790,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Ampullary Carcinoma",
+            "tumorTypeCount": 41,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cervical Cancer",
+            "tumorTypeCount": 74,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Prostate Cancer",
+            "tumorTypeCount": 879,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Invasive Breast Carcinoma",
+            "tumorTypeCount": 2206,
+            "variantCount": 12
+        },
+        {
+            "tumorType": "Thymic Tumor",
+            "tumorTypeCount": 30,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Skin Cancer, Non-Melanoma",
+            "tumorTypeCount": 179,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Mesothelioma",
+            "tumorTypeCount": 141,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Lung Neuroendocrine Tumor",
+            "tumorTypeCount": 86,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Anal Cancer",
+            "tumorTypeCount": 45,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Endometrial Carcinoma",
+            "tumorTypeCount": 507,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Non-Cholangio Hepatobiliary Cancer",
+            "tumorTypeCount": 208,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cancer of Unknown Primary",
+            "tumorTypeCount": 349,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Soft Tissue Sarcoma",
+            "tumorTypeCount": 550,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Appendiceal Adenocarcinoma",
+            "tumorTypeCount": 92,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Esophagogastric Cancer",
+            "tumorTypeCount": 355,
+            "variantCount": 3
+        },
+        {
+            "tumorType": "Nerve Sheath Tumor",
+            "tumorTypeCount": 25,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Ovarian Cancer",
+            "tumorTypeCount": 333,
+            "variantCount": 5
+        },
+        {
+            "tumorType": "Non-cutaneous Melanoma",
+            "tumorTypeCount": 175,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Renal Non-Clear Cell Carcinoma",
+            "tumorTypeCount": 174,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Retinoblastoma",
+            "tumorTypeCount": 11,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Sex Cord Stromal Tumor",
+            "tumorTypeCount": 24,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Thyroid Cancer",
+            "tumorTypeCount": 269,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Gastrointestinal Neuroendocrine Tumors",
+            "tumorTypeCount": 77,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Germ Cell Tumor",
+            "tumorTypeCount": 317,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Pancreatic Neuroendocrine Tumor",
+            "tumorTypeCount": 99,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Small Cell Lung Cancer",
+            "tumorTypeCount": 118,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cutaneous Melanoma",
+            "tumorTypeCount": 298,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Gastrointestinal Stromal Tumor",
+            "tumorTypeCount": 193,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Salivary Carcinoma",
+            "tumorTypeCount": 125,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Other",
+            "tumorTypeCount": 382,
+            "variantCount": 3
+        },
+        {
+            "tumorType": "Bladder Cancer",
+            "tumorTypeCount": 498,
+            "variantCount": 3
+        },
+        {
+            "tumorType": "Small Bowel Cancer",
+            "tumorTypeCount": 52,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Colorectal Adenocarcinoma",
+            "tumorTypeCount": 1384,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Non-Small Cell Lung Cancer",
+            "tumorTypeCount": 2187,
+            "variantCount": 6
+        },
+        {
+            "tumorType": "Adrenocortical Carcinoma",
+            "tumorTypeCount": 36,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Bone Cancer",
+            "tumorTypeCount": 174,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Renal Clear Cell Carcinoma",
+            "tumorTypeCount": 262,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Head and Neck Cancer",
+            "tumorTypeCount": 258,
+            "variantCount": 1
+        }
+    ]
+}

--- a/service/src/test/resources/signal/17_g.41276046_41276047insG.json
+++ b/service/src/test/resources/signal/17_g.41276046_41276047insG.json
@@ -1,0 +1,236 @@
+{
+    "hugoGeneSymbol": "BRCA1",
+    "chromosome": "17",
+    "startPosition": 41276046,
+    "endPosition": 41276047,
+    "referenceAllele": "-",
+    "variantAllele": "G",
+    "mutationStatus": "somatic",
+    "countsByTumorType": [
+        {
+            "tumorType": "Cholangiocarcinoma",
+            "tumorTypeCount": 288,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Embryonal Tumor",
+            "tumorTypeCount": 112,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Pancreatic Adenocarcinoma",
+            "tumorTypeCount": 758,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Non Glioma CNS Cancers",
+            "tumorTypeCount": 71,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Uterine Sarcoma",
+            "tumorTypeCount": 127,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Unknown",
+            "tumorTypeCount": 39,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Diffuse Glioma",
+            "tumorTypeCount": 836,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Ampullary Carcinoma",
+            "tumorTypeCount": 47,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cervical Cancer",
+            "tumorTypeCount": 79,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Prostate Cancer",
+            "tumorTypeCount": 1042,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Invasive Breast Carcinoma",
+            "tumorTypeCount": 2422,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Thymic Tumor",
+            "tumorTypeCount": 44,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Skin Cancer, Non-Melanoma",
+            "tumorTypeCount": 196,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Mesothelioma",
+            "tumorTypeCount": 172,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Lung Neuroendocrine Tumor",
+            "tumorTypeCount": 97,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Anal Cancer",
+            "tumorTypeCount": 48,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Endometrial Carcinoma",
+            "tumorTypeCount": 547,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Non-Cholangio Hepatobiliary Cancer",
+            "tumorTypeCount": 236,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cancer of Unknown Primary",
+            "tumorTypeCount": 409,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Soft Tissue Sarcoma",
+            "tumorTypeCount": 666,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Appendiceal Adenocarcinoma",
+            "tumorTypeCount": 122,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Esophagogastric Cancer",
+            "tumorTypeCount": 429,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Nerve Sheath Tumor",
+            "tumorTypeCount": 33,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Ovarian Cancer",
+            "tumorTypeCount": 384,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Non-cutaneous Melanoma",
+            "tumorTypeCount": 197,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Renal Non-Clear Cell Carcinoma",
+            "tumorTypeCount": 190,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Retinoblastoma",
+            "tumorTypeCount": 12,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Sex Cord Stromal Tumor",
+            "tumorTypeCount": 27,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Thyroid Cancer",
+            "tumorTypeCount": 306,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Gastrointestinal Neuroendocrine Tumors",
+            "tumorTypeCount": 85,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Germ Cell Tumor",
+            "tumorTypeCount": 367,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Pancreatic Neuroendocrine Tumor",
+            "tumorTypeCount": 112,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Small Cell Lung Cancer",
+            "tumorTypeCount": 132,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cutaneous Melanoma",
+            "tumorTypeCount": 322,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Gastrointestinal Stromal Tumor",
+            "tumorTypeCount": 211,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Salivary Carcinoma",
+            "tumorTypeCount": 149,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Other",
+            "tumorTypeCount": 475,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Bladder Cancer",
+            "tumorTypeCount": 548,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Small Bowel Cancer",
+            "tumorTypeCount": 59,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Colorectal Adenocarcinoma",
+            "tumorTypeCount": 1495,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Non-Small Cell Lung Cancer",
+            "tumorTypeCount": 2463,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Adrenocortical Carcinoma",
+            "tumorTypeCount": 41,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Bone Cancer",
+            "tumorTypeCount": 206,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Renal Clear Cell Carcinoma",
+            "tumorTypeCount": 272,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Head and Neck Cancer",
+            "tumorTypeCount": 279,
+            "variantCount": 0
+        }
+    ]
+}

--- a/service/src/test/resources/signal/7_g.140453136A_T.json
+++ b/service/src/test/resources/signal/7_g.140453136A_T.json
@@ -1,0 +1,236 @@
+{
+    "hugoGeneSymbol": "BRAF",
+    "chromosome": "7",
+    "startPosition": 140453136,
+    "endPosition": 140453136,
+    "referenceAllele": "A",
+    "variantAllele": "T",
+    "mutationStatus": "somatic",
+    "countsByTumorType": [
+        {
+            "tumorType": "Cholangiocarcinoma",
+            "tumorTypeCount": 288,
+            "variantCount": 6
+        },
+        {
+            "tumorType": "Embryonal Tumor",
+            "tumorTypeCount": 112,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Pancreatic Adenocarcinoma",
+            "tumorTypeCount": 758,
+            "variantCount": 3
+        },
+        {
+            "tumorType": "Non Glioma CNS Cancers",
+            "tumorTypeCount": 71,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Uterine Sarcoma",
+            "tumorTypeCount": 127,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Unknown",
+            "tumorTypeCount": 39,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Diffuse Glioma",
+            "tumorTypeCount": 836,
+            "variantCount": 12
+        },
+        {
+            "tumorType": "Ampullary Carcinoma",
+            "tumorTypeCount": 47,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Cervical Cancer",
+            "tumorTypeCount": 79,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Prostate Cancer",
+            "tumorTypeCount": 1042,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Invasive Breast Carcinoma",
+            "tumorTypeCount": 2422,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Thymic Tumor",
+            "tumorTypeCount": 44,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Skin Cancer, Non-Melanoma",
+            "tumorTypeCount": 196,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Mesothelioma",
+            "tumorTypeCount": 172,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Lung Neuroendocrine Tumor",
+            "tumorTypeCount": 97,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Anal Cancer",
+            "tumorTypeCount": 48,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Endometrial Carcinoma",
+            "tumorTypeCount": 547,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Non-Cholangio Hepatobiliary Cancer",
+            "tumorTypeCount": 236,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cancer of Unknown Primary",
+            "tumorTypeCount": 409,
+            "variantCount": 9
+        },
+        {
+            "tumorType": "Soft Tissue Sarcoma",
+            "tumorTypeCount": 666,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Appendiceal Adenocarcinoma",
+            "tumorTypeCount": 122,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Esophagogastric Cancer",
+            "tumorTypeCount": 429,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Nerve Sheath Tumor",
+            "tumorTypeCount": 33,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Ovarian Cancer",
+            "tumorTypeCount": 384,
+            "variantCount": 3
+        },
+        {
+            "tumorType": "Non-cutaneous Melanoma",
+            "tumorTypeCount": 197,
+            "variantCount": 5
+        },
+        {
+            "tumorType": "Renal Non-Clear Cell Carcinoma",
+            "tumorTypeCount": 190,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Retinoblastoma",
+            "tumorTypeCount": 12,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Sex Cord Stromal Tumor",
+            "tumorTypeCount": 27,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Thyroid Cancer",
+            "tumorTypeCount": 306,
+            "variantCount": 108
+        },
+        {
+            "tumorType": "Gastrointestinal Neuroendocrine Tumors",
+            "tumorTypeCount": 85,
+            "variantCount": 6
+        },
+        {
+            "tumorType": "Germ Cell Tumor",
+            "tumorTypeCount": 367,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Pancreatic Neuroendocrine Tumor",
+            "tumorTypeCount": 112,
+            "variantCount": 3
+        },
+        {
+            "tumorType": "Small Cell Lung Cancer",
+            "tumorTypeCount": 132,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cutaneous Melanoma",
+            "tumorTypeCount": 322,
+            "variantCount": 78
+        },
+        {
+            "tumorType": "Gastrointestinal Stromal Tumor",
+            "tumorTypeCount": 211,
+            "variantCount": 2
+        },
+        {
+            "tumorType": "Salivary Carcinoma",
+            "tumorTypeCount": 149,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Other",
+            "tumorTypeCount": 475,
+            "variantCount": 42
+        },
+        {
+            "tumorType": "Bladder Cancer",
+            "tumorTypeCount": 548,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Small Bowel Cancer",
+            "tumorTypeCount": 59,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Colorectal Adenocarcinoma",
+            "tumorTypeCount": 1495,
+            "variantCount": 106
+        },
+        {
+            "tumorType": "Non-Small Cell Lung Cancer",
+            "tumorTypeCount": 2463,
+            "variantCount": 36
+        },
+        {
+            "tumorType": "Adrenocortical Carcinoma",
+            "tumorTypeCount": 41,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Bone Cancer",
+            "tumorTypeCount": 206,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Renal Clear Cell Carcinoma",
+            "tumorTypeCount": 272,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Head and Neck Cancer",
+            "tumorTypeCount": 279,
+            "variantCount": 0
+        }
+    ]
+}

--- a/service/src/test/resources/signal/7_g.55241617G_A.json
+++ b/service/src/test/resources/signal/7_g.55241617G_A.json
@@ -1,0 +1,236 @@
+{
+    "hugoGeneSymbol": "EGFR",
+    "chromosome": "7",
+    "startPosition": 55241617,
+    "endPosition": 55241617,
+    "referenceAllele": "G",
+    "variantAllele": "A",
+    "mutationStatus": "somatic",
+    "countsByTumorType": [
+        {
+            "tumorType": "Cholangiocarcinoma",
+            "tumorTypeCount": 288,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Embryonal Tumor",
+            "tumorTypeCount": 112,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Pancreatic Adenocarcinoma",
+            "tumorTypeCount": 758,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Non Glioma CNS Cancers",
+            "tumorTypeCount": 71,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Uterine Sarcoma",
+            "tumorTypeCount": 127,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Unknown",
+            "tumorTypeCount": 39,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Diffuse Glioma",
+            "tumorTypeCount": 836,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Ampullary Carcinoma",
+            "tumorTypeCount": 47,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cervical Cancer",
+            "tumorTypeCount": 79,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Prostate Cancer",
+            "tumorTypeCount": 1042,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Invasive Breast Carcinoma",
+            "tumorTypeCount": 2422,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Thymic Tumor",
+            "tumorTypeCount": 44,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Skin Cancer, Non-Melanoma",
+            "tumorTypeCount": 196,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Mesothelioma",
+            "tumorTypeCount": 172,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Lung Neuroendocrine Tumor",
+            "tumorTypeCount": 97,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Anal Cancer",
+            "tumorTypeCount": 48,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Endometrial Carcinoma",
+            "tumorTypeCount": 547,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Non-Cholangio Hepatobiliary Cancer",
+            "tumorTypeCount": 236,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cancer of Unknown Primary",
+            "tumorTypeCount": 409,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Soft Tissue Sarcoma",
+            "tumorTypeCount": 666,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Appendiceal Adenocarcinoma",
+            "tumorTypeCount": 122,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Esophagogastric Cancer",
+            "tumorTypeCount": 429,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Nerve Sheath Tumor",
+            "tumorTypeCount": 33,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Ovarian Cancer",
+            "tumorTypeCount": 384,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Non-cutaneous Melanoma",
+            "tumorTypeCount": 197,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Renal Non-Clear Cell Carcinoma",
+            "tumorTypeCount": 190,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Retinoblastoma",
+            "tumorTypeCount": 12,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Sex Cord Stromal Tumor",
+            "tumorTypeCount": 27,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Thyroid Cancer",
+            "tumorTypeCount": 306,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Gastrointestinal Neuroendocrine Tumors",
+            "tumorTypeCount": 85,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Germ Cell Tumor",
+            "tumorTypeCount": 367,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Pancreatic Neuroendocrine Tumor",
+            "tumorTypeCount": 112,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Small Cell Lung Cancer",
+            "tumorTypeCount": 132,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Cutaneous Melanoma",
+            "tumorTypeCount": 322,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Gastrointestinal Stromal Tumor",
+            "tumorTypeCount": 211,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Salivary Carcinoma",
+            "tumorTypeCount": 149,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Other",
+            "tumorTypeCount": 475,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Bladder Cancer",
+            "tumorTypeCount": 548,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Small Bowel Cancer",
+            "tumorTypeCount": 59,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Colorectal Adenocarcinoma",
+            "tumorTypeCount": 1495,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Non-Small Cell Lung Cancer",
+            "tumorTypeCount": 2463,
+            "variantCount": 1
+        },
+        {
+            "tumorType": "Adrenocortical Carcinoma",
+            "tumorTypeCount": 41,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Bone Cancer",
+            "tumorTypeCount": 206,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Renal Clear Cell Carcinoma",
+            "tumorTypeCount": 272,
+            "variantCount": 0
+        },
+        {
+            "tumorType": "Head and Neck Cancer",
+            "tumorTypeCount": 279,
+            "variantCount": 0
+        }
+    ]
+}

--- a/service/src/test/resources/variant/13_g.32914438_32914438delT.json
+++ b/service/src/test/resources/variant/13_g.32914438_32914438delT.json
@@ -1,0 +1,73 @@
+{
+    "variant": "13:g.32914438_32914438delT",
+    "colocatedVariants": [
+        {
+            "dbSnpId": "CD126349"
+        },
+        {
+            "dbSnpId": "CD961857"
+        },
+        {
+            "dbSnpId": "CD994374"
+        },
+        {
+            "dbSnpId": "COSV66447676"
+        },
+        {
+            "dbSnpId": "rs80359550"
+        }
+    ],
+    "originalVariantQuery": "13:g.32914438_32914438delT",
+    "hgvsg": "13:g.32914438_32914438delT",
+    "id": "13:g.32914438_32914438delT",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "13",
+    "start": 32914438,
+    "end": 32914438,
+    "allele_string": "T/-",
+    "strand": 1,
+    "most_severe_consequence": "frameshift_variant",
+    "transcript_consequences": [
+        {
+            "exon": "11/27",
+            "transcript_id": "ENST00000380152",
+            "hgvsp": "ENSP00000369497.3:p.Ser1982ArgfsTer22",
+            "hgvsc": "ENST00000380152.3:c.5946del",
+            "variant_allele": "-",
+            "codons": "agT/ag",
+            "protein_id": "ENSP00000369497",
+            "protein_start": 1982,
+            "protein_end": 1982,
+            "gene_symbol": "BRCA2",
+            "gene_id": "ENSG00000139618",
+            "amino_acids": "S/X",
+            "hgnc_id": "1101",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "11/28",
+            "transcript_id": "ENST00000544455",
+            "hgvsp": "ENSP00000439902.1:p.Ser1982ArgfsTer22",
+            "hgvsc": "ENST00000544455.1:c.5946del",
+            "variant_allele": "-",
+            "codons": "agT/ag",
+            "protein_id": "ENSP00000439902",
+            "protein_start": 1982,
+            "protein_end": 1982,
+            "gene_symbol": "BRCA2",
+            "gene_id": "ENSG00000139618",
+            "amino_acids": "S/X",
+            "hgnc_id": "1101",
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_000059.3"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        }
+    ],
+    "successfully_annotated": true
+}

--- a/service/src/test/resources/variant/17_g.41276045_41276046delCT.json
+++ b/service/src/test/resources/variant/17_g.41276045_41276046delCT.json
@@ -1,0 +1,476 @@
+{
+    "variant": "17:g.41276045_41276046delCT",
+    "colocatedVariants": [
+        {
+            "dbSnpId": "rs80357914"
+        }
+    ],
+    "originalVariantQuery": "17:g.41276045_41276046delCT",
+    "hgvsg": "17:g.41276045_41276046delCT",
+    "id": "17:g.41276045_41276046delCT",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "17",
+    "start": 41276045,
+    "end": 41276046,
+    "allele_string": "CT/-",
+    "strand": 1,
+    "most_severe_consequence": "frameshift_variant",
+    "transcript_consequences": [
+        {
+            "exon": "2/22",
+            "transcript_id": "ENST00000309486",
+            "hgvsc": "ENST00000309486.4:c.-767_-766del",
+            "variant_allele": "-",
+            "protein_id": "ENSP00000310938",
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "hgnc_id": "1100",
+            "refseq_transcript_ids": [
+                "NM_007297.3"
+            ],
+            "consequence_terms": [
+                "5_prime_UTR_variant"
+            ]
+        },
+        {
+            "exon": "2/19",
+            "transcript_id": "ENST00000346315",
+            "hgvsp": "ENSP00000246907.4:p.Glu23ValfsTer17",
+            "hgvsc": "ENST00000346315.3:c.68_69del",
+            "variant_allele": "-",
+            "codons": "gAG/g",
+            "protein_id": "ENSP00000246907",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/X",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "1/19",
+            "transcript_id": "ENST00000351666",
+            "hgvsp": "ENSP00000338007.3:p.Glu23ValfsTer17",
+            "hgvsc": "ENST00000351666.3:c.68_69del",
+            "variant_allele": "-",
+            "codons": "gAG/g",
+            "protein_id": "ENSP00000338007",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/X",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/22",
+            "transcript_id": "ENST00000352993",
+            "hgvsp": "ENSP00000312236.5:p.Glu23ValfsTer17",
+            "hgvsc": "ENST00000352993.3:c.68_69del",
+            "variant_allele": "-",
+            "codons": "gAG/g",
+            "protein_id": "ENSP00000312236",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/X",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/18",
+            "transcript_id": "ENST00000354071",
+            "hgvsp": "ENSP00000326002.6:p.Glu23ValfsTer17",
+            "hgvsc": "ENST00000354071.3:c.68_69del",
+            "variant_allele": "-",
+            "codons": "gAG/g",
+            "protein_id": "ENSP00000326002",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/X",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000356906",
+            "variant_allele": "-",
+            "gene_symbol": "NBR2",
+            "gene_id": "ENSG00000198496",
+            "hgnc_id": "20691",
+            "canonical": "1",
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ]
+        },
+        {
+            "exon": "2/23",
+            "transcript_id": "ENST00000357654",
+            "hgvsp": "ENSP00000350283.3:p.Glu23ValfsTer17",
+            "hgvsc": "ENST00000357654.3:c.68_69del",
+            "variant_allele": "-",
+            "codons": "gAG/g",
+            "protein_id": "ENSP00000350283",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/X",
+            "hgnc_id": "1100",
+            "refseq_transcript_ids": [
+                "NM_007294.3"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000460115",
+            "variant_allele": "-",
+            "gene_symbol": "NBR2",
+            "gene_id": "ENSG00000198496",
+            "hgnc_id": "20691",
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ]
+        },
+        {
+            "exon": "2/23",
+            "transcript_id": "ENST00000461221",
+            "hgvsp": "ENSP00000418548.1:p.Glu23ValfsTer17",
+            "hgvsc": "ENST00000461221.1:c.68_69del",
+            "variant_allele": "-",
+            "codons": "gAG/g",
+            "protein_id": "ENSP00000418548",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/X",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant",
+                "NMD_transcript_variant"
+            ]
+        },
+        {
+            "exon": "2/7",
+            "transcript_id": "ENST00000461798",
+            "hgvsp": "ENSP00000417988.1:p.Glu23ValfsTer17",
+            "hgvsc": "ENST00000461798.1:c.68_69del",
+            "variant_allele": "-",
+            "codons": "gAG/g",
+            "protein_id": "ENSP00000417988",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/X",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant",
+                "NMD_transcript_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000467245",
+            "variant_allele": "-",
+            "gene_symbol": "NBR2",
+            "gene_id": "ENSG00000198496",
+            "hgnc_id": "20691",
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ]
+        },
+        {
+            "exon": "2/10",
+            "transcript_id": "ENST00000467274",
+            "hgvsc": "ENST00000467274.1:n.132_133del",
+            "variant_allele": "-",
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "non_coding_transcript_exon_variant"
+            ]
+        },
+        {
+            "exon": "2/22",
+            "transcript_id": "ENST00000468300",
+            "hgvsp": "ENSP00000417148.1:p.Glu23ValfsTer17",
+            "hgvsc": "ENST00000468300.1:c.68_69del",
+            "variant_allele": "-",
+            "codons": "gAG/g",
+            "protein_id": "ENSP00000417148",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/X",
+            "hgnc_id": "1100",
+            "refseq_transcript_ids": [
+                "NM_007299.3"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/10",
+            "transcript_id": "ENST00000470026",
+            "hgvsp": "ENSP00000419274.1:p.Glu23ValfsTer17",
+            "hgvsc": "ENST00000470026.1:c.68_69del",
+            "variant_allele": "-",
+            "codons": "gAG/g",
+            "protein_id": "ENSP00000419274",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/X",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/24",
+            "transcript_id": "ENST00000471181",
+            "hgvsp": "ENSP00000418960.2:p.Glu23ValfsTer17",
+            "hgvsc": "ENST00000471181.2:c.68_69del",
+            "variant_allele": "-",
+            "codons": "gAG/g",
+            "protein_id": "ENSP00000418960",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/X",
+            "hgnc_id": "1100",
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_007300.3"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/9",
+            "transcript_id": "ENST00000476777",
+            "hgvsp": "ENSP00000417554.1:p.Glu23ValfsTer17",
+            "hgvsc": "ENST00000476777.1:c.68_69del",
+            "variant_allele": "-",
+            "codons": "gAG/g",
+            "protein_id": "ENSP00000417554",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/X",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/9",
+            "transcript_id": "ENST00000477152",
+            "hgvsp": "ENSP00000419988.1:p.Glu23ValfsTer17",
+            "hgvsc": "ENST00000477152.1:c.68_69del",
+            "variant_allele": "-",
+            "codons": "gAG/g",
+            "protein_id": "ENSP00000419988",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/X",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/18",
+            "transcript_id": "ENST00000478531",
+            "hgvsp": "ENSP00000420412.1:p.Glu23ValfsTer17",
+            "hgvsc": "ENST00000478531.1:c.68_69del",
+            "variant_allele": "-",
+            "codons": "gAG/g",
+            "protein_id": "ENSP00000420412",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/X",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/5",
+            "transcript_id": "ENST00000489037",
+            "hgvsp": "ENSP00000420781.1:p.Glu23ValfsTer17",
+            "hgvsc": "ENST00000489037.1:c.68_69del",
+            "variant_allele": "-",
+            "codons": "gAG/g",
+            "protein_id": "ENSP00000420781",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/X",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/23",
+            "transcript_id": "ENST00000491747",
+            "hgvsp": "ENSP00000420705.2:p.Glu23ValfsTer17",
+            "hgvsc": "ENST00000491747.2:c.68_69del",
+            "variant_allele": "-",
+            "codons": "gAG/g",
+            "protein_id": "ENSP00000420705",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/X",
+            "hgnc_id": "1100",
+            "refseq_transcript_ids": [
+                "NM_007298.3"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/11",
+            "transcript_id": "ENST00000492859",
+            "hgvsp": "ENSP00000420253.1:p.Glu23ValfsTer17",
+            "hgvsc": "ENST00000492859.1:c.68_69del",
+            "variant_allele": "-",
+            "codons": "gAG/g",
+            "protein_id": "ENSP00000420253",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/X",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant",
+                "NMD_transcript_variant"
+            ]
+        },
+        {
+            "exon": "2/22",
+            "transcript_id": "ENST00000493795",
+            "hgvsc": "ENST00000493795.1:c.-20_-19del",
+            "variant_allele": "-",
+            "protein_id": "ENSP00000418775",
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "5_prime_UTR_variant"
+            ]
+        },
+        {
+            "exon": "2/17",
+            "transcript_id": "ENST00000493919",
+            "hgvsc": "ENST00000493919.1:c.-20_-19del",
+            "variant_allele": "-",
+            "protein_id": "ENSP00000418819",
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "5_prime_UTR_variant"
+            ]
+        },
+        {
+            "exon": "2/10",
+            "transcript_id": "ENST00000494123",
+            "hgvsp": "ENSP00000419103.1:p.Glu23ValfsTer17",
+            "hgvsc": "ENST00000494123.1:c.68_69del",
+            "variant_allele": "-",
+            "codons": "gAG/g",
+            "protein_id": "ENSP00000419103",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/X",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000497488",
+            "hgvsc": "ENST00000497488.1:c.-219+1242_-219+1243del",
+            "variant_allele": "-",
+            "protein_id": "ENSP00000418986",
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "intron_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000586385",
+            "hgvsc": "ENST00000586385.1:c.4+1153_4+1154del",
+            "variant_allele": "-",
+            "protein_id": "ENSP00000465818",
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "intron_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000591534",
+            "hgvsc": "ENST00000591534.1:c.-44+1242_-44+1243del",
+            "variant_allele": "-",
+            "protein_id": "ENSP00000467329",
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "intron_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000591849",
+            "hgvsc": "ENST00000591849.1:c.-99+1242_-99+1243del",
+            "variant_allele": "-",
+            "protein_id": "ENSP00000465347",
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "intron_variant"
+            ]
+        }
+    ],
+    "successfully_annotated": true
+}

--- a/service/src/test/resources/variant/17_g.41276046_41276047insG.json
+++ b/service/src/test/resources/variant/17_g.41276046_41276047insG.json
@@ -1,0 +1,482 @@
+{
+    "variant": "17:g.41276046_41276047insG",
+    "colocatedVariants": [
+        {
+            "dbSnpId": "CI054449"
+        },
+        {
+            "dbSnpId": "CI962220"
+        },
+        {
+            "dbSnpId": "rs1555600897"
+        }
+    ],
+    "originalVariantQuery": "17:g.41276046_41276047insG",
+    "hgvsg": "17:g.41276046_41276047insG",
+    "id": "17:g.41276046_41276047insG",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "17",
+    "start": 41276047,
+    "end": 41276046,
+    "allele_string": "-/G",
+    "strand": 1,
+    "most_severe_consequence": "frameshift_variant",
+    "transcript_consequences": [
+        {
+            "exon": "2/22",
+            "transcript_id": "ENST00000309486",
+            "hgvsc": "ENST00000309486.4:c.-768_-767insC",
+            "variant_allele": "G",
+            "protein_id": "ENSP00000310938",
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "hgnc_id": "1100",
+            "refseq_transcript_ids": [
+                "NM_007297.3"
+            ],
+            "consequence_terms": [
+                "5_prime_UTR_variant"
+            ]
+        },
+        {
+            "exon": "2/19",
+            "transcript_id": "ENST00000346315",
+            "hgvsp": "ENSP00000246907.4:p.Glu23AlafsTer18",
+            "hgvsc": "ENST00000346315.3:c.67_68insC",
+            "variant_allele": "G",
+            "codons": "gag/gCag",
+            "protein_id": "ENSP00000246907",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/AX",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "1/19",
+            "transcript_id": "ENST00000351666",
+            "hgvsp": "ENSP00000338007.3:p.Glu23AlafsTer18",
+            "hgvsc": "ENST00000351666.3:c.67_68insC",
+            "variant_allele": "G",
+            "codons": "gag/gCag",
+            "protein_id": "ENSP00000338007",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/AX",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/22",
+            "transcript_id": "ENST00000352993",
+            "hgvsp": "ENSP00000312236.5:p.Glu23AlafsTer18",
+            "hgvsc": "ENST00000352993.3:c.67_68insC",
+            "variant_allele": "G",
+            "codons": "gag/gCag",
+            "protein_id": "ENSP00000312236",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/AX",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/18",
+            "transcript_id": "ENST00000354071",
+            "hgvsp": "ENSP00000326002.6:p.Glu23AlafsTer18",
+            "hgvsc": "ENST00000354071.3:c.67_68insC",
+            "variant_allele": "G",
+            "codons": "gag/gCag",
+            "protein_id": "ENSP00000326002",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/AX",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000356906",
+            "variant_allele": "G",
+            "gene_symbol": "NBR2",
+            "gene_id": "ENSG00000198496",
+            "hgnc_id": "20691",
+            "canonical": "1",
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ]
+        },
+        {
+            "exon": "2/23",
+            "transcript_id": "ENST00000357654",
+            "hgvsp": "ENSP00000350283.3:p.Glu23AlafsTer18",
+            "hgvsc": "ENST00000357654.3:c.67_68insC",
+            "variant_allele": "G",
+            "codons": "gag/gCag",
+            "protein_id": "ENSP00000350283",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/AX",
+            "hgnc_id": "1100",
+            "refseq_transcript_ids": [
+                "NM_007294.3"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000460115",
+            "variant_allele": "G",
+            "gene_symbol": "NBR2",
+            "gene_id": "ENSG00000198496",
+            "hgnc_id": "20691",
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ]
+        },
+        {
+            "exon": "2/23",
+            "transcript_id": "ENST00000461221",
+            "hgvsp": "ENSP00000418548.1:p.Glu23AlafsTer18",
+            "hgvsc": "ENST00000461221.1:c.67_68insC",
+            "variant_allele": "G",
+            "codons": "gag/gCag",
+            "protein_id": "ENSP00000418548",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/AX",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant",
+                "NMD_transcript_variant"
+            ]
+        },
+        {
+            "exon": "2/7",
+            "transcript_id": "ENST00000461798",
+            "hgvsp": "ENSP00000417988.1:p.Glu23AlafsTer18",
+            "hgvsc": "ENST00000461798.1:c.67_68insC",
+            "variant_allele": "G",
+            "codons": "gag/gCag",
+            "protein_id": "ENSP00000417988",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/AX",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant",
+                "NMD_transcript_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000467245",
+            "variant_allele": "G",
+            "gene_symbol": "NBR2",
+            "gene_id": "ENSG00000198496",
+            "hgnc_id": "20691",
+            "consequence_terms": [
+                "upstream_gene_variant"
+            ]
+        },
+        {
+            "exon": "2/10",
+            "transcript_id": "ENST00000467274",
+            "hgvsc": "ENST00000467274.1:n.131_132insC",
+            "variant_allele": "G",
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "non_coding_transcript_exon_variant"
+            ]
+        },
+        {
+            "exon": "2/22",
+            "transcript_id": "ENST00000468300",
+            "hgvsp": "ENSP00000417148.1:p.Glu23AlafsTer18",
+            "hgvsc": "ENST00000468300.1:c.67_68insC",
+            "variant_allele": "G",
+            "codons": "gag/gCag",
+            "protein_id": "ENSP00000417148",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/AX",
+            "hgnc_id": "1100",
+            "refseq_transcript_ids": [
+                "NM_007299.3"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/10",
+            "transcript_id": "ENST00000470026",
+            "hgvsp": "ENSP00000419274.1:p.Glu23AlafsTer18",
+            "hgvsc": "ENST00000470026.1:c.67_68insC",
+            "variant_allele": "G",
+            "codons": "gag/gCag",
+            "protein_id": "ENSP00000419274",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/AX",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/24",
+            "transcript_id": "ENST00000471181",
+            "hgvsp": "ENSP00000418960.2:p.Glu23AlafsTer18",
+            "hgvsc": "ENST00000471181.2:c.67_68insC",
+            "variant_allele": "G",
+            "codons": "gag/gCag",
+            "protein_id": "ENSP00000418960",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/AX",
+            "hgnc_id": "1100",
+            "canonical": "1",
+            "refseq_transcript_ids": [
+                "NM_007300.3"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/9",
+            "transcript_id": "ENST00000476777",
+            "hgvsp": "ENSP00000417554.1:p.Glu23AlafsTer18",
+            "hgvsc": "ENST00000476777.1:c.67_68insC",
+            "variant_allele": "G",
+            "codons": "gag/gCag",
+            "protein_id": "ENSP00000417554",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/AX",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/9",
+            "transcript_id": "ENST00000477152",
+            "hgvsp": "ENSP00000419988.1:p.Glu23AlafsTer18",
+            "hgvsc": "ENST00000477152.1:c.67_68insC",
+            "variant_allele": "G",
+            "codons": "gag/gCag",
+            "protein_id": "ENSP00000419988",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/AX",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/18",
+            "transcript_id": "ENST00000478531",
+            "hgvsp": "ENSP00000420412.1:p.Glu23AlafsTer18",
+            "hgvsc": "ENST00000478531.1:c.67_68insC",
+            "variant_allele": "G",
+            "codons": "gag/gCag",
+            "protein_id": "ENSP00000420412",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/AX",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/5",
+            "transcript_id": "ENST00000489037",
+            "hgvsp": "ENSP00000420781.1:p.Glu23AlafsTer18",
+            "hgvsc": "ENST00000489037.1:c.67_68insC",
+            "variant_allele": "G",
+            "codons": "gag/gCag",
+            "protein_id": "ENSP00000420781",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/AX",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/23",
+            "transcript_id": "ENST00000491747",
+            "hgvsp": "ENSP00000420705.2:p.Glu23AlafsTer18",
+            "hgvsc": "ENST00000491747.2:c.67_68insC",
+            "variant_allele": "G",
+            "codons": "gag/gCag",
+            "protein_id": "ENSP00000420705",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/AX",
+            "hgnc_id": "1100",
+            "refseq_transcript_ids": [
+                "NM_007298.3"
+            ],
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "exon": "2/11",
+            "transcript_id": "ENST00000492859",
+            "hgvsp": "ENSP00000420253.1:p.Glu23AlafsTer18",
+            "hgvsc": "ENST00000492859.1:c.67_68insC",
+            "variant_allele": "G",
+            "codons": "gag/gCag",
+            "protein_id": "ENSP00000420253",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/AX",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant",
+                "NMD_transcript_variant"
+            ]
+        },
+        {
+            "exon": "2/22",
+            "transcript_id": "ENST00000493795",
+            "hgvsc": "ENST00000493795.1:c.-21_-20insC",
+            "variant_allele": "G",
+            "protein_id": "ENSP00000418775",
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "5_prime_UTR_variant"
+            ]
+        },
+        {
+            "exon": "2/17",
+            "transcript_id": "ENST00000493919",
+            "hgvsc": "ENST00000493919.1:c.-21_-20insC",
+            "variant_allele": "G",
+            "protein_id": "ENSP00000418819",
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "5_prime_UTR_variant"
+            ]
+        },
+        {
+            "exon": "2/10",
+            "transcript_id": "ENST00000494123",
+            "hgvsp": "ENSP00000419103.1:p.Glu23AlafsTer18",
+            "hgvsc": "ENST00000494123.1:c.67_68insC",
+            "variant_allele": "G",
+            "codons": "gag/gCag",
+            "protein_id": "ENSP00000419103",
+            "protein_start": 23,
+            "protein_end": 23,
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "amino_acids": "E/AX",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "frameshift_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000497488",
+            "hgvsc": "ENST00000497488.1:c.-219+1241_-219+1242insC",
+            "variant_allele": "G",
+            "protein_id": "ENSP00000418986",
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "intron_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000586385",
+            "hgvsc": "ENST00000586385.1:c.4+1152_4+1153insC",
+            "variant_allele": "G",
+            "protein_id": "ENSP00000465818",
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "intron_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000591534",
+            "hgvsc": "ENST00000591534.1:c.-44+1241_-44+1242insC",
+            "variant_allele": "G",
+            "protein_id": "ENSP00000467329",
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "intron_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000591849",
+            "hgvsc": "ENST00000591849.1:c.-99+1241_-99+1242insC",
+            "variant_allele": "G",
+            "protein_id": "ENSP00000465347",
+            "gene_symbol": "BRCA1",
+            "gene_id": "ENSG00000012048",
+            "hgnc_id": "1100",
+            "consequence_terms": [
+                "intron_variant"
+            ]
+        }
+    ],
+    "successfully_annotated": true
+}

--- a/service/src/test/resources/variant/7_g.55241617G_A.json
+++ b/service/src/test/resources/variant/7_g.55241617G_A.json
@@ -1,0 +1,117 @@
+{
+    "variant": "7:g.55241617G>A",
+    "colocatedVariants": [
+        {
+            "dbSnpId": "COSV51807743"
+        }
+    ],
+    "originalVariantQuery": "7:g.55241617G>A",
+    "hgvsg": "7:g.55241617G>A",
+    "id": "7:g.55241617G>A",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "7",
+    "start": 55241617,
+    "end": 55241617,
+    "allele_string": "G/A",
+    "strand": 1,
+    "most_severe_consequence": "missense_variant",
+    "transcript_consequences": [
+        {
+            "exon": "18/28",
+            "transcript_id": "ENST00000275493",
+            "hgvsp": "ENSP00000275493.2:p.Val689Met",
+            "hgvsc": "ENST00000275493.2:c.2065G>A",
+            "variant_allele": "A",
+            "codons": "Gtg/Atg",
+            "protein_id": "ENSP00000275493",
+            "protein_start": 689,
+            "protein_end": 689,
+            "gene_symbol": "EGFR",
+            "gene_id": "ENSG00000146648",
+            "amino_acids": "V/M",
+            "hgnc_id": "3236",
+            "canonical": "1",
+            "polyphen_score": 0.905,
+            "polyphen_prediction": "possibly_damaging",
+            "sift_score": 0,
+            "sift_prediction": "deleterious",
+            "refseq_transcript_ids": [
+                "NM_005228.3"
+            ],
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000344576",
+            "variant_allele": "A",
+            "protein_id": "ENSP00000345973",
+            "gene_symbol": "EGFR",
+            "gene_id": "ENSG00000146648",
+            "hgnc_id": "3236",
+            "refseq_transcript_ids": [
+                "NM_201284.1"
+            ],
+            "consequence_terms": [
+                "downstream_gene_variant"
+            ]
+        },
+        {
+            "transcript_id": "ENST00000442591",
+            "hgvsc": "ENST00000442591.1:c.*28+996G>A",
+            "variant_allele": "A",
+            "protein_id": "ENSP00000410031",
+            "gene_symbol": "EGFR",
+            "gene_id": "ENSG00000146648",
+            "hgnc_id": "3236",
+            "consequence_terms": [
+                "intron_variant"
+            ]
+        },
+        {
+            "exon": "18/28",
+            "transcript_id": "ENST00000454757",
+            "hgvsp": "ENSP00000395243.2:p.Val636Met",
+            "hgvsc": "ENST00000454757.2:c.1906G>A",
+            "variant_allele": "A",
+            "codons": "Gtg/Atg",
+            "protein_id": "ENSP00000395243",
+            "protein_start": 636,
+            "protein_end": 636,
+            "gene_symbol": "EGFR",
+            "gene_id": "ENSG00000146648",
+            "amino_acids": "V/M",
+            "hgnc_id": "3236",
+            "polyphen_score": 0.905,
+            "polyphen_prediction": "possibly_damaging",
+            "sift_score": 0,
+            "sift_prediction": "deleterious",
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        },
+        {
+            "exon": "17/26",
+            "transcript_id": "ENST00000455089",
+            "hgvsp": "ENSP00000415559.1:p.Val644Met",
+            "hgvsc": "ENST00000455089.1:c.1930G>A",
+            "variant_allele": "A",
+            "codons": "Gtg/Atg",
+            "protein_id": "ENSP00000415559",
+            "protein_start": 644,
+            "protein_end": 644,
+            "gene_symbol": "EGFR",
+            "gene_id": "ENSG00000146648",
+            "amino_acids": "V/M",
+            "hgnc_id": "3236",
+            "polyphen_score": 0.72,
+            "polyphen_prediction": "possibly_damaging",
+            "sift_score": 0.01,
+            "sift_prediction": "deleterious",
+            "consequence_terms": [
+                "missense_variant"
+            ]
+        }
+    ],
+    "successfully_annotated": true
+}

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/SignalQueryController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/SignalQueryController.java
@@ -32,11 +32,11 @@ public class SignalQueryController
         produces = "application/json")
     public List<SignalQuery> searchSignalByKeywordGET(
         @ApiParam(
-            value="keyword. For example BRCA; 13:32906640-32906640; 13:g.32890665G>A",
+            value="keyword. For example BRCA; BRAF V600; 13:32906640-32906640; 13:g.32890665G>A",
             required = true)
         @PathVariable String keyword,
         @RequestParam(required = false)
-        @ApiParam(value="Max number matching results to return")
+        @ApiParam(value="Max number of matching results to return")
             Integer limit
     ) {
         return this.signalQueryService.search(keyword, limit);

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
@@ -60,6 +60,7 @@ public class ApiObjectMapper extends ObjectMapper
         mixinMap.put(AlleleFrequency.class, AlleleFrequencyMixin.class);
         mixinMap.put(IntergenicConsequences.class, IntergenicConsequencesMixin.class);
         mixinMap.put(SignalMutation.class, SignalMutationMixin.class);
+        mixinMap.put(SignalQuery.class, SignalQueryMixin.class);
         mixinMap.put(CountByTumorType.class, CountByTumorTypeMixin.class);
         super.setMixIns(mixinMap);
     }

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/SignalQueryMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/SignalQueryMixin.java
@@ -1,0 +1,30 @@
+package org.cbioportal.genome_nexus.web.mixin;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.annotations.ApiModelProperty;
+import org.cbioportal.genome_nexus.model.SignalMatchType;
+import org.cbioportal.genome_nexus.model.SignalQueryType;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SignalQueryMixin {
+    @ApiModelProperty("Query Type")
+    private SignalQueryType queryType;
+
+    @ApiModelProperty("Match Type")
+    private SignalMatchType matchType;
+
+    @ApiModelProperty("Matching Hugo Gene Symbol (e.g: BRCA2, BRAF)")
+    private String hugoSymbol;
+
+    @ApiModelProperty("Matching Alteration (e.g: V600E)")
+    private String alteration;
+
+    @ApiModelProperty("Matching Region (e.g: 13:32968940-32968940)")
+    private String region;
+
+    @ApiModelProperty("Matching HGVSG Variant (e.g: 17:g.37880220T>C)")
+    private String variant;
+
+    @ApiModelProperty("Optional free-form text")
+    private String description;
+}


### PR DESCRIPTION
Related to knowledgesystems/signal#65

- Enable basic search by alteration (e.g. `V600`)
- Break down `SignalQueryServiceImpl` into multiple components.