### PR TITLE
Create mongodb index by region to speed up signal queries

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/SignalMutation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/SignalMutation.java
@@ -1,11 +1,13 @@
 package org.cbioportal.genome_nexus.model;
 
+import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.util.List;
 
 @Document(collection = "signal.mutation")
+@CompoundIndex(def = "{'chromosome': 1, 'start_position': 1, 'end_position': 1}")
 public class SignalMutation {
     @Field("hugo_gene_symbol")
     private String hugoGeneSymbol;

--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/SignalMutationRepository.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/SignalMutationRepository.java
@@ -1,7 +1,6 @@
 package org.cbioportal.genome_nexus.persistence;
 
 import org.cbioportal.genome_nexus.model.SignalMutation;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.List;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/SignalAnnotationEnricher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/SignalAnnotationEnricher.java
@@ -1,9 +1,10 @@
 package org.cbioportal.genome_nexus.service.enricher;
 
+import org.cbioportal.genome_nexus.component.annotation.GenomicLocationResolver;
+import org.cbioportal.genome_nexus.model.GenomicLocation;
 import org.cbioportal.genome_nexus.model.SignalAnnotation;
 import org.cbioportal.genome_nexus.model.SignalMutation;
 import org.cbioportal.genome_nexus.model.VariantAnnotation;
-import org.cbioportal.genome_nexus.service.AnnotationEnricher;
 import org.cbioportal.genome_nexus.service.SignalMutationService;
 
 import java.util.List;
@@ -11,6 +12,7 @@ import java.util.List;
 public class SignalAnnotationEnricher extends BaseAnnotationEnricher
 {
     private final SignalMutationService signalMutationService;
+    private final GenomicLocationResolver genomicLocationResolver;
 
     public SignalAnnotationEnricher(
         String id,
@@ -18,18 +20,15 @@ public class SignalAnnotationEnricher extends BaseAnnotationEnricher
     ) {
         super(id);
         this.signalMutationService = signalMutationService;
+        this.genomicLocationResolver = new GenomicLocationResolver();
     }
 
     @Override
     public void enrich(VariantAnnotation annotation) {
         SignalAnnotation signalAnnotation = new SignalAnnotation();
-        String hgvsg = annotation.getHgvsg();
-
-        if (hgvsg != null) {
-            List<SignalMutation> mutations = this.signalMutationService.getSignalMutationsByHgvsg(hgvsg);
-            signalAnnotation.setAnnotation(mutations);
-        }
-
+        GenomicLocation genomicLocation = this.genomicLocationResolver.resolve(annotation);
+        List<SignalMutation> mutations = this.signalMutationService.getSignalMutations(genomicLocation);
+        signalAnnotation.setAnnotation(mutations);
         annotation.setSignalAnnotation(signalAnnotation);
     }
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/SignalMutationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/SignalMutationServiceImpl.java
@@ -50,24 +50,19 @@ public class SignalMutationServiceImpl implements SignalMutationService
     public List<SignalMutation> getSignalMutationsByHgvsg(String hgvsg) {
         GenomicLocation genomicLocation = this.notationConverter.hgvsgToGenomicLocation(hgvsg);
         GenomicVariant gv = GenomicVariantUtil.fromHgvs(hgvsg);
+
         if (genomicLocation == null) {
             return Collections.emptyList();
         }
         if (gv.getType() == GenomicVariant.Type.INDEL || gv.getType() == GenomicVariant.Type.DELETION) {
-            return this.signalMutationRepository.findByChromosomeAndStartPositionAndEndPositionAndVariantAllele(
-                genomicLocation.getChromosome(),
-                genomicLocation.getStart().longValue(),
-                genomicLocation.getEnd().longValue(),
-                genomicLocation.getVariantAllele()
-            );            
-        } else {
-            return this.signalMutationRepository.findByChromosomeAndStartPositionAndEndPositionAndReferenceAlleleAndVariantAllele(
-                genomicLocation.getChromosome(),
-                genomicLocation.getStart().longValue(),
-                genomicLocation.getEnd().longValue(),
-                genomicLocation.getReferenceAllele(),
-                genomicLocation.getVariantAllele()
+            return this.signalMutationRepository.findByChromosomeAndStartPositionAndEndPositionAndVariantAllele(	
+                genomicLocation.getChromosome(),	
+                genomicLocation.getStart().longValue(),	
+                genomicLocation.getEnd().longValue(),	
+                genomicLocation.getVariantAllele()	
             );
+        } else {
+            return this.getSignalMutations(genomicLocation);	
         }
     }
 
@@ -76,7 +71,6 @@ public class SignalMutationServiceImpl implements SignalMutationService
         if (genomicLocation == null) {
             return Collections.emptyList();
         }
-
         return this.signalMutationRepository.findByChromosomeAndStartPositionAndEndPositionAndReferenceAlleleAndVariantAllele(
             genomicLocation.getChromosome(),
             genomicLocation.getStart().longValue(),


### PR DESCRIPTION
Fix: https://github.com/cBioPortal/cbioportal/issues/8318

Build signal query index by `chromosome`, `start` and `end`. 
10k queries take more than 10 minutes before, and take about 30s now.
