### PR TITLE
Make keyword request param instead of path variable

### DIFF
--- a/web/src/main/java/org/cbioportal/genome_nexus/web/SignalQueryController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/SignalQueryController.java
@@ -27,17 +27,16 @@ public class SignalQueryController
     }
 
     @ApiOperation(value = "Performs search by gene, protein change, variant or region.")
-    @RequestMapping(value = "/signal/search/{keyword:.+}",
+    @RequestMapping(value = "/signal/search",
         method = RequestMethod.GET,
         produces = "application/json")
     public List<SignalQuery> searchSignalByKeywordGET(
         @ApiParam(
             value="keyword. For example BRCA; BRAF V600; 13:32906640-32906640; 13:g.32890665G>A",
             required = true)
-        @PathVariable String keyword,
-        @RequestParam(required = false)
+        @RequestParam String keyword,
         @ApiParam(value="Max number of matching results to return")
-            Integer limit
+        @RequestParam(required = false) Integer limit
     ) {
         return this.signalQueryService.search(keyword, limit);
     }


### PR DESCRIPTION
Fix knowledgesystems/signal/issues/80

Looks like the auto generated API client cannot auto escape problematic characters when using a path variable. Using a request param fixes the problem.