### PR TITLE
Add clinvar to genome nexus

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/Clinvar.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/Clinvar.java
@@ -1,0 +1,95 @@
+package org.cbioportal.genome_nexus.model;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Document(collection="clinvar.mutation")
+public class Clinvar {
+    @Field(value = "chromosome")
+    private String chromosome;
+
+    @Field(value = "start_position")
+    private Integer startPosition;
+
+    @Field(value = "end_position")
+    private Integer endPosition;
+
+    @Field(value = "reference_allele")
+    private String referenceAllele;
+
+    @Field(value = "alternate_allele")
+    private String alternateAllele;
+
+    @Field(value = "clinvar_id")
+    private Integer clinvarId;
+
+    @Field(value = "clnsig")
+    private String clinicalSignificance;
+
+    @Field(value = "clnsigconf")
+    private String conflictingClinicalSignificance;
+
+    public String getChromosome() {
+        return chromosome;
+    }
+
+    public void setChromosome(String chromosome) {
+        this.chromosome = chromosome;
+    }
+
+    public Integer getStartPosition() {
+        return startPosition;
+    }
+
+    public void setStartPosition(Integer startPosition) {
+        this.startPosition = startPosition;
+    }
+
+    public Integer getEndPosition() {
+        return endPosition;
+    }
+
+    public void setEndPosition(Integer endPosition) {
+        this.endPosition = endPosition;
+    }
+
+    public String getReferenceAllele() {
+        return referenceAllele;
+    }
+
+    public void setReferenceAllele(String referenceAllele) {
+        this.referenceAllele = referenceAllele;
+    }
+
+    public String getAlternateAllele() {
+        return alternateAllele;
+    }
+
+    public void setAlternateAllele(String alternateAllele) {
+        this.alternateAllele = alternateAllele;
+    }
+
+    public Integer getClinvarId() {
+        return clinvarId;
+    }
+
+    public void setClinvarId(Integer clinvarId) {
+        this.clinvarId = clinvarId;
+    }
+
+    public String getClinicalSignificance() {
+        return clinicalSignificance;
+    }
+
+    public void setClinicalSignificance(String clinicalSignificance) {
+        this.clinicalSignificance = clinicalSignificance;
+    }
+
+    public String getConflictingClinicalSignificance() {
+        return conflictingClinicalSignificance;
+    }
+
+    public void setConflictingClinicalSignificance(String conflictingClinicalSignificance) {
+        this.conflictingClinicalSignificance = conflictingClinicalSignificance;
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/ClinvarAnnotation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/ClinvarAnnotation.java
@@ -1,0 +1,17 @@
+package org.cbioportal.genome_nexus.model;
+
+public class ClinvarAnnotation {
+    private Clinvar annotation;
+
+    public ClinvarAnnotation(Clinvar annotation) {
+        this.annotation = annotation;
+    }
+
+    public Clinvar getAnnotation() {
+        return annotation;
+    }
+
+    public void setAnnotation(Clinvar annotation) {
+        this.annotation = annotation;
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
@@ -71,6 +71,7 @@ public class VariantAnnotation
     private HotspotAnnotation hotspotAnnotation;
     private PtmAnnotation ptmAnnotation;
     private OncokbAnnotation oncokbAnnotation;
+    private ClinvarAnnotation clinvarAnnotation;
     private VariantAnnotationSummary annotationSummary;
     private SignalAnnotation signalAnnotation;
     private String originalVariantQuery;
@@ -318,6 +319,14 @@ public class VariantAnnotation
 
     public void setOncokbAnnotation(OncokbAnnotation oncokbAnnotation) {
         this.oncokbAnnotation = oncokbAnnotation;
+    }
+
+    public ClinvarAnnotation getClinvarAnnotation() {
+        return clinvarAnnotation;
+    }
+
+    public void setClinvarAnnotation(ClinvarAnnotation clinvarAnnotation) {
+        this.clinvarAnnotation = clinvarAnnotation;
     }
 
     public void setSuccessfullyAnnotated(Boolean successfullyAnnotated) {

--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/ClinvarVariantAnnotationRepository.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/ClinvarVariantAnnotationRepository.java
@@ -1,0 +1,13 @@
+package org.cbioportal.genome_nexus.persistence;
+
+import org.cbioportal.genome_nexus.model.Clinvar;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ClinvarVariantAnnotationRepository extends MongoRepository<Clinvar, String> {
+    Clinvar findByChromosomeAndStartPositionAndEndPositionAndReferenceAlleleAndAlternateAllele(
+        String chromosome,
+        Integer startPosition,
+        Integer endPosition,
+        String referenceAllele,
+        String alternateAllele);
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/ClinvarVariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/ClinvarVariantAnnotationService.java
@@ -1,0 +1,8 @@
+package org.cbioportal.genome_nexus.service;
+
+import org.cbioportal.genome_nexus.model.Clinvar;
+import org.cbioportal.genome_nexus.model.GenomicLocation;
+
+public interface ClinvarVariantAnnotationService {
+    Clinvar getClinvarVariantAnnotationByGenomicLocation(GenomicLocation genomicLocation);
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/ClinvarVariantAnnotationEnricher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/enricher/ClinvarVariantAnnotationEnricher.java
@@ -1,0 +1,32 @@
+package org.cbioportal.genome_nexus.service.enricher;
+
+import org.cbioportal.genome_nexus.component.annotation.GenomicLocationResolver;
+import org.cbioportal.genome_nexus.model.Clinvar;
+import org.cbioportal.genome_nexus.model.ClinvarAnnotation;
+import org.cbioportal.genome_nexus.model.GenomicLocation;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.ClinvarVariantAnnotationService;
+
+public class ClinvarVariantAnnotationEnricher extends BaseAnnotationEnricher
+{
+    private ClinvarVariantAnnotationService clinvarVariantAnnotationService;
+    private final GenomicLocationResolver genomicLocationResolver;
+
+    public ClinvarVariantAnnotationEnricher(
+        String id,
+        ClinvarVariantAnnotationService clinvarVariantAnnotationService
+    ) {
+        super(id);
+        this.clinvarVariantAnnotationService = clinvarVariantAnnotationService;
+        this.genomicLocationResolver = new GenomicLocationResolver();
+    }
+
+    @Override
+    public void enrich(VariantAnnotation annotation)
+    {
+        GenomicLocation genomicLocation = this.genomicLocationResolver.resolve(annotation);
+        Clinvar clinvar = this.clinvarVariantAnnotationService.getClinvarVariantAnnotationByGenomicLocation(genomicLocation);
+        ClinvarAnnotation clinvarAnnotation = new ClinvarAnnotation(clinvar);
+        annotation.setClinvarAnnotation(clinvarAnnotation);
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/BaseVariantAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/BaseVariantAnnotationServiceImpl.java
@@ -63,6 +63,7 @@ public abstract class BaseVariantAnnotationServiceImpl implements VariantAnnotat
     private final PostTranslationalModificationService postTranslationalModificationService;
     private final SignalMutationService signalMutationService;
     private final OncokbService oncokbService;
+    private final ClinvarVariantAnnotationService clinvarVariantAnnotationService;
 
     public BaseVariantAnnotationServiceImpl(
         BaseCachedExternalResourceFetcher<VariantAnnotation, VariantAnnotationRepository> resourceFetcher,
@@ -74,7 +75,8 @@ public abstract class BaseVariantAnnotationServiceImpl implements VariantAnnotat
         VariantAnnotationSummaryService variantAnnotationSummaryService,
         PostTranslationalModificationService postTranslationalModificationService,
         SignalMutationService signalMutationService,
-        OncokbService oncokbService
+        OncokbService oncokbService,
+        ClinvarVariantAnnotationService clinvarVariantAnnotationService
     ) {
         this.resourceFetcher = resourceFetcher;
         this.ensemblService = ensemblService;
@@ -86,6 +88,7 @@ public abstract class BaseVariantAnnotationServiceImpl implements VariantAnnotat
         this.postTranslationalModificationService = postTranslationalModificationService;
         this.signalMutationService = signalMutationService;
         this.oncokbService = oncokbService;
+        this.clinvarVariantAnnotationService = clinvarVariantAnnotationService;
     }
 
     // Needs to be overridden to support normalizing variants
@@ -307,6 +310,13 @@ public abstract class BaseVariantAnnotationServiceImpl implements VariantAnnotat
                     variantAnnotationSummaryService,
                     oncokbToken
                 )
+            );
+        }
+
+        if (fields != null && fields.contains("clinvar"))
+        {
+            postEnrichmentService.registerEnricher(
+                new ClinvarVariantAnnotationEnricher("clinvar", clinvarVariantAnnotationService)
             );
         }
 

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/ClinvarVariantAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/ClinvarVariantAnnotationServiceImpl.java
@@ -1,0 +1,23 @@
+package org.cbioportal.genome_nexus.service.internal;
+
+import org.cbioportal.genome_nexus.model.Clinvar;
+import org.cbioportal.genome_nexus.model.GenomicLocation;
+import org.cbioportal.genome_nexus.persistence.ClinvarVariantAnnotationRepository;
+import org.cbioportal.genome_nexus.service.ClinvarVariantAnnotationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ClinvarVariantAnnotationServiceImpl implements ClinvarVariantAnnotationService {
+    private final ClinvarVariantAnnotationRepository clinvarRepository;
+
+    @Autowired
+    public ClinvarVariantAnnotationServiceImpl(ClinvarVariantAnnotationRepository clinvarRepository) {
+        this.clinvarRepository = clinvarRepository;
+    }
+
+    @Override
+    public Clinvar getClinvarVariantAnnotationByGenomicLocation(GenomicLocation genomicLocation) {
+        return this.clinvarRepository.findByChromosomeAndStartPositionAndEndPositionAndReferenceAlleleAndAlternateAllele(genomicLocation.getChromosome(), genomicLocation.getStart(), genomicLocation.getEnd(), genomicLocation.getReferenceAllele(), genomicLocation.getVariantAllele());
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/DbsnpVariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/DbsnpVariantAnnotationService.java
@@ -59,7 +59,8 @@ public class DbsnpVariantAnnotationService extends BaseVariantAnnotationServiceI
         @Lazy VariantAnnotationSummaryService variantAnnotationSummaryService,
         @Lazy PostTranslationalModificationService postTranslationalModificationService,
         @Lazy SignalMutationService signalMutationService,
-        @Lazy OncokbService oncokbService
+        @Lazy OncokbService oncokbService,
+        @Lazy ClinvarVariantAnnotationService clinvarVariantAnnotationService
     ) {
         super(
             cachedVariantIdAnnotationFetcher,
@@ -71,7 +72,8 @@ public class DbsnpVariantAnnotationService extends BaseVariantAnnotationServiceI
             variantAnnotationSummaryService,
             postTranslationalModificationService,
             signalMutationService,
-            oncokbService
+            oncokbService,
+            clinvarVariantAnnotationService
         );
     }
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HgvsVariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HgvsVariantAnnotationService.java
@@ -61,7 +61,8 @@ public class HgvsVariantAnnotationService extends BaseVariantAnnotationServiceIm
         @Lazy VariantAnnotationSummaryService variantAnnotationSummaryService,
         @Lazy PostTranslationalModificationService postTranslationalModificationService,
         @Lazy SignalMutationService signalMutationService,
-        @Lazy OncokbService oncokbService
+        @Lazy OncokbService oncokbService,
+        @Lazy ClinvarVariantAnnotationService clinvarVariantAnnotationService
     ) {
         super(
             cachedVariantAnnotationFetcher,
@@ -73,7 +74,8 @@ public class HgvsVariantAnnotationService extends BaseVariantAnnotationServiceIm
             variantAnnotationSummaryService,
             postTranslationalModificationService,
             signalMutationService,
-            oncokbService
+            oncokbService,
+            clinvarVariantAnnotationService
         );
 
         this.notationConverter = notationConverter;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/RegionVariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/RegionVariantAnnotationService.java
@@ -59,7 +59,8 @@ public class RegionVariantAnnotationService extends BaseVariantAnnotationService
         @Lazy VariantAnnotationSummaryService variantAnnotationSummaryService,
         @Lazy PostTranslationalModificationService postTranslationalModificationService,
         @Lazy SignalMutationService signalMutationService,
-        @Lazy OncokbService oncokbService
+        @Lazy OncokbService oncokbService,
+        @Lazy ClinvarVariantAnnotationService clinvarVariantAnnotationService
     ) {
         super(
             cachedVariantRegionAnnotationFetcher,
@@ -71,7 +72,8 @@ public class RegionVariantAnnotationService extends BaseVariantAnnotationService
             variantAnnotationSummaryService,
             postTranslationalModificationService,
             signalMutationService,
-            oncokbService
+            oncokbService,
+            clinvarVariantAnnotationService
         );
     }
 }


### PR DESCRIPTION
Fix: https://github.com/knowledgesystems/signal/issues/104

Query "clinvar" by annotation enpoints.

For example:
`1,955619,955619,G,C`:
```
"clinvarAnnotation": {
    "annotation": {
      "chromosome": "1",
      "startPosition": 955619,
      "endPosition": 955619,
      "referenceAllele": "G",
      "alternateAllele": "C",
      "clinvarId": 210112,
      "clinicalSignificance": "Conflicting_interpretations_of_pathogenicity",
      "conflictingClinicalSignificance": "Benign(1),Likely_benign(2),Uncertain_significance(1)"
    }
  },
```
