### PR TITLE
fix my variant info missing in BRCA2 mutations

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/MyVariantInfoAnnotationEnricher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/MyVariantInfoAnnotationEnricher.java
@@ -52,7 +52,9 @@ public class MyVariantInfoAnnotationEnricher extends BaseAnnotationEnricher
         try {
             List<MyVariantInfo> myVariantInfo = myVariantInfoService.getMyVariantInfoByAnnotation(annotations);
             Map<String, MyVariantInfo> hgvsToMyVariantInfoMap =
-                myVariantInfo.stream().collect(Collectors.toMap(MyVariantInfo::getHgvs, v -> v));
+                myVariantInfo.stream()
+                    .filter(info -> info.getHgvs() != null)
+                    .collect(Collectors.toMap(MyVariantInfo::getHgvs, v -> v));
 
             for (VariantAnnotation annotation: annotations) {
                 this.enrichAnnotationWithMyVariantInfo(annotation,

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/BaseVariantAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/BaseVariantAnnotationServiceImpl.java
@@ -229,7 +229,7 @@ public abstract class BaseVariantAnnotationServiceImpl implements VariantAnnotat
                 postEnrichmentService.enrichAnnotations(variantAnnotations);
             }
         } catch (VariantAnnotationWebServiceException e) {
-            LOG.warn(e.getLocalizedMessage());
+            LOG.warn(e.getLocalizedMessage(), e);
         }
 
         return variantAnnotations;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/MyVariantInfoServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/MyVariantInfoServiceImpl.java
@@ -65,7 +65,9 @@ public class MyVariantInfoServiceImpl implements MyVariantInfoService
             myVariantInfos = this.getMyVariantInfoByMyVariantInfoVariant(queryVariants);
             // manually set the original hgvs variant field
             for (MyVariantInfo myVariantInfo: myVariantInfos) {
-                myVariantInfo.setHgvs(queryToVariant.get(myVariantInfo.getQuery()));
+                // myVariantInfo.getVariant() will return my_variant_info query id (e.g. chr7:g.140453136A>T)
+                // queryToVariant.get() will return genome nexus query id (e.g. 7:g.140453136A>T)
+                myVariantInfo.setHgvs(queryToVariant.get(myVariantInfo.getVariant()));
             }
         } catch (MyVariantInfoWebServiceException e) {
             LOG.warn(e.getResponseBody());


### PR DESCRIPTION
**Problem**
https://www.signaldb.org/gene/BRCA2
All mutations are missing my_variant_info in annotation. 
Fix: https://github.com/genome-nexus/genome-nexus/issues/469

**Reason**
Some variants don't have `query` in `my_variant_info` response(e.g. expected to be chr7:g.140453136A>T), but we use this field to match our query(e.g. expected to be 7:g.140453136A>T)

**Solution**
Using `variant` instead

**Example**
POST:
[{"chromosome":"13","start":32972777,"end":32972777,"referenceAllele":"C","variantAllele":"G"},{"chromosome":"13","start":32972893,"end":32972893,"referenceAllele":"A","variantAllele":"-"},{"chromosome":"13","start":32890607,"end":32890607,"referenceAllele":"G","variantAllele":"T"},{"chromosome":"13","start":32911686,"end":32911686,"referenceAllele":"T","variantAllele":"-"}]
can't get my variant info, but remove the last one should be able to work