### PR TITLE
Validate Reference_Allele string when annotating (if present)

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/GenomicLocation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/GenomicLocation.java
@@ -63,4 +63,66 @@ public class GenomicLocation
     public String toString() {
         return this.getChromosome() + "," + this.getStart() + "," + this.getEnd() + "," + this.getReferenceAllele() + "," + this.getVariantAllele();
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof GenomicLocation)) {
+            return false;
+        }
+        GenomicLocation gl = (GenomicLocation)obj;
+        // compare start
+        if (this.start == null && gl.start != null) {
+            return false;
+        }
+        if (!this.start.equals(gl.start)) {
+            return false;
+        }
+        // compare end
+        if (this.end == null && gl.end != null) {
+            return false;
+        }
+        if (!this.end.equals(gl.end)) {
+            return false;
+        }
+        // compare chromosome
+        if (this.chromosome == null && gl.chromosome != null) {
+            return false;
+        }
+        if (!this.chromosome.equals(gl.chromosome)) {
+            return false;
+        }
+        // compare referenceAllele
+        if (this.referenceAllele == null && gl.referenceAllele != null) {
+            return false;
+        }
+        if (!this.referenceAllele.equals(gl.referenceAllele)) {
+            return false;
+        }
+        // compare variantAllele
+        if (this.variantAllele == null && gl.variantAllele != null) {
+            return false;
+        }
+        if (!this.variantAllele.equals(gl.variantAllele)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        if (this == null) {
+            return 0;
+        }
+        int hash = 7;
+        hash =  31 * hash + (start == null ? 0 : start.hashCode());
+        hash =  31 * hash + (end == null ? 0 : end.hashCode());
+        hash =  31 * hash + (chromosome == null ? 0 : chromosome.hashCode());
+        hash =  31 * hash + (referenceAllele == null ? 0 : referenceAllele.hashCode());
+        hash =  31 * hash + (variantAllele == null ? 0 : variantAllele.hashCode());
+        return hash;
+    }
+
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/SelectedAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/SelectedAnnotationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2021 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -39,15 +39,18 @@ import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebService
 
 import java.util.*;
 
-/**
- * @author Benjamin Gross
- */
-public interface VariantAnnotationService
-{
-    VariantAnnotation getAnnotation(String variant)
-        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException;
-    List<VariantAnnotation> getAnnotations(List<String> variants);
-    VariantAnnotation getAnnotation(String variant, String isoformOverrideSource, Map<String, String> token, List<String> fields)
-        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException;
-    List<VariantAnnotation> getAnnotations(List<String> variants, String isoformOverrideSource, Map<String, String> token, List<String> fields);
+public interface SelectedAnnotationService {
+
+    public VariantAnnotation getAnnotation(
+            String variant,
+            String isoformOverrideSource,
+            Map<String, String> token,
+            List<String> fields) throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException;
+
+    public List<VariantAnnotation> getAnnotations(
+            List<String> variants,
+            String isoformOverrideSource,
+            Map<String, String> token,
+            List<String> fields) throws VariantAnnotationNotFoundException, VariantAnnotationQueryMixedFormatException, VariantAnnotationWebServiceException;
+
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/exception/VariantAnnotationQueryMixedFormatException.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/exception/VariantAnnotationQueryMixedFormatException.java
@@ -1,0 +1,21 @@
+package org.cbioportal.genome_nexus.service.exception;
+
+public class VariantAnnotationQueryMixedFormatException extends Exception {
+
+    public VariantAnnotationQueryMixedFormatException() {
+        super();
+    }
+
+    public VariantAnnotationQueryMixedFormatException(String message) {
+        super(message);
+    }
+
+    public VariantAnnotationQueryMixedFormatException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public VariantAnnotationQueryMixedFormatException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/BaseVariantAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/BaseVariantAnnotationServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2015 - 2021 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -161,7 +161,9 @@ public abstract class BaseVariantAnnotationServiceImpl implements VariantAnnotat
         }
 
         try {
-            return variantAnnotation.get();
+            VariantAnnotation returnValue = variantAnnotation.get();
+            returnValue.setOriginalVariantQuery(variant);
+            return returnValue;
         } catch (NoSuchElementException e) {
             throw new VariantAnnotationNotFoundException(normalizedVariant);
         }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 - 2021 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -59,12 +59,12 @@ public class CancerHotspotServiceImpl implements CancerHotspotService
 
     @Autowired
     public CancerHotspotServiceImpl(HotspotRepository hotspotRepository,
-                                    VariantAnnotationService hgvsVariantAnnotationService,
+                                    VariantAnnotationService verifiedHgvsVariantAnnotationService,
                                     HotspotFilter hotspotFilter,
                                     NotationConverter notationConverter)
     {
         this.hotspotRepository = hotspotRepository;
-        this.variantAnnotationService = hgvsVariantAnnotationService;
+        this.variantAnnotationService = verifiedHgvsVariantAnnotationService;
         this.hotspotFilter = hotspotFilter;
         this.notationConverter = notationConverter;
     }
@@ -97,16 +97,16 @@ public class CancerHotspotServiceImpl implements CancerHotspotService
     {
         return this.hotspotRepository.findAll();
     }
-   
+
     public List<AggregatedHotspots> getHotspotsByTranscriptIds(List<String> transcriptIds) throws CancerHotspotsWebServiceException
     {
         List<AggregatedHotspots> hotspots = new ArrayList<>();
         for (String transcriptId : transcriptIds) {
             AggregatedHotspots aggregatedHotspots = new AggregatedHotspots();
-            
+
             // add protein location information
             aggregatedHotspots.setTranscriptId(transcriptId);
-            
+
             // query hotspots service by protein location
             aggregatedHotspots.setHotspots(this.getHotspots(transcriptId));
             hotspots.add(aggregatedHotspots);
@@ -218,7 +218,7 @@ public class CancerHotspotServiceImpl implements CancerHotspotService
             aggregatedHotspots.setHotspots(hotspotFilter.proteinLocationHotspotsFilter(this.getHotspots(proteinLocation.getTranscriptId()), proteinLocation));
             hotspots.add(aggregatedHotspots);
         }
-        
+
         return hotspots;
     }
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/MutationAssessorServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/MutationAssessorServiceImpl.java
@@ -28,10 +28,10 @@ public class MutationAssessorServiceImpl implements MutationAssessorService
 
     @Autowired
     public MutationAssessorServiceImpl(CachedMutationAssessorFetcher cachedExternalResourceFetcher,
-                                       VariantAnnotationService hgvsVariantAnnotationService)
+                                       VariantAnnotationService verifiedHgvsVariantAnnotationService)
     {
         this.cachedExternalResourceFetcher = cachedExternalResourceFetcher;
-        this.variantAnnotationService = hgvsVariantAnnotationService;
+        this.variantAnnotationService = verifiedHgvsVariantAnnotationService;
     }
 
     /**

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/NucleotideContextServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/NucleotideContextServiceImpl.java
@@ -29,10 +29,10 @@ public class NucleotideContextServiceImpl implements NucleotideContextService
 
     @Autowired
     public NucleotideContextServiceImpl(CachedNucleotideContextFetcher cachedExternalResourceFetcher,
-                                       VariantAnnotationService hgvsVariantAnnotationService)
+                                       VariantAnnotationService verifiedHgvsVariantAnnotationService)
     {
         this.cachedExternalResourceFetcher = cachedExternalResourceFetcher;
-        this.variantAnnotationService = hgvsVariantAnnotationService;
+        this.variantAnnotationService = verifiedHgvsVariantAnnotationService;
     }
 
     /**

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/SelectedAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/SelectedAnnotationServiceImpl.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2021 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal Genome Nexus.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.genome_nexus.service;
+
+import org.cbioportal.genome_nexus.component.annotation.NotationConverter;
+import org.cbioportal.genome_nexus.model.GenomicLocation;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.GenomicLocationAnnotationService;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationQueryMixedFormatException;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
+import org.cbioportal.genome_nexus.service.internal.HgvsVariantAnnotationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.logging.Log;
+
+@Service
+public class SelectedAnnotationServiceImpl implements SelectedAnnotationService {
+    private final VariantAnnotationService verifiedHgvsVariantAnnotationService;
+    private final GenomicLocationAnnotationService genomicLocationAnnotationService;
+    private final NotationConverter notationConverter;
+    private final Boolean isRegionAnnotationEnabled;
+
+private static final Log LOG = LogFactory.getLog(SelectedAnnotationServiceImpl.class);
+
+    @Autowired
+    public SelectedAnnotationServiceImpl(
+            VariantAnnotationService verifiedHgvsVariantAnnotationService,
+            GenomicLocationAnnotationService genomicLocationAnnotationServiceImpl,
+            NotationConverter notationConverter,
+            @Value("${gn_vep.region.url:}")
+            String vepRegionUrl) {
+        this.verifiedHgvsVariantAnnotationService = verifiedHgvsVariantAnnotationService;
+        this.genomicLocationAnnotationService = genomicLocationAnnotationServiceImpl;
+        this.notationConverter = notationConverter;
+        this.isRegionAnnotationEnabled = vepRegionUrl != null && vepRegionUrl.length() > 0;
+    }
+
+    @Override
+    public VariantAnnotation getAnnotation(
+            String variant,
+            String isoformOverrideSource,
+            Map<String, String> token,
+            List<String> fields) throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException {
+        if (needToConvertHgvsToRegionForAnnotation(variant)) {
+            GenomicLocation variantAsGenomicLocation = notationConverter.hgvsgToGenomicLocation(variant);
+            // TODO: we should provide a getAnnotation() call to genomicLocationAnnotationService which accepts GenomicLocation
+            return genomicLocationAnnotationService.getAnnotation(variantAsGenomicLocation.toString(), isoformOverrideSource, token, fields);
+        } else {
+            // TODO: do we support configuration of Genome-Nexus where non-hgvs variants will arrive at /annotation/{variant} endpoint and they get sent to a (non-hgvs) vep.url ? If not, make this service hgvs only.
+            return verifiedHgvsVariantAnnotationService.getAnnotation(variant, isoformOverrideSource, token, fields);
+        }
+    }
+
+    @Override
+    public List<VariantAnnotation> getAnnotations(
+            List<String> variants,
+            String isoformOverrideSource,
+            Map<String, String> token,
+            List<String> fields) throws VariantAnnotationNotFoundException, VariantAnnotationQueryMixedFormatException, VariantAnnotationWebServiceException {
+        if (needToConvertHgvsToRegionForAnnotation(variants)) {
+            List<GenomicLocation> variantsAsGenomicLocations = notationConverter.hgvsgToGenomicLocations(variants);
+            return genomicLocationAnnotationService.getAnnotations(variantsAsGenomicLocations, isoformOverrideSource, token, fields);
+        } else {
+            // all variants will be sent to the hgvsAnnotationService, so non-hgvs formatted variants will fail annotation and hgvs formatted variants may succeed
+            // TODO: do we support configuration of Genome-Nexus where non-hgvs variants will arrive at /annotation endpoint and they get sent to a (non-hgvs) vep.url ? If not, make this service hgvs only.
+            return verifiedHgvsVariantAnnotationService.getAnnotations(variants, isoformOverrideSource, token, fields);
+        }
+    }
+
+    private boolean isHgvsFormat(String variant) {
+        return variant.contains("g.");
+    }
+
+    private boolean needToConvertHgvsToRegionForAnnotation(String variant) {
+        if (!isRegionAnnotationEnabled) {
+            return false; // without a local gn_vep service processing region format queries, all variants are processed via hgvsAnnotationService
+        }
+        if (!isHgvsFormat(variant)) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean needToConvertHgvsToRegionForAnnotation(List<String> variants) throws VariantAnnotationQueryMixedFormatException {
+        if (!isRegionAnnotationEnabled) {
+            return false; // without a local gn_vep service processing region format queries, all variants are processed via hgvsAnnotationService
+        }
+        if (variants.isEmpty()) {
+            return false; // no variants to annotate
+        }
+        boolean someElementIsHgvs = false;
+        boolean someElementIsNonHgvs = false;
+        for (String variant : variants) {
+            if (isHgvsFormat(variant)) {
+                someElementIsHgvs = true;
+            } else {
+                someElementIsNonHgvs = true;
+            }
+            if (someElementIsHgvs && someElementIsNonHgvs) {
+                throw new VariantAnnotationQueryMixedFormatException("This server cannot process a mixture of HGVS formatted and non-HGVS formatted variants submitted in a single annotation request");
+            }
+        }
+        if (!someElementIsHgvs) {
+            return false; // hgvs not present in any variant
+        }
+        return true;
+    }
+
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
@@ -46,7 +46,7 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
 
     @Autowired
     public VariantAnnotationSummaryServiceImpl(
-        VariantAnnotationService hgvsVariantAnnotationService,
+        VariantAnnotationService verifiedHgvsVariantAnnotationService,
         EnsemblService ensemblService,
         CanonicalTranscriptResolver canonicalTranscriptResolver,
         AminoAcidsResolver aminoAcidsResolver,
@@ -64,7 +64,7 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
         VariantTypeResolver variantTypeResolver,
         ExonResolver exonResolver
     ) {
-        this.variantAnnotationService = hgvsVariantAnnotationService;
+        this.variantAnnotationService = verifiedHgvsVariantAnnotationService;
         this.ensemblService = ensemblService;
         this.canonicalTranscriptResolver = canonicalTranscriptResolver;
         this.codonChangeResolver = codonChangeResolver;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VerifiedGenomicLocationAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VerifiedGenomicLocationAnnotationServiceImpl.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2021 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.genome_nexus.service.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.cbioportal.genome_nexus.model.*;
+import org.cbioportal.genome_nexus.service.*;
+
+import org.cbioportal.genome_nexus.component.annotation.NotationConverter;
+import org.cbioportal.genome_nexus.service.cached.CachedVariantRegionAnnotationFetcher;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.*;
+
+import java.util.*;
+
+@Service
+public class VerifiedGenomicLocationAnnotationServiceImpl implements GenomicLocationAnnotationService
+{
+    private static final Log LOG = LogFactory.getLog(VerifiedGenomicLocationAnnotationServiceImpl.class);
+
+    private final GenomicLocationAnnotationService genomicLocationAnnotationService;
+    private final NotationConverter notationConverter;
+
+    @Autowired
+    public VerifiedGenomicLocationAnnotationServiceImpl(
+            GenomicLocationAnnotationService genomicLocationAnnotationService,
+            NotationConverter notationConverter)
+    {
+        this.genomicLocationAnnotationService = genomicLocationAnnotationService;
+        this.notationConverter = notationConverter;
+    }
+
+    @Override
+    public VariantAnnotation getAnnotation(GenomicLocation genomicLocation)
+        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException
+    {
+        VariantAnnotation annotation = genomicLocationAnnotationService.getAnnotation(genomicLocation);
+        VariantAnnotation verifiedAnnotation = verifyOrFailAnnotation(annotation);
+        return verifiedAnnotation;
+    }
+
+    @Override
+    public VariantAnnotation getAnnotation(String genomicLocation)
+        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException
+    {
+        VariantAnnotation annotation = genomicLocationAnnotationService.getAnnotation(genomicLocation);
+        VariantAnnotation verifiedAnnotation = verifyOrFailAnnotation(annotation);
+        return verifiedAnnotation;
+    }
+
+    @Override
+    public List<VariantAnnotation> getAnnotations(List<GenomicLocation> genomicLocations)
+    {
+        List<VariantAnnotation> annotations = genomicLocationAnnotationService.getAnnotations(genomicLocations);
+        for (int index = 0; index < annotations.size(); index = index + 1) {
+            VariantAnnotation annotation = annotations.get(index);
+            VariantAnnotation verifiedAnnotation = verifyOrFailAnnotation(annotation);
+            annotations.set(index, verifiedAnnotation);
+        }
+        return annotations;
+    }
+
+    @Override
+    public VariantAnnotation getAnnotation(String genomicLocation,
+                                           String isoformOverrideSource,
+                                           Map<String, String> token,
+                                           List<String> fields)
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        VariantAnnotation annotation = genomicLocationAnnotationService.getAnnotation(genomicLocation, isoformOverrideSource, token, fields);
+        VariantAnnotation verifiedAnnotation = verifyOrFailAnnotation(annotation);
+        return verifiedAnnotation;
+    }
+
+    @Override
+    public List<VariantAnnotation> getAnnotations(List<GenomicLocation> genomicLocations,
+                                                                    String isoformOverrideSource,
+                                                                    Map<String, String> token,
+                                                                    List<String> fields)
+    {
+        List<VariantAnnotation> annotations = genomicLocationAnnotationService.getAnnotations(genomicLocations, isoformOverrideSource, token, fields);
+        for (int index = 0; index < annotations.size(); index = index + 1) {
+            VariantAnnotation annotation = annotations.get(index);
+            VariantAnnotation verifiedAnnotation = verifyOrFailAnnotation(annotation);
+            annotations.set(index, verifiedAnnotation);
+        }
+        return annotations;
+    }
+
+    private VariantAnnotation verifyOrFailAnnotation(VariantAnnotation annotation)
+    {
+        String originalVariantQuery = annotation.getOriginalVariantQuery(); // save for failed response
+        String originalVariant = annotation.getVariant(); // save for failed response
+        String originalQuery = originalVariantQuery;
+        if (originalVariantQuery == null || originalVariantQuery.length() == 0) {
+            originalQuery = originalVariant;
+        }
+        String providedReferenceAllele = notationConverter.parseGenomicLocation(originalQuery).getReferenceAllele();
+        if (providedReferenceAllele.length() == 0) {
+            // no comparison possible : allele not specified in query
+            return annotation;
+        }
+        LOG.debug("verifying providedReferenceAllele : '" + providedReferenceAllele + "'");
+        String responseReferenceAllele = getReferenceAlleleFromAnnotation(annotation);
+        if (responseReferenceAllele.length() != providedReferenceAllele.length()) {
+            // for altered length Deletion-Insertion responses, recover full reference allele with followup query
+            String followUpVariant = constructFollowUpQuery(originalQuery);
+            if (followUpVariant.length() > 0) {
+                try {
+                    LOG.debug("performing followup annotation request to get VEP genome assembly sequence : '" + providedReferenceAllele + "'");
+                    VariantAnnotation followUpAnnotation = genomicLocationAnnotationService.getAnnotation(followUpVariant);
+                    responseReferenceAllele = getReferenceAlleleFromAnnotation(followUpAnnotation);
+                } catch (VariantAnnotationNotFoundException|VariantAnnotationWebServiceException vae) {
+                    // followup validation failed - could not verify provided allele, so accept failure
+                    LOG.debug("followup annotation request failed - Reference_Allele could not be verified");
+                }
+            }
+        }
+        if (providedReferenceAllele.equals(responseReferenceAllele)) {
+            // validation complete
+            return annotation;
+        }
+        // return annotation failure
+        return createFailedAnnotation(originalVariantQuery, originalVariant);
+    }
+
+    private String constructFollowUpQuery(String originalQuery)
+    {
+        // create a deletion variant covering the referenced genome positions
+        // this code should only run for delins variants where part of the TumorSeq allele matches the reference genome
+        GenomicLocation followUpQueryGenomicLocation = notationConverter.parseGenomicLocation(originalQuery);
+        followUpQueryGenomicLocation.setVariantAllele("-");
+        if (followUpQueryGenomicLocation.getReferenceAllele().equals("-")) {
+            return ""; // unexpectantly called constructFollowUpQuery on insertion query -- this annotation will fail
+        }
+        return followUpQueryGenomicLocation.toString();
+    }
+
+    private String getReferenceAlleleFromAnnotation(VariantAnnotation annotation)
+    {
+        String alleleString = annotation.getAlleleString();
+        if (alleleString == null) {
+            // maybe original annotation attempt failed
+            return "";
+        }
+        int slashPosition = alleleString.indexOf('/');
+        if (slashPosition == -1 || slashPosition == 0) {
+            return "";
+        }
+        return alleleString.substring(0,slashPosition);
+
+    }
+
+    private VariantAnnotation createFailedAnnotation(String originalVariantQuery, String originalVariant)
+    {
+        VariantAnnotation annotation = new VariantAnnotation();
+        if (originalVariantQuery != null && originalVariantQuery.length() > 0) {
+            annotation.setOriginalVariantQuery(originalVariantQuery);
+        }
+        if (originalVariant != null && originalVariant.length() > 0) {
+            annotation.setVariant(originalVariant);
+        }
+        annotation.setSuccessfullyAnnotated(false);
+        return annotation;
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VerifiedHgvsVariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VerifiedHgvsVariantAnnotationService.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2021 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.genome_nexus.service.internal;
+
+import java.util.*;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.*;
+import org.cbioportal.genome_nexus.service.cached.CachedVariantAnnotationFetcher;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
+import org.cbioportal.genome_nexus.service.internal.HgvsVariantAnnotationService;
+import org.cbioportal.genome_nexus.util.GenomicVariantUtil;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Service
+public class VerifiedHgvsVariantAnnotationService implements VariantAnnotationService
+{
+    private static final Log LOG = LogFactory.getLog(VerifiedHgvsVariantAnnotationService.class);
+    private final HgvsVariantAnnotationService hgvsVariantAnnotationService;
+
+    @Autowired
+    public VerifiedHgvsVariantAnnotationService(
+        HgvsVariantAnnotationService hgvsVariantAnnotationService)
+    {
+        this.hgvsVariantAnnotationService = hgvsVariantAnnotationService;
+    }
+
+    @Override
+    public VariantAnnotation getAnnotation(String variant)
+            throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException
+    {
+        VariantAnnotation annotation = hgvsVariantAnnotationService.getAnnotation(variant);
+        VariantAnnotation verifiedAnnotation = verifyOrFailAnnotation(annotation);
+        return verifiedAnnotation;
+    }
+
+    @Override
+    public List<VariantAnnotation> getAnnotations(List<String> variants)
+    {
+        List<VariantAnnotation> annotations = hgvsVariantAnnotationService.getAnnotations(variants);
+        for (int index = 0; index < annotations.size(); index = index + 1) {
+            VariantAnnotation annotation = annotations.get(index);
+            VariantAnnotation verifiedAnnotation = verifyOrFailAnnotation(annotation);
+            annotations.set(index, verifiedAnnotation);
+        }
+        return annotations;
+    }
+
+    @Override
+    public VariantAnnotation getAnnotation(String variant, String isoformOverrideSource, Map<String, String> token, List<String> fields)
+            throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        VariantAnnotation annotation = hgvsVariantAnnotationService.getAnnotation(variant, isoformOverrideSource, token, fields);
+        VariantAnnotation verifiedAnnotation = verifyOrFailAnnotation(annotation);
+        return verifiedAnnotation;
+    }
+
+    @Override
+    public List<VariantAnnotation> getAnnotations(List<String> variants, String isoformOverrideSource, Map<String, String> token, List<String> fields)
+    {
+        List<VariantAnnotation> annotations = hgvsVariantAnnotationService.getAnnotations(variants, isoformOverrideSource, token, fields);
+        for (int index = 0; index < annotations.size(); index = index + 1) {
+            VariantAnnotation annotation = annotations.get(index);
+            VariantAnnotation verifiedAnnotation = verifyOrFailAnnotation(annotation);
+            annotations.set(index, verifiedAnnotation);
+        }
+        return annotations;
+    }
+
+    private VariantAnnotation verifyOrFailAnnotation(VariantAnnotation annotation)
+    {
+        String originalVariantQuery = annotation.getOriginalVariantQuery(); // save for failed response
+        String originalVariant = annotation.getVariant(); // save for failed response
+        String originalQuery = originalVariantQuery;
+        if (originalVariantQuery == null || originalVariantQuery.length() == 0) {
+            originalQuery = originalVariant;
+        }
+        String providedReferenceAllele = GenomicVariantUtil.providedReferenceAlleleFromHgvs(originalQuery);
+        if (providedReferenceAllele.length() == 0) {
+            // no comparison possible : allele not specified in query
+            return annotation;
+        }
+        LOG.debug("verifying providedReferenceAllele : '" + providedReferenceAllele + "'");
+        String responseReferenceAllele = getReferenceAlleleFromAnnotation(annotation);
+        if (responseReferenceAllele.length() != providedReferenceAllele.length()) {
+            // for altered length Deletion-Insertion responses, recover full reference allele with followup query
+            String followUpVariant = constructFollowUpQuery(originalQuery);
+            if (followUpVariant.length() > 0) {
+                try {
+                    LOG.debug("performing followup annotation request to get VEP genome assembly sequence : '" + providedReferenceAllele + "'");
+                    VariantAnnotation followUpAnnotation = hgvsVariantAnnotationService.getAnnotation(followUpVariant);
+                    responseReferenceAllele = getReferenceAlleleFromAnnotation(followUpAnnotation);
+                } catch (VariantAnnotationNotFoundException|VariantAnnotationWebServiceException vae) {
+                    // followup validation failed - could not verify provided allele, so accept failure
+                    LOG.debug("followup annotation request failed - Reference_Allele could not be verified");
+                }
+            }
+        }
+        if (providedReferenceAllele.equals(responseReferenceAllele)) {
+            // validation complete
+            return annotation;
+        }
+        // return annotation failure
+        return createFailedAnnotation(originalVariantQuery, originalVariant);
+    }
+
+    private String constructFollowUpQuery(String originalQuery)
+    {
+        // create a deletion variant covering the referenced genome positions
+        // this code should only run for delins variants where part of the TumorSeq allele matches the reference genome
+        String followUpQuery = originalQuery.replaceFirst("ins.*|del.*","");
+        if (followUpQuery.length() == originalQuery.length()) {
+            return ""; // unexpectantly called constructFollowUpQuery on non-delins hgvs query -- this annotation will fail
+        }
+        return followUpQuery + "del";
+    }
+
+    private String getReferenceAlleleFromAnnotation(VariantAnnotation annotation)
+    {
+        String alleleString = annotation.getAlleleString();
+        if (alleleString == null) {
+            // maybe original annotation attempt failed
+            return "";
+        }
+        int slashPosition = alleleString.indexOf('/');
+        if (slashPosition == -1 || slashPosition == 0) {
+            return "";
+        }
+        return alleleString.substring(0,slashPosition);
+
+    }
+
+    private VariantAnnotation createFailedAnnotation(String originalVariantQuery, String originalVariant)
+    {
+        VariantAnnotation annotation = new VariantAnnotation();
+        if (originalVariantQuery != null && originalVariantQuery.length() > 0) {
+            annotation.setOriginalVariantQuery(originalVariantQuery);
+        }
+        if (originalVariant != null && originalVariant.length() > 0) {
+            annotation.setVariant(originalVariant);
+        }
+        annotation.setSuccessfullyAnnotated(false);
+        return annotation;
+    }
+
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VerifiedGenomicLocationAnnotationServiceTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VerifiedGenomicLocationAnnotationServiceTest.java
@@ -1,0 +1,462 @@
+/*
+ * Copyright (c) 2021 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.genome_nexus.service.internal;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import org.cbioportal.genome_nexus.component.annotation.NotationConverter;
+import org.cbioportal.genome_nexus.model.GenomicLocation;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.GenomicLocationAnnotationService;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class VerifiedGenomicLocationAnnotationServiceTest
+{
+    // Tested Class
+    private VerifiedGenomicLocationAnnotationServiceImpl verifiedGenomicLocationAnnotationServiceImpl;
+
+    // Use the production NotationConverter utility
+    private NotationConverter notationConverter = new NotationConverter();
+
+    @Mock
+    private GenomicLocationAnnotationService glVariantAnnotationService;
+
+    // case lists
+    public List<VariantTestCase> glSubstitutions = null;
+    public List<VariantTestCase> glDeletions = null;
+    public List<VariantTestCase> glInsertions = null;
+    public List<VariantTestCase> glInsertionDeletions = null;
+    // single query stub maps
+    public Map<String, Boolean> variantToVepSuccessfullyAnnotated = new HashMap<String, Boolean>();
+    public Map<String, String> variantToVepAlleleString = new HashMap<String, String>();
+    // argument list stubs
+    public String mockIsoformOverrideSource = "mockIsoformOverrideSource";
+    public Map<String, String> mockTokenMap = new HashMap<String, String>();
+    public List<String> mockFields = new ArrayList<String>();
+
+    class VariantTestCase
+    {
+        public String originalVariantQuery;
+        public boolean expectedGnSuccessfullyAnnotated;
+        public String expectedGnAlleleString;
+        public String description;
+        public VariantTestCase(
+                String originalVariantQuery,
+                boolean expectedGnSuccessfullyAnnotated,
+                String expectedGnAlleleString,
+                String description) {
+            this.originalVariantQuery =  originalVariantQuery;
+            this.expectedGnSuccessfullyAnnotated = expectedGnSuccessfullyAnnotated;
+            this.expectedGnAlleleString = expectedGnAlleleString;
+            this.description = description;
+        }
+    }
+
+    class TestCaseInsufficentlyModeledException extends Exception
+    {
+        public TestCaseInsufficentlyModeledException(String msg) {
+            super(msg);
+        }
+    }
+
+    @Before
+    public void setUp()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException, TestCaseInsufficentlyModeledException
+    {
+        verifiedGenomicLocationAnnotationServiceImpl = new VerifiedGenomicLocationAnnotationServiceImpl(glVariantAnnotationService, notationConverter);
+        initializeTestCaseLists();
+        setUpServiceStubs(); // these are based on the test case lists
+    }
+
+    private void initializeTestCaseLists()
+    {
+        if (glSubstitutions == null) {
+            glSubstitutions = new ArrayList<VariantTestCase>();
+            glSubstitutions.add(new VariantTestCase("5,138163256,138163256,C,T", true, "C/T", "valid substitution"));
+            glSubstitutions.add(new VariantTestCase("5,138163256,138163256,A,T", false, null, "discrepant RefAllele"));
+            glDeletions = new ArrayList<VariantTestCase>();
+            glDeletions.add(new VariantTestCase("5,138163256,138163256,C,-", true, "C/-", "1nt deletion with RefAllele"));
+            glDeletions.add(new VariantTestCase("5,138163256,138163256,A,-", false, null, "1nt deletion with discrepant RefAllele"));
+            glDeletions.add(new VariantTestCase("5,138163255,138163256,TC,-", true, "TC/-", "2nt deletion with RefAllele"));
+            glDeletions.add(new VariantTestCase("5,138163255,138163256,CC,-", false, null, "2nt deletion with discrepant RefAllele"));
+            glDeletions.add(new VariantTestCase("5,138163255,138163256,CCCC,-", false, null, "2nt deletion with invalid RefAllele"));
+            glInsertions = new ArrayList<VariantTestCase>();
+            glInsertions.add(new VariantTestCase("5,138163255,138163256,-,T", true, "-/T", "1nt insertion"));
+            glInsertions.add(new VariantTestCase("5,138163255,138163256,-,TT", true, "-/TT", "2nt insertion"));
+            glInsertions.add(new VariantTestCase("5,138163255,138163256,-,-", true, "-/-", "insertion missing TumorSeqAllele")); // note : different result than ensembl
+            glInsertionDeletions = new ArrayList<VariantTestCase>();
+            glInsertionDeletions.add(new VariantTestCase("5,138163256,138163256,C,T", true, "C/T", "1nt deletion with RefAllele, 1nt insertion"));
+            glInsertionDeletions.add(new VariantTestCase("5,138163256,138163256,A,T", false, null, "1nt deletion with discrepant RefAllele, 1nt insertion"));
+            glInsertionDeletions.add(new VariantTestCase("5,138163256,138163256,C,TT", true, "C/TT", "1nt deletion with RefAllele, 2nt insertion"));
+            glInsertionDeletions.add(new VariantTestCase("5,138163256,138163256,A,TT", false, null, "1nt deletion with discrepant RefAllele, 2nt insertion"));
+            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,TC,A", true, "TC/A", "2nt deletion with RefAllele, 1nt insertion"));
+            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,TA,G", false, null, "2nt deletion with discrepant RefAllele, 1nt insertion"));
+            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,TC,TC", true, "TC/TC", "2nt deletion with RefAllele, 2nt insertion no change")); // note : different result than ensembl
+            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,TC,TT", true, "C/T", "2nt deletion with RefAllele, 2nt insertion, partial change"));
+            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,TC,GG", true, "TC/GG", "2nt deletion with RefAllele, 2nt insertion, full change"));
+            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,CC,TC", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion no change")); // note : different result than ensembl
+            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,CC,TT", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion, partial change"));
+            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,CC,GG", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion, full change"));
+            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,CCCC,TT", false, null, "2nt deletion with invalid RefAllele, 2nt insertion"));
+        }
+    }
+
+    private void setUpQueryToStubMaps(String variantQuery, boolean successfullyAnnotated, String alleleString)
+    {
+        variantToVepSuccessfullyAnnotated.put(variantQuery, successfullyAnnotated);
+        variantToVepAlleleString.put(variantQuery, alleleString);
+    }
+
+    private void setUpQueryToStubMaps()
+    {
+        // VEP responses for these test cases were extracted from queries to http://genie.genomenexus.org/annotation/genomic/<variant>
+        // these contain only the elements neccessary for testing the business logic in VerifiedGenomicLocationAnnotationService
+        setUpQueryToStubMaps("5,138163256,138163256,C,T", true, "C/T");
+        setUpQueryToStubMaps("5,138163256,138163256,A,T", false, null);
+        setUpQueryToStubMaps("5,138163256,138163256,C,-", true, "C/-");
+        setUpQueryToStubMaps("5,138163256,138163256,A,-", true, "C/-");
+        setUpQueryToStubMaps("5,138163255,138163256,TC,-", true, "TC/-");
+        setUpQueryToStubMaps("5,138163255,138163256,CC,-", true, "TC/-");
+        setUpQueryToStubMaps("5,138163255,138163256,CCCC,-", true, "TC/-");
+        setUpQueryToStubMaps("5,138163255,138163256,-,T", true, "-/T");
+        setUpQueryToStubMaps("5,138163255,138163256,-,TT", true, "-/TT");
+        setUpQueryToStubMaps("5,138163255,138163256,-,-", true, "-/-");
+        setUpQueryToStubMaps("5,138163256,138163256,C,TT", true, "C/TT");
+        setUpQueryToStubMaps("5,138163256,138163256,A,TT", true, "C/TT");
+        setUpQueryToStubMaps("5,138163255,138163256,TC,A", true, "TC/A");
+        setUpQueryToStubMaps("5,138163255,138163256,TA,G", true, "TC/G");
+        setUpQueryToStubMaps("5,138163255,138163256,TC,TC", true, "TC/TC");
+        setUpQueryToStubMaps("5,138163255,138163256,TC,TT", true, "C/T");
+        setUpQueryToStubMaps("5,138163255,138163256,TC,GG", true, "TC/GG");
+        setUpQueryToStubMaps("5,138163255,138163256,CC,TC", true, "TC/TC");
+        setUpQueryToStubMaps("5,138163255,138163256,CC,TT", true, "TC/TT");
+        setUpQueryToStubMaps("5,138163255,138163256,CC,GG", true, "TC/GG");
+        setUpQueryToStubMaps("5,138163255,138163256,CCCC,TT", true, "TC/TT");
+    }
+
+    private VariantAnnotation stubAnnotation(String originalVariantQuery, String variant, boolean successfullyAnnotated, String alleleString)
+    {
+        VariantAnnotation stub = new VariantAnnotation();
+        stub.setOriginalVariantQuery(originalVariantQuery);
+        stub.setVariant(variant);
+        stub.setAlleleString(alleleString);
+        stub.setSuccessfullyAnnotated(successfullyAnnotated);
+        return stub;
+    }
+
+    private void stubGenomicLocationAnnotationServiceMethodsForType(List<VariantTestCase> variantTestCaseList)
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException, TestCaseInsufficentlyModeledException
+    {
+        // create stubs for single variant queries, and begin building lists too
+        ArrayList<String> queryStringList = new ArrayList<String>();
+        ArrayList<GenomicLocation> queryGenomicLocationList = new ArrayList<GenomicLocation>();
+        ArrayList<VariantAnnotation> responseList = new ArrayList<VariantAnnotation>();
+        for (VariantTestCase testCase : variantTestCaseList) {
+            GenomicLocation genomicLocation = notationConverter.parseGenomicLocation(testCase.originalVariantQuery);
+            queryStringList.add(testCase.originalVariantQuery);
+            queryGenomicLocationList.add(genomicLocation);
+            if (!variantToVepSuccessfullyAnnotated.containsKey(testCase.originalVariantQuery)) {
+                throw new TestCaseInsufficentlyModeledException("No Vep successfully_annotated stub defined for original_variant_query : " + testCase.originalVariantQuery);
+            }
+            Boolean successfullyAnnotatedStub = variantToVepSuccessfullyAnnotated.get(testCase.originalVariantQuery);
+            if (successfullyAnnotatedStub == null) {
+                throw new TestCaseInsufficentlyModeledException("No Vep successfully_annotated stub defined for original_variant_query : " + testCase.originalVariantQuery);
+            }
+            if (!variantToVepAlleleString.containsKey(testCase.originalVariantQuery)) {
+                throw new TestCaseInsufficentlyModeledException("No Vep allele_string stub defined for original_variant_query : " + testCase.originalVariantQuery);
+            }
+            String alleleStringStub = variantToVepAlleleString.get(testCase.originalVariantQuery); // null is an acceptable stub value for allele_string
+            VariantAnnotation response = stubAnnotation(
+                    testCase.originalVariantQuery,
+                    testCase.originalVariantQuery,
+                    successfullyAnnotatedStub,
+                    alleleStringStub);
+            responseList.add(response);
+            //response.setAnnotationJSON("{ \"originalVariantQuery\" : \"" + testCase.originalVariantQuery + "\", \"successfullyAnnotated\" : " + successfullyAnnotatedStub + ", \"allele\" : \"" + alleleStringStub + "\" }");
+            Mockito.when(glVariantAnnotationService.getAnnotation(testCase.originalVariantQuery)).thenReturn(response);
+            Mockito.when(glVariantAnnotationService.getAnnotation(testCase.originalVariantQuery, mockIsoformOverrideSource, mockTokenMap, mockFields)).thenReturn(response);
+            Mockito.when(glVariantAnnotationService.getAnnotation(genomicLocation)).thenReturn(response);
+        }
+        // create stubs for multi variant queries from built lists .. after jittering order
+        // order of response not guaranteed to match order of query - business logic should handle this properly
+        VariantAnnotation movedItem = responseList.remove(0);
+        responseList.add(movedItem); // first element is now last
+        Mockito.when(glVariantAnnotationService.getAnnotations(queryGenomicLocationList)).thenReturn(responseList);
+        Mockito.when(glVariantAnnotationService.getAnnotations(queryGenomicLocationList, mockIsoformOverrideSource, mockTokenMap, mockFields)).thenReturn(responseList);
+    }
+
+    private void setUpServiceStubs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException, TestCaseInsufficentlyModeledException
+    {
+        setUpQueryToStubMaps();
+        stubGenomicLocationAnnotationServiceMethodsForType(glSubstitutions);
+        stubGenomicLocationAnnotationServiceMethodsForType(glDeletions);
+        stubGenomicLocationAnnotationServiceMethodsForType(glInsertions);
+        stubGenomicLocationAnnotationServiceMethodsForType(glInsertionDeletions);
+    }
+
+    private void runTestSetByVariantString(List<VariantTestCase> variantTestCaseList, boolean supplyOtherParameters)
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        for (VariantTestCase testCase : variantTestCaseList) {
+            VariantAnnotation testResponse = null;
+            if (supplyOtherParameters) {
+                testResponse = verifiedGenomicLocationAnnotationServiceImpl.getAnnotation(testCase.originalVariantQuery, mockIsoformOverrideSource, mockTokenMap, mockFields);
+            } else {
+                testResponse = verifiedGenomicLocationAnnotationServiceImpl.getAnnotation(testCase.originalVariantQuery);
+            }
+            Assert.assertEquals(testCase.originalVariantQuery + " : response query field does not match request query string", testCase.originalVariantQuery, testResponse.getOriginalVariantQuery());
+            if (testCase.expectedGnSuccessfullyAnnotated) {
+                Assert.assertTrue(testCase.originalVariantQuery + " : expected successful annotation", testResponse.isSuccessfullyAnnotated());
+            } else {
+                Assert.assertFalse(testCase.originalVariantQuery + " : expected failed annotation", testResponse.isSuccessfullyAnnotated());
+            }
+            if (testResponse.isSuccessfullyAnnotated()) {
+                Assert.assertEquals(testCase.originalVariantQuery + " : Variant Allele comparison", testCase.expectedGnAlleleString, testResponse.getAlleleString());
+            }
+        }
+    }
+
+    private void runTestSetByGenomicLocation(List<VariantTestCase> variantTestCaseList)
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        for (VariantTestCase testCase : variantTestCaseList) {
+            GenomicLocation genomicLocation = notationConverter.parseGenomicLocation(testCase.originalVariantQuery);
+            VariantAnnotation testResponse = null;
+            testResponse = verifiedGenomicLocationAnnotationServiceImpl.getAnnotation(testCase.originalVariantQuery);
+            Assert.assertEquals(genomicLocation.toString() + " : response query field does not match request query string", genomicLocation.toString(), testResponse.getOriginalVariantQuery());
+            if (testCase.expectedGnSuccessfullyAnnotated) {
+                Assert.assertTrue(genomicLocation.toString() + " : expected successful annotation", testResponse.isSuccessfullyAnnotated());
+            } else {
+                Assert.assertFalse(genomicLocation.toString() + " : expected failed annotation", testResponse.isSuccessfullyAnnotated());
+            }
+            if (testResponse.isSuccessfullyAnnotated()) {
+                Assert.assertEquals(genomicLocation.toString() + " : Variant Allele comparison", testCase.expectedGnAlleleString, testResponse.getAlleleString());
+            }
+        }
+    }
+
+    private void runTestSetByGenomicLocationList(List<VariantTestCase> variantTestCaseList, boolean supplyOtherParameters)
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        // make list of variant query strings and submit
+        List<GenomicLocation> queryGenomicLocations = variantTestCaseList.stream().map(t -> notationConverter.parseGenomicLocation(t.originalVariantQuery)).collect(Collectors.toList());
+        List<VariantAnnotation> variantResponse = null;
+        if (supplyOtherParameters) {
+            variantResponse = verifiedGenomicLocationAnnotationServiceImpl.getAnnotations(queryGenomicLocations, mockIsoformOverrideSource, mockTokenMap, mockFields);
+        } else {
+            variantResponse = verifiedGenomicLocationAnnotationServiceImpl.getAnnotations(queryGenomicLocations);
+        }
+        // check each element of response against expectations
+        HashMap<String, VariantAnnotation> queryToResponse = new HashMap<String, VariantAnnotation>();
+        for (VariantAnnotation responseElement : variantResponse) {
+            if (queryToResponse.put(responseElement.getOriginalVariantQuery(), responseElement) != null) {
+                Assert.fail("More than one response received for query string " + responseElement.getOriginalVariantQuery());
+            }
+        }
+        for (VariantTestCase testCase : variantTestCaseList) {
+            VariantAnnotation testResponse = queryToResponse.get(testCase.originalVariantQuery);
+            if (testResponse == null) {
+                Assert.fail("Response did not include record for query string " + testCase.originalVariantQuery);
+            }
+            if (testCase.expectedGnSuccessfullyAnnotated) {
+                Assert.assertTrue(testCase.originalVariantQuery + " : expected successful annotation", testResponse.isSuccessfullyAnnotated());
+            } else {
+                Assert.assertFalse(testCase.originalVariantQuery + " : expected failed annotation", testResponse.isSuccessfullyAnnotated());
+            }
+            if (testResponse.isSuccessfullyAnnotated()) {
+                Assert.assertEquals(testCase.originalVariantQuery + " : Variant Allele comparison", testCase.expectedGnAlleleString, testResponse.getAlleleString());
+            }
+        }
+    }
+
+    // Tests of the getAnnotation(String) function
+
+    @Test
+    public void getAnnotationForSubstitutionsByVariantString()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(glSubstitutions, false);
+    }
+
+    @Test
+    public void getAnnotationForDeletionsByVariantString()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(glDeletions, false);
+    }
+
+    @Test
+    public void getAnnotationForInsertionsByVariantString()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(glInsertions, false);
+    }
+
+    @Test
+    public void getAnnotationForInsertionDeletionsByVariantString()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(glInsertionDeletions, false);
+    }
+
+    // Tests of the getAnnotation(String, overrideSource, tokenMap, fields) function
+
+    @Test
+    public void getAnnotationForSubstitutionsByVariantStringWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(glSubstitutions, true);
+    }
+
+    @Test
+    public void getAnnotationForDeletionsByVariantStringWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(glDeletions, true);
+    }
+
+    @Test
+    public void getAnnotationForInsertionsByVariantStringWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(glInsertions, true);
+    }
+
+    @Test
+    public void getAnnotationForInsertionDeletionsByVariantStringWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(glInsertionDeletions, true);
+    }
+
+    // Tests of the getAnnotation(GenomicLocation) function
+
+    @Test
+    public void getAnnotationForSubstitutionsByGenomicLocation()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByGenomicLocation(glSubstitutions);
+    }
+
+    @Test
+    public void getAnnotationForDeletionsByGenomicLocation()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByGenomicLocation(glDeletions);
+    }
+
+    @Test
+    public void getAnnotationForInsertionsByGenomicLocation()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByGenomicLocation(glInsertions);
+    }
+
+    @Test
+    public void getAnnotationForInsertionDeletionsByGenomicLocation()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByGenomicLocation(glInsertionDeletions);
+    }
+
+    // Tests of the getAnnotations(List<GenomicLocation>) function
+
+    @Test
+    public void getAnnotationsForSubstitutionsByGenomicLocationList()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByGenomicLocationList(glSubstitutions, false);
+    }
+
+    @Test
+    public void getAnnotationsForDeletionsByGenomicLocationList()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByGenomicLocationList(glDeletions, false);
+    }
+
+    @Test
+    public void getAnnotationsForInsertionsByGenomicLocationList()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByGenomicLocationList(glInsertions, false);
+    }
+
+    @Test
+    public void getAnnotationsForInsertionDeletionsByGenomicLocationList()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByGenomicLocationList(glInsertionDeletions, false);
+    }
+
+    // Tests of the getAnnotations(List<GenomicLocation>, overrideSource, tokenMap, fields) function
+
+    @Test
+    public void getAnnotationsForSubstitutionsByGenomicLocationListWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByGenomicLocationList(glSubstitutions, true);
+    }
+
+    @Test
+    public void getAnnotationsForDeletionsByGenomicLocationListWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByGenomicLocationList(glDeletions, true);
+    }
+
+    @Test
+    public void getAnnotationsForInsertionsByGenomicLocationListWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByGenomicLocationList(glInsertions, true);
+    }
+
+    @Test
+    public void getAnnotationsForInsertionDeletionsByGenomicLocationListWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByGenomicLocationList(glInsertionDeletions, true);
+    }
+
+}

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VerifiedHgvsVariantAnnotationServiceTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VerifiedHgvsVariantAnnotationServiceTest.java
@@ -1,0 +1,461 @@
+/*
+ * Copyright (c) 2021 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.genome_nexus.service.internal;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class VerifiedHgvsVariantAnnotationServiceTest
+{
+    // Tested Class
+    private VerifiedHgvsVariantAnnotationService verifiedHgvsVariantAnnotationService;
+
+    @Mock
+    private HgvsVariantAnnotationService hgvsVariantAnnotationService;
+
+    // test cases
+    public List<VariantTestCase> hgvsSubstitutions = null;
+    public List<VariantTestCase> hgvsDeletions = null;
+    public List<VariantTestCase> hgvsInsertions = null;
+    public List<VariantTestCase> hgvsInsertionDeletions = null;
+    public List<VariantTestCase> hgvsInversions = null; // test results of an unsupported format query
+    // other types (duplications, no-change, methylation, specified alleles) are not handled by genome nexus and are not tested
+    // single query stub maps
+    public Map<String, Boolean> variantToVepSuccessfullyAnnotated = new HashMap<String, Boolean>();
+    public Map<String, String> variantToVepAlleleString = new HashMap<String, String>();
+    // argument list stubs
+    public String mockIsoformOverrideSource = "mockIsoformOverrideSource";
+    public Map<String, String> mockTokenMap = new HashMap<String, String>();
+    public List<String> mockFields = new ArrayList<String>();
+
+    class VariantTestCase {
+        public String originalVariantQuery;
+        public boolean expectedGnSuccessfullyAnnotated;
+        public String expectedGnAlleleString;
+        public String description;
+        public VariantTestCase(
+                String originalVariantQuery,
+                boolean expectedGnSuccessfullyAnnotated,
+                String expectedGnAlleleString,
+                String description) {
+            this.originalVariantQuery =  originalVariantQuery;
+            this.expectedGnSuccessfullyAnnotated = expectedGnSuccessfullyAnnotated;
+            this.expectedGnAlleleString = expectedGnAlleleString;
+            this.description = description;
+        }
+    }
+
+    class TestCaseInsufficentlyModeledException extends Exception
+    {
+        public TestCaseInsufficentlyModeledException(String msg) {
+            super(msg);
+        }
+    }
+
+    @Before
+    public void setUp()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException, TestCaseInsufficentlyModeledException
+    {
+        verifiedHgvsVariantAnnotationService = new VerifiedHgvsVariantAnnotationService(hgvsVariantAnnotationService);
+        initializeTestCaseLists();
+        setUpServiceStubs(); // these are based on the test case lists
+    }
+
+    private void initializeTestCaseLists()
+    {
+        if (hgvsSubstitutions == null) {
+            hgvsSubstitutions = new ArrayList<VariantTestCase>();
+            hgvsSubstitutions.add(new VariantTestCase("5:g.138163256C>T", true, "C/T", "valid substitution"));
+            hgvsSubstitutions.add(new VariantTestCase("5:g.138163256A>T", false, null, "discrepant RefAllele"));
+            hgvsSubstitutions.add(new VariantTestCase("5:g.138163256>T", false, null, "missing RefAllele"));
+            hgvsDeletions = new ArrayList<VariantTestCase>();
+            hgvsDeletions.add(new VariantTestCase("5:g.138163256delC", true, "C/-", "1nt deletion with RefAllele"));
+            hgvsDeletions.add(new VariantTestCase("5:g.138163256delA", false, null, "1nt deletion with discrepant RefAllele"));
+            hgvsDeletions.add(new VariantTestCase("5:g.138163256del", true, "C/-", "1nt deletion missing RefAllele"));
+            hgvsDeletions.add(new VariantTestCase("5:g.138163255_138163256delTC", true, "TC/-", "2nt deletion with RefAllele"));
+            hgvsDeletions.add(new VariantTestCase("5:g.138163255_138163256delCC", false, null, "2nt deletion with discrepant RefAllele"));
+            hgvsDeletions.add(new VariantTestCase("5:g.138163255_138163256delCCCC", false, null, "2nt deletion with invalid RefAllele"));
+            hgvsDeletions.add(new VariantTestCase("5:g.138163255_138163256del", true, "TC/-", "2nt deletion missing RefAllele"));
+            hgvsInsertions = new ArrayList<VariantTestCase>();
+            hgvsInsertions.add(new VariantTestCase("5:g.138163255_138163256insT", true, "-/T", "1nt insertion"));
+            hgvsInsertions.add(new VariantTestCase("5:g.138163255_138163256insTT", true, "-/TT", "2nt insertion"));
+            hgvsInsertions.add(new VariantTestCase("5:g.138163255_138163256ins", false, null, "insertion missing TumorSeqAllele"));
+            hgvsInsertionDeletions = new ArrayList<VariantTestCase>();
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163256delinsT", true, "C/T", "1nt deletion without RefAllele, 1nt insertion"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163256delCinsT", true, "C/T", "1nt deletion with RefAllele, 1nt insertion"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163256delAinsT", false, null, "1nt deletion with discrepant RefAllele, 1nt insertion"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163256delinsC", false, null, "1nt deletion without RefAllele, 1nt insertion no change"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163256delinsTT", true, "C/TT", "1nt deletion without RefAllele, 2nt insertion"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163256delCinsTT", true, "C/TT", "1nt deletion with RefAllele, 2nt insertion"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163256delAinsTT", false, null, "1nt deletion with discrepant RefAllele, 2nt insertion"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delinsG", true, "TC/G", "2nt deletion without RefAllele, 1nt insertion"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delTCinsA", true, "TC/A", "2nt deletion with RefAllele, 1nt insertion"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delTAinsG", false, null, "2nt deletion with discrepant RefAllele, 1nt insertion"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delTCinsTC", false, null, "2nt deletion with RefAllele, 2nt insertion no change"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delTCinsTT", true, "C/T", "2nt deletion with RefAllele, 2nt insertion, partial change"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delTCinsGG", true, "TC/GG", "2nt deletion with RefAllele, 2nt insertion, full change"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delCCinsTC", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion no change"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delCCinsTT", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion, partial change"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delCCinsGG", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion, full change"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delinsTC", false, null, "2nt deletion without RefAllele, 2nt insertion no change"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delinsTT", true, "C/T", "2nt deletion without RefAllele, 2nt insertion, partial change"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delinsGG", true, "TC/GG", "2nt deletion without RefAllele, 2nt insertion, full change"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delCCCCinsTT", false, null, "2nt deletion with invalid RefAllele, 2nt insertion"));
+            hgvsInversions = new ArrayList<VariantTestCase>();
+            hgvsInversions.add(new VariantTestCase("5:g.138163255_138163256inv", true, "TC/GA", "inversions not supported - but will run as passthrough"));
+            hgvsInversions.add(new VariantTestCase("5:g.138163255_138163256invTC", false, null, "inversion format does not allow specification of RefAllele"));
+        }
+    }
+
+    private void setUpQueryToStubMaps(String variantQuery, boolean successfullyAnnotated, String alleleString)
+    {
+        variantToVepSuccessfullyAnnotated.put(variantQuery, successfullyAnnotated);
+        variantToVepAlleleString.put(variantQuery, alleleString);
+    }
+
+    private void setUpQueryToStubMaps()
+    {
+        // VEP responses for these test cases are extracted from queries to http://grch37.rest.ensembl.org/vep/human/hgvs/<variant>
+        // these contain only the elements neccessary for testing the business logic in VerifiedGenomicLocationAnnotationService
+        setUpQueryToStubMaps("5:g.138163256C>T", true, "C/T");
+        setUpQueryToStubMaps("5:g.138163256A>T", false, null);
+        setUpQueryToStubMaps("5:g.138163256>T", false, null);
+        setUpQueryToStubMaps("5:g.138163256delC", true, "C/-");
+        setUpQueryToStubMaps("5:g.138163256delA", true, "C/-");
+        setUpQueryToStubMaps("5:g.138163256del", true, "C/-");
+        setUpQueryToStubMaps("5:g.138163255_138163256delTC", true, "TC/-");
+        setUpQueryToStubMaps("5:g.138163255_138163256delCC", true, "TC/-");
+        setUpQueryToStubMaps("5:g.138163255_138163256delCCCC", true, "TC/-");
+        setUpQueryToStubMaps("5:g.138163255_138163256del", true, "TC/-");
+        setUpQueryToStubMaps("5:g.138163255_138163256insT", true, "-/T");
+        setUpQueryToStubMaps("5:g.138163255_138163256insTT", true, "-/TT");
+        setUpQueryToStubMaps("5:g.138163255_138163256ins", false, null);
+        setUpQueryToStubMaps("5:g.138163256delinsT", true, "C/T");
+        setUpQueryToStubMaps("5:g.138163256delCinsT", true, "C/T");
+        setUpQueryToStubMaps("5:g.138163256delAinsT", true, "C/T");
+        setUpQueryToStubMaps("5:g.138163256delinsC", false, null);
+        setUpQueryToStubMaps("5:g.138163256delinsTT", true, "C/TT");
+        setUpQueryToStubMaps("5:g.138163256delCinsTT", true, "C/TT");
+        setUpQueryToStubMaps("5:g.138163256delAinsTT", true, "C/TT");
+        setUpQueryToStubMaps("5:g.138163255_138163256delinsG", true, "TC/G");
+        setUpQueryToStubMaps("5:g.138163255_138163256delTCinsA", true, "TC/A");
+        setUpQueryToStubMaps("5:g.138163255_138163256delTAinsG", true, "TC/G");
+        setUpQueryToStubMaps("5:g.138163255_138163256delTCinsTC", false, null);
+        setUpQueryToStubMaps("5:g.138163255_138163256delTCinsTT", true, "C/T");
+        setUpQueryToStubMaps("5:g.138163255_138163256delTCinsGG", true, "TC/GG");
+        setUpQueryToStubMaps("5:g.138163255_138163256delCCinsTC", false, null);
+        setUpQueryToStubMaps("5:g.138163255_138163256delCCinsTT", true, "C/T");
+        setUpQueryToStubMaps("5:g.138163255_138163256delCCinsGG", true, "TC/GG");
+        setUpQueryToStubMaps("5:g.138163255_138163256delinsTC", false, null);
+        setUpQueryToStubMaps("5:g.138163255_138163256delinsTT", true, "C/T");
+        setUpQueryToStubMaps("5:g.138163255_138163256delinsGG", true, "TC/GG");
+        setUpQueryToStubMaps("5:g.138163255_138163256delCCCCinsTT", true, "C/T");
+        setUpQueryToStubMaps("5:g.138163255_138163256inv", true, "TC/GA");
+        setUpQueryToStubMaps("5:g.138163255_138163256invTC", false, null);
+    }
+
+    private VariantAnnotation stubAnnotation(String originalVariantQuery, String variant, boolean successfullyAnnotated, String alleleString)
+    {
+        VariantAnnotation stub = new VariantAnnotation();
+        stub.setOriginalVariantQuery(originalVariantQuery);
+        stub.setVariant(variant);
+        stub.setAlleleString(alleleString);
+        stub.setSuccessfullyAnnotated(successfullyAnnotated);
+        return stub;
+    }
+
+    private void stubHgvsVariantAnnotationServiceMethodsForType(List<VariantTestCase> variantTestCaseList)
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException, TestCaseInsufficentlyModeledException
+    {
+        // create stubs for single variant queries, and begin building lists too
+        ArrayList<String> queryStringList = new ArrayList<String>();
+        ArrayList<VariantAnnotation> responseList = new ArrayList<VariantAnnotation>();
+        for (VariantTestCase testCase : variantTestCaseList) {
+            queryStringList.add(testCase.originalVariantQuery);
+            if (!variantToVepSuccessfullyAnnotated.containsKey(testCase.originalVariantQuery)) {
+                throw new TestCaseInsufficentlyModeledException("No Vep successfully_annotated stub defined for original_variant_query : " + testCase.originalVariantQuery);
+            }
+            Boolean successfullyAnnotatedStub = variantToVepSuccessfullyAnnotated.get(testCase.originalVariantQuery);
+            if (successfullyAnnotatedStub == null) {
+                throw new TestCaseInsufficentlyModeledException("No Vep successfully_annotated stub defined for original_variant_query : " + testCase.originalVariantQuery);
+            }
+            if (!variantToVepAlleleString.containsKey(testCase.originalVariantQuery)) {
+                throw new TestCaseInsufficentlyModeledException("No Vep allele_string stub defined for original_variant_query : " + testCase.originalVariantQuery);
+            }
+            String alleleStringStub = variantToVepAlleleString.get(testCase.originalVariantQuery); // null is an acceptable stub value for allele_string
+            VariantAnnotation response = stubAnnotation(
+                    testCase.originalVariantQuery,
+                    testCase.originalVariantQuery,
+                    successfullyAnnotatedStub,
+                    alleleStringStub);
+            responseList.add(response);
+            //response.setAnnotationJSON("{ \"originalVariantQuery\" : \"" + testCase.originalVariantQuery + "\", \"successfullyAnnotated\" : " + successfullyAnnotatedStub + ", \"allele\" : \"" + alleleStringStub + "\" }");
+            Mockito.when(hgvsVariantAnnotationService.getAnnotation(testCase.originalVariantQuery)).thenReturn(response);
+            Mockito.when(hgvsVariantAnnotationService.getAnnotation(testCase.originalVariantQuery, mockIsoformOverrideSource, mockTokenMap, mockFields)).thenReturn(response);
+        }
+        // create stubs for multi variant queries from built lists .. after jittering order
+        // order of response not guaranteed to match order of query - business logic should handle this properly
+        VariantAnnotation movedItem = responseList.remove(0);
+        responseList.add(movedItem); // first element is now last
+        Mockito.when(hgvsVariantAnnotationService.getAnnotations(queryStringList)).thenReturn(responseList);
+        Mockito.when(hgvsVariantAnnotationService.getAnnotations(queryStringList, mockIsoformOverrideSource, mockTokenMap, mockFields)).thenReturn(responseList);
+
+    }
+
+    private void setUpServiceStubs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException, TestCaseInsufficentlyModeledException
+    {
+        setUpQueryToStubMaps();
+        stubHgvsVariantAnnotationServiceMethodsForType(hgvsSubstitutions);
+        stubHgvsVariantAnnotationServiceMethodsForType(hgvsDeletions);
+        stubHgvsVariantAnnotationServiceMethodsForType(hgvsInsertions);
+        stubHgvsVariantAnnotationServiceMethodsForType(hgvsInsertionDeletions);
+        stubHgvsVariantAnnotationServiceMethodsForType(hgvsInversions);
+    }
+
+    private void runTestSetByVariantString(List<VariantTestCase> variantTestCaseList, boolean supplyOtherParameters)
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        for (VariantTestCase testCase : variantTestCaseList) {
+            VariantAnnotation testResponse = null;
+            if (supplyOtherParameters) {
+                testResponse = verifiedHgvsVariantAnnotationService.getAnnotation(testCase.originalVariantQuery, mockIsoformOverrideSource, mockTokenMap, mockFields);
+            } else {
+                testResponse = verifiedHgvsVariantAnnotationService.getAnnotation(testCase.originalVariantQuery);
+            }
+            Assert.assertEquals(testCase.originalVariantQuery + " : response query field does not match request query string", testCase.originalVariantQuery, testResponse.getOriginalVariantQuery());
+            if (testCase.expectedGnSuccessfullyAnnotated) {
+                Assert.assertTrue(testCase.originalVariantQuery + " : expected successful annotation", testResponse.isSuccessfullyAnnotated());
+            } else {
+                Assert.assertFalse(testCase.originalVariantQuery + " : expected failed annotation", testResponse.isSuccessfullyAnnotated());
+            }
+            if (testResponse.isSuccessfullyAnnotated()) {
+                Assert.assertEquals(testCase.originalVariantQuery + " : Variant Allele comparison", testCase.expectedGnAlleleString, testResponse.getAlleleString());
+            }
+        }
+    }
+
+    private void runTestSetByVariantList(List<VariantTestCase> variantTestCaseList, boolean supplyOtherParameters)
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        // make list of variant query strings and submit
+        List<String> queryHgvsList = variantTestCaseList.stream().map(t -> t.originalVariantQuery).collect(Collectors.toList());
+        List<VariantAnnotation> variantResponse = null;
+        if (supplyOtherParameters) {
+            variantResponse = verifiedHgvsVariantAnnotationService.getAnnotations(queryHgvsList, mockIsoformOverrideSource, mockTokenMap, mockFields);
+        } else {
+            variantResponse = verifiedHgvsVariantAnnotationService.getAnnotations(queryHgvsList);
+        }
+        // check each element of response against expectations
+        HashMap<String, VariantAnnotation> queryToResponse = new HashMap<String, VariantAnnotation>();
+        for (VariantAnnotation responseElement : variantResponse) {
+            if (queryToResponse.put(responseElement.getOriginalVariantQuery(), responseElement) != null) {
+                Assert.fail("More than one response received for query string " + responseElement.getOriginalVariantQuery());
+            }
+        }
+        for (VariantTestCase testCase : variantTestCaseList) {
+            VariantAnnotation testResponse = queryToResponse.get(testCase.originalVariantQuery);
+            if (testResponse == null) {
+                Assert.fail("Response did not include record for query string " + testCase.originalVariantQuery);
+            }
+            if (testCase.expectedGnSuccessfullyAnnotated) {
+                Assert.assertTrue(testCase.originalVariantQuery + " : expected successful annotation", testResponse.isSuccessfullyAnnotated());
+            } else {
+                Assert.assertFalse(testCase.originalVariantQuery + " : expected failed annotation", testResponse.isSuccessfullyAnnotated());
+            }
+            if (testResponse.isSuccessfullyAnnotated()) {
+                Assert.assertEquals(testCase.originalVariantQuery + " : Variant Allele comparison", testCase.expectedGnAlleleString, testResponse.getAlleleString());
+            }
+        }
+    }
+
+    // Tests of the getAnnotation(String) function
+
+    @Test
+    public void getAnnotationForSubstitutionsByVariantString()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(hgvsSubstitutions, false);
+    }
+
+    @Test
+    public void getAnnotationForDeletionsByVariantString()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(hgvsDeletions, false);
+    }
+
+    @Test
+    public void getAnnotationForInsertionsByVariantString()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(hgvsInsertions, false);
+    }
+
+    @Test
+    public void getAnnotationForInsertionDeletionsByVariantString()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(hgvsInsertionDeletions, false);
+    }
+
+    @Test
+    public void getAnnotationForInversionsByVariantString()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(hgvsInversions, false);
+    }
+
+    // Tests of the getAnnotation(String, overrideSource, tokenMap, fields) function
+
+    @Test
+    public void getAnnotationForSubstitutionsByVariantStringWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(hgvsSubstitutions, true);
+    }
+
+    @Test
+    public void getAnnotationForDeletionsByVariantStringWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(hgvsDeletions, true);
+    }
+
+    @Test
+    public void getAnnotationForInsertionsByVariantStringWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(hgvsInsertions, true);
+    }
+
+    @Test
+    public void getAnnotationForInsertionDeletionsByVariantStringWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(hgvsInsertionDeletions, true);
+    }
+
+    @Test
+    public void getAnnotationForInversionsByVariantStringWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantString(hgvsInversions, true);
+    }
+
+    // Tests of the getAnnotation(List<String>) function
+
+    @Test
+    public void getAnnotationForSubstitutionsByVariantLists()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantList(hgvsSubstitutions, false);
+    }
+
+    @Test
+    public void getAnnotationForDeletionsByVariantLists()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantList(hgvsDeletions, false);
+    }
+
+    @Test
+    public void getAnnotationForInsertionsByVariantLists()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantList(hgvsInsertions, false);
+    }
+
+    @Test
+    public void getAnnotationForInsertionDeletionsByVariantLists()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantList(hgvsInsertionDeletions, false);
+    }
+
+    @Test
+    public void getAnnotationForInversionsByVariantLists()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantList(hgvsInversions, false);
+    }
+
+    // Tests of the getAnnotations(List<String>, overrideSource, tokenMap, fields) function
+
+    @Test
+    public void getAnnotationForSubstitutionsByVariantListWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantList(hgvsSubstitutions, true);
+    }
+
+    @Test
+    public void getAnnotationForDeletionsByVariantListWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantList(hgvsDeletions, true);
+    }
+
+    @Test
+    public void getAnnotationForInsertionsByVariantListWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantList(hgvsInsertions, true);
+    }
+
+    @Test
+    public void getAnnotationForInsertionDeletionsByVariantListWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantList(hgvsInsertionDeletions, true);
+    }
+
+    @Test
+    public void getAnnotationForInversionsByVariantListWithArgs()
+        throws VariantAnnotationWebServiceException, VariantAnnotationNotFoundException
+    {
+        runTestSetByVariantList(hgvsInversions, true);
+    }
+
+}

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/AnnotationController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-17 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2015 - 2021 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -33,23 +33,21 @@
 package org.cbioportal.genome_nexus.web;
 
 import io.swagger.annotations.*;
-
-import org.cbioportal.genome_nexus.component.annotation.NotationConverter;
-import org.cbioportal.genome_nexus.model.*;
-import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
-import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
-import org.cbioportal.genome_nexus.util.TokenMapConverter;
-import org.cbioportal.genome_nexus.service.*;
-import org.cbioportal.genome_nexus.web.validation.*;
-import org.cbioportal.genome_nexus.web.config.PublicApi;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.validation.annotation.Validated;
-import org.cbioportal.genome_nexus.util.TokenMapConverter;
-
 import java.util.*;
-
+import org.cbioportal.genome_nexus.model.GenomicLocation;
+import org.cbioportal.genome_nexus.model.VariantAnnotation;
+import org.cbioportal.genome_nexus.service.GenomicLocationAnnotationService;
+import org.cbioportal.genome_nexus.service.SelectedAnnotationService;
+import org.cbioportal.genome_nexus.service.VariantAnnotationService;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationQueryMixedFormatException;
+import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
+import org.cbioportal.genome_nexus.service.internal.VerifiedGenomicLocationAnnotationServiceImpl;
+import org.cbioportal.genome_nexus.util.TokenMapConverter;
+import org.cbioportal.genome_nexus.web.config.PublicApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * @author Benjamin Gross
@@ -61,236 +59,182 @@ import java.util.*;
 @Validated
 public class AnnotationController
 {
-    private final VariantAnnotationService hgvsAnnotationService;
     private final VariantAnnotationService dbsnpAnnotationService;
-    private final GenomicLocationAnnotationService genomicLocationAnnotationService;
-    private final NotationConverter notationConverter; 
-    private final Boolean isRegionAnnotationEnabled; 
+    private final GenomicLocationAnnotationService verifiedGenomicLocationAnnotationService;
+    private final SelectedAnnotationService selectedAnnotationService;
     private final TokenMapConverter tokenMapConverter;
+
     @Autowired
-    public AnnotationController(VariantAnnotationService hgvsVariantAnnotationService,
-                                VariantAnnotationService dbsnpVariantAnnotationService,
-                                GenomicLocationAnnotationService genomicLocationAnnotationService,
-                                NotationConverter notationConverter,
-                                @Value("${gn_vep.region.url:}") String vepRegionUrl)
+    public AnnotationController(VariantAnnotationService dbsnpVariantAnnotationService,
+                                GenomicLocationAnnotationService verifiedGenomicLocationAnnotationServiceImpl,
+                                SelectedAnnotationService selectedAnnotationService)
     {
-        this.hgvsAnnotationService = hgvsVariantAnnotationService;
         this.dbsnpAnnotationService = dbsnpVariantAnnotationService;
-        this.genomicLocationAnnotationService = genomicLocationAnnotationService;
-        this.notationConverter = notationConverter;
-        this.isRegionAnnotationEnabled = vepRegionUrl != null && vepRegionUrl.length() > 0;
+        this.verifiedGenomicLocationAnnotationService = verifiedGenomicLocationAnnotationServiceImpl;
+        this.selectedAnnotationService = selectedAnnotationService;
         this.tokenMapConverter = new TokenMapConverter();
     }
 
     // TODO remove this endpoint after all internal dependencies are resolved
-    @ApiOperation(value = "Retrieves VEP annotation for the provided list of variants",
-        hidden = true,
-        nickname = "getVariantAnnotation")
-    @RequestMapping(value = "/hgvs/{variants:.+}",
-        method = RequestMethod.GET,
-        produces = "application/json")
+    @ApiOperation(value = "Retrieves VEP annotation for the provided list of variants", hidden = true, nickname = "getVariantAnnotation")
+    @RequestMapping(value = "/hgvs/{variants:.+}", method = RequestMethod.GET, produces = "application/json")
     @Deprecated
     public List<VariantAnnotation> getVariantAnnotation(
-        @PathVariable
-        @ApiParam(value="Comma separated list of variants. For example X:g.66937331T>A,17:g.41242962_41242963insGA " +
-            "(GRCh37) or 1:g.182712A>C,2:g.265023C>T,3:g.319781del,19:g.110753dup,1:g.1385015_1387562del (GRCh38)",
-            required = true,
-            allowMultiple = true)
-        List<String> variants,
-        @RequestParam(required = false)
-        @ApiParam(value="Isoform override source. For example uniprot",
-            required = false)
-        String isoformOverrideSource,
-        @RequestParam(required = false)
-        @ApiParam(value="Map of tokens. For example {\"source1\":\"put-your-token1-here\",\"source2\":\"put-your-token2-here\"}",
-            required = false)
+            @PathVariable
+            @ApiParam(value="Comma separated list of variants. For example X:g.66937331T>A,17:g.41242962_41242963insGA " +
+                    "(GRCh37) or 1:g.182712A>C,2:g.265023C>T,3:g.319781del,19:g.110753dup,1:g.1385015_1387562del (GRCh38)",
+                    required = true, allowMultiple = true)
+            List<String> variants,
+            @RequestParam(required = false)
+            @ApiParam(value="Isoform override source. For example uniprot", required = false)
+            String isoformOverrideSource,
+            @RequestParam(required = false)
+            @ApiParam(value="Map of tokens. For example {\"source1\":\"put-your-token1-here\",\"source2\":\"put-your-token2-here\"}",
+                    required = false)
             String token,
-        @RequestParam(required = false)
-        @ApiParam(value="Comma separated list of fields to include (case-sensitive!). " +
-            "For example: hotspots", required = false, defaultValue = "hotspots")
-        List<String> fields)
+            @RequestParam(required = false)
+            @ApiParam(value="Comma separated list of fields to include (case-sensitive!). " +
+                    "For example: hotspots", required = false, defaultValue = "hotspots")
+            List<String> fields) throws VariantAnnotationNotFoundException, VariantAnnotationQueryMixedFormatException, VariantAnnotationWebServiceException
     {
         return this.fetchVariantAnnotationPOST(variants, isoformOverrideSource, token, fields);
     }
 
     // TODO remove this endpoint after all internal dependencies are resolved
-    @ApiOperation(value = "Retrieves VEP annotation for the provided list of variants",
-        hidden = true,
-        nickname = "postVariantAnnotation")
-    @RequestMapping(value = "/hgvs",
-        method = RequestMethod.POST,
-        produces = "application/json")
+    @ApiOperation(value = "Retrieves VEP annotation for the provided list of variants", hidden = true, nickname = "postVariantAnnotation")
+    @RequestMapping(value = "/hgvs", method = RequestMethod.POST, produces = "application/json")
     @Deprecated
     public List<VariantAnnotation> postVariantAnnotation(
-        @RequestParam
-        @ApiParam(value="Comma separated list of variants. For example X:g.66937331T>A,17:g.41242962_41242963insGA " +
-            "(GRCh37) or 1:g.182712A>C,2:g.265023C>T,3:g.319781del,19:g.110753dup,1:g.1385015_1387562del (GRCh38)",
-            required = true,
-            allowMultiple = true)
+            @RequestParam
+            @ApiParam(value="Comma separated list of variants. For example X:g.66937331T>A,17:g.41242962_41242963insGA " +
+                    "(GRCh37) or 1:g.182712A>C,2:g.265023C>T,3:g.319781del,19:g.110753dup,1:g.1385015_1387562del (GRCh38)",
+                    required = true, allowMultiple = true)
             List<String> variants,
-        @RequestParam(required = false)
-        @ApiParam(value="Isoform override source. For example uniprot",
-            required = false)
+            @RequestParam(required = false)
+            @ApiParam(value="Isoform override source. For example uniprot", required = false)
             String isoformOverrideSource,
-        @RequestParam(required = false) 
-        @ApiParam(value="Map of tokens. For example {\"source1\":\"put-your-token1-here\",\"source2\":\"put-your-token2-here\"}",
-            required = false)
+            @RequestParam(required = false) 
+            @ApiParam(value="Map of tokens. For example {\"source1\":\"put-your-token1-here\",\"source2\":\"put-your-token2-here\"}", required = false)
             String token,
-        @RequestParam(required = false)
-        @ApiParam(value="Comma separated list of fields to include (case-sensitive!). " +
-            "For example: hotspots", required = false, defaultValue = "hotspots")
+            @RequestParam(required = false)
+            @ApiParam(value="Comma separated list of fields to include (case-sensitive!). For example: hotspots", required = false, defaultValue = "hotspots")
+            List<String> fields) throws VariantAnnotationNotFoundException, VariantAnnotationQueryMixedFormatException, VariantAnnotationWebServiceException
+    {
+        return this.fetchVariantAnnotationPOST(variants, isoformOverrideSource, token, fields);
+    }
+
+    @ApiOperation(value = "Retrieves VEP annotation for the provided list of variants", nickname = "fetchVariantAnnotationPOST")
+    @RequestMapping(value = "/annotation", method = RequestMethod.POST, produces = "application/json")
+    public List<VariantAnnotation> fetchVariantAnnotationPOST(
+            @ApiParam(value="List of variants. For example [\"X:g.66937331T>A\",\"17:g.41242962_41242963insGA\"] (GRCh37) " +
+                    "or [\"1:g.182712A>C\", \"2:g.265023C>T\", \"3:g.319781del\", \"19:g.110753dup\", " +
+                    "\"1:g.1385015_1387562del\"] (GRCh38)", required = true)
+            @RequestBody
+            List<String> variants,
+            @ApiParam(value="Isoform override source. For example uniprot", required = false)
+            @RequestParam(required = false)
+            String isoformOverrideSource,
+            @ApiParam(value="Map of tokens. For example {\"source1\":\"put-your-token1-here\",\"source2\":\"put-your-token2-here\"}", required = false)
+            @RequestParam(required = false)
+            String token,
+            @ApiParam(value="Comma separated list of fields to include (case-sensitive!). For example: hotspots", required = false, defaultValue = "hotspots")
+            @RequestParam(required = false)
+            List<String> fields) throws VariantAnnotationNotFoundException, VariantAnnotationQueryMixedFormatException, VariantAnnotationWebServiceException
+    {
+        return this.selectedAnnotationService.getAnnotations(variants, isoformOverrideSource, tokenMapConverter.convertToMap(token), fields);
+    }
+
+    @ApiOperation(value = "Retrieves VEP annotation for the provided variant", nickname = "fetchVariantAnnotationGET")
+    @RequestMapping(value = "/annotation/{variant:.+}", method = RequestMethod.GET, produces = "application/json")
+    public VariantAnnotation fetchVariantAnnotationGET(
+            @ApiParam(value="Variant. For example 17:g.41242962_41242963insGA", required = true)
+            @PathVariable
+            String variant,
+            @ApiParam(value="Isoform override source. For example uniprot", required = false)
+            @RequestParam(required = false)
+            String isoformOverrideSource,
+            @ApiParam(value="Map of tokens. For example {\"source1\":\"put-your-token1-here\",\"source2\":\"put-your-token2-here\"}", required = false)
+            @RequestParam(required = false)
+            String token,
+            @ApiParam(value="Comma separated list of fields to include (case-sensitive!). For example: hotspots", required = false, defaultValue = "hotspots")
+            @RequestParam(required = false) List<String> fields) throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException
+    {
+        return this.selectedAnnotationService.getAnnotation(variant, isoformOverrideSource, tokenMapConverter.convertToMap(token), fields);
+    }
+
+    @ApiOperation(value = "Retrieves VEP annotation for the provided list of genomic locations", nickname = "fetchVariantAnnotationByGenomicLocationPOST")
+    @RequestMapping(value = "/annotation/genomic", method = RequestMethod.POST, produces = "application/json")
+    public List<VariantAnnotation> fetchVariantAnnotationByGenomicLocationPOST(
+            @ApiParam(value="List of Genomic Locations", required = true)
+            @RequestBody
+            List<GenomicLocation> genomicLocations,
+            @ApiParam(value="Isoform override source. For example uniprot", required = false)
+            @RequestParam(required = false)
+            String isoformOverrideSource,
+            @ApiParam(value="Map of tokens. For example {\"source1\":\"put-your-token1-here\",\"source2\":\"put-your-token2-here\"}", required = false)
+            @RequestParam(required = false)
+            String token,
+            @ApiParam(value="Comma separated list of fields to include (case-sensitive!). For example: hotspots", required = false, defaultValue = "hotspots")
+            @RequestParam(required = false)
             List<String> fields)
     {
-        return fetchVariantAnnotationPOST(variants, isoformOverrideSource, token, fields);
-    }
-
-    @ApiOperation(value = "Retrieves VEP annotation for the provided list of variants",
-        nickname = "fetchVariantAnnotationPOST")
-    @RequestMapping(value = "/annotation",
-        method = RequestMethod.POST,
-        produces = "application/json")
-    public List<VariantAnnotation> fetchVariantAnnotationPOST(
-        @ApiParam(value="List of variants. For example [\"X:g.66937331T>A\",\"17:g.41242962_41242963insGA\"] (GRCh37) " +
-            "or [\"1:g.182712A>C\", \"2:g.265023C>T\", \"3:g.319781del\", \"19:g.110753dup\", " +
-            "\"1:g.1385015_1387562del\"] (GRCh38)",
-            required = true)
-        @RequestBody List<String> variants,
-        @ApiParam(value="Isoform override source. For example uniprot",
-            required = false)
-        @RequestParam(required = false) String isoformOverrideSource,
-        @ApiParam(value="Map of tokens. For example {\"source1\":\"put-your-token1-here\",\"source2\":\"put-your-token2-here\"}",
-            required = false)
-        @RequestParam(required = false) String token,
-        @ApiParam(value="Comma separated list of fields to include (case-sensitive!). " +
-            "For example: hotspots", required = false, defaultValue = "hotspots")
-        @RequestParam(required = false) List<String> fields)
-    {
-        if (this.isRegionAnnotationEnabled && variants.size() > 0 && variants.stream().anyMatch(v -> v.contains("g.")))
-        {
-            // if any is of hgvsg format, assume all of hgvsg format
-            return this.genomicLocationAnnotationService.getAnnotations(notationConverter.hgvsgToGenomicLocations(variants), isoformOverrideSource, tokenMapConverter.convertToMap(token), fields);
-        }
-        else {
-            return this.hgvsAnnotationService.getAnnotations(variants, isoformOverrideSource, tokenMapConverter.convertToMap(token), fields);
-        }
-    }
-
-    @ApiOperation(value = "Retrieves VEP annotation for the provided variant",
-        nickname = "fetchVariantAnnotationGET")
-    @RequestMapping(value = "/annotation/{variant:.+}",
-        method = RequestMethod.GET,
-        produces = "application/json")
-    public VariantAnnotation fetchVariantAnnotationGET(
-        @ApiParam(value="Variant. For example 17:g.41242962_41242963insGA",
-            required = true)
-        @PathVariable String variant,
-        @ApiParam(value="Isoform override source. For example uniprot",
-            required = false)
-        @RequestParam(required = false) String isoformOverrideSource,
-        @ApiParam(value="Map of tokens. For example {\"source1\":\"put-your-token1-here\",\"source2\":\"put-your-token2-here\"}",
-            required = false)
-        @RequestParam(required = false) String token,
-        @ApiParam(value="Comma separated list of fields to include (case-sensitive!). " +
-            "For example: hotspots", required = false, defaultValue = "hotspots")
-        @RequestParam(required = false) List<String> fields)
-        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException
-    {
-        if (this.isRegionAnnotationEnabled && variant.contains("g."))
-        {
-            // convert to genomic location to be able to use VEP region 
-            return this.genomicLocationAnnotationService.getAnnotation(notationConverter.hgvsgToGenomicLocation(variant).toString(), isoformOverrideSource, tokenMapConverter.convertToMap(token), fields);
-        } else {
-            return this.hgvsAnnotationService.getAnnotation(variant, isoformOverrideSource, tokenMapConverter.convertToMap(token), fields);
-        }
-    }
-
-    @ApiOperation(value = "Retrieves VEP annotation for the provided list of genomic locations",
-        nickname = "fetchVariantAnnotationByGenomicLocationPOST")
-    @RequestMapping(value = "/annotation/genomic",
-        method = RequestMethod.POST,
-        produces = "application/json")
-    public List<VariantAnnotation> fetchVariantAnnotationByGenomicLocationPOST(
-        @ApiParam(value="List of Genomic Locations",
-            required = true)
-        @RequestBody List<GenomicLocation> genomicLocations,
-        @ApiParam(value="Isoform override source. For example uniprot",
-            required = false)
-        @RequestParam(required = false) String isoformOverrideSource,
-        @ApiParam(value="Map of tokens. For example {\"source1\":\"put-your-token1-here\",\"source2\":\"put-your-token2-here\"}",
-            required = false)
-        @RequestParam(required = false) String token,
-        @ApiParam(value="Comma separated list of fields to include (case-sensitive!). " +
-            "For example: hotspots", required = false, defaultValue = "hotspots")
-        @RequestParam(required = false) List<String> fields)
-    {
-        return this.genomicLocationAnnotationService.getAnnotations(
+        return this.verifiedGenomicLocationAnnotationService.getAnnotations(
             genomicLocations, isoformOverrideSource, tokenMapConverter.convertToMap(token), fields);
     }
 
-    @ApiOperation(value = "Retrieves VEP annotation for the provided genomic location",
-        nickname = "fetchVariantAnnotationByGenomicLocationGET")
-    @RequestMapping(value = "/annotation/genomic/{genomicLocation:.+}",
-        method = RequestMethod.GET,
-        produces = "application/json")
+    @ApiOperation(value = "Retrieves VEP annotation for the provided genomic location", nickname = "fetchVariantAnnotationByGenomicLocationGET")
+    @RequestMapping(value = "/annotation/genomic/{genomicLocation:.+}", method = RequestMethod.GET, produces = "application/json")
     public VariantAnnotation fetchVariantAnnotationByGenomicLocationGET(
-        @ApiParam(value="A genomic location. For example 7,140453136,140453136,A,T",
-            required = true)
-        @PathVariable String genomicLocation,
-        @ApiParam(value="Isoform override source. For example uniprot",
-            required = false)
-        @RequestParam(required = false) String isoformOverrideSource,
-        @ApiParam(value="Map of tokens. For example {\"source1\":\"put-your-token1-here\",\"source2\":\"put-your-token2-here\"}",
-            required = false)
-        @RequestParam(required = false) String token,
-        @ApiParam(value="Comma separated list of fields to include (case-sensitive!). " +
-            "For example: hotspots", required = false, defaultValue = "hotspots")
-        @RequestParam(required = false) List<String> fields)
-        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException
+            @ApiParam(value="A genomic location. For example 7,140453136,140453136,A,T", required = true)
+            @PathVariable
+            String genomicLocation,
+            @ApiParam(value="Isoform override source. For example uniprot", required = false)
+            @RequestParam(required = false)
+            String isoformOverrideSource,
+            @ApiParam(value="Map of tokens. For example {\"source1\":\"put-your-token1-here\",\"source2\":\"put-your-token2-here\"}", required = false)
+            @RequestParam(required = false)
+            String token,
+            @ApiParam(value="Comma separated list of fields to include (case-sensitive!). For example: hotspots", required = false, defaultValue = "hotspots")
+            @RequestParam(required = false)
+            List<String> fields) throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException
     {
-        return this.genomicLocationAnnotationService.getAnnotation(genomicLocation, isoformOverrideSource, tokenMapConverter.convertToMap(token), fields);
+        return this.verifiedGenomicLocationAnnotationService.getAnnotation(genomicLocation, isoformOverrideSource, tokenMapConverter.convertToMap(token), fields);
     }
 
-    @ApiOperation(value = "Retrieves VEP annotation for the provided list of dbSNP ids",
-        nickname = "fetchVariantAnnotationByIdPOST")
-    @RequestMapping(value = "/annotation/dbsnp/",
-        method = RequestMethod.POST,
-        produces = "application/json")
+    @ApiOperation(value = "Retrieves VEP annotation for the provided list of dbSNP ids", nickname = "fetchVariantAnnotationByIdPOST")
+    @RequestMapping(value = "/annotation/dbsnp/", method = RequestMethod.POST, produces = "application/json")
     public List<VariantAnnotation> fetchVariantbyDbSnpIdAnnotationPOST(
-        @ApiParam(value="List of variant IDs. For example [\"rs116035550\"]",
-            required = true)
-        @RequestBody List<String> variantIds,
-        @ApiParam(value="Isoform override source. For example uniprot",
-            required = false)
-        @RequestParam(required = false) String isoformOverrideSource,
-        @ApiParam(value="Map of tokens. For example {\"source1\":\"put-your-token1-here\",\"source2\":\"put-your-token2-here\"}",
-            required = false)
-        @RequestParam(required = false) String token,
-        @ApiParam(value="Comma separated list of fields to include (case-sensitive!). " +
-            "For example: annotation_summary", required = false, defaultValue = "annotation_summary")
-        @RequestParam(required = false) List<String> fields)
+            @ApiParam(value="List of variant IDs. For example [\"rs116035550\"]", required = true)
+            @RequestBody
+            List<String> variantIds,
+            @ApiParam(value="Isoform override source. For example uniprot", required = false)
+            @RequestParam(required = false)
+            String isoformOverrideSource,
+            @ApiParam(value="Map of tokens. For example {\"source1\":\"put-your-token1-here\",\"source2\":\"put-your-token2-here\"}", required = false)
+            @RequestParam(required = false)
+            String token,
+            @ApiParam(value="Comma separated list of fields to include (case-sensitive!). For example: annotation_summary", required = false, defaultValue = "annotation_summary")
+            @RequestParam(required = false)
+            List<String> fields)
     {
         return this.dbsnpAnnotationService.getAnnotations(variantIds, isoformOverrideSource, tokenMapConverter.convertToMap(token), fields);
     }
 
-    @ApiOperation(value = "Retrieves VEP annotation for the give dbSNP id",
-        nickname = "fetchVariantAnnotationByIdGET")
-    @RequestMapping(value = "/annotation/dbsnp/{variantId:.+}",
-        method = RequestMethod.GET,
-        produces = "application/json")
+    @ApiOperation(value = "Retrieves VEP annotation for the give dbSNP id", nickname = "fetchVariantAnnotationByIdGET")
+    @RequestMapping(value = "/annotation/dbsnp/{variantId:.+}", method = RequestMethod.GET, produces = "application/json")
     public VariantAnnotation fetchVariantAnnotationByDbSnpIdGET(
-        @ApiParam(value="dbSNP id. For example rs116035550.",
-            required = true)
-        @PathVariable String variantId,
-        @ApiParam(value="Isoform override source. For example uniprot",
-            required = false)
-        @RequestParam(required = false) String isoformOverrideSource,
-        @ApiParam(value="Map of tokens. For example {\"source1\":\"put-your-token1-here\",\"source2\":\"put-your-token2-here\"}",
-            required = false)
-        @RequestParam(required = false) String token,
-        @ApiParam(value="Comma separated list of fields to include (case-sensitive!). " +
-            "For example: annotation_summary", required = false, defaultValue = "annotation_summary")
-        @RequestParam(required = false) List<String> fields)
-        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException
+            @ApiParam(value="dbSNP id. For example rs116035550.", required = true)
+            @PathVariable
+            String variantId,
+            @ApiParam(value="Isoform override source. For example uniprot", required = false)
+            @RequestParam(required = false)
+            String isoformOverrideSource,
+            @ApiParam(value="Map of tokens. For example {\"source1\":\"put-your-token1-here\",\"source2\":\"put-your-token2-here\"}", required = false)
+            @RequestParam(required = false)
+            String token,
+            @ApiParam(value="Comma separated list of fields to include (case-sensitive!). " + "For example: annotation_summary", required = false, defaultValue = "annotation_summary")
+            @RequestParam(required = false)
+            List<String> fields) throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException
     {
         return this.dbsnpAnnotationService.getAnnotation(variantId, isoformOverrideSource, tokenMapConverter.convertToMap(token), fields);
     }

--- a/web/src/test/java/org/cbioportal/genome_nexus/web/AnnotationIntegrationTest.java
+++ b/web/src/test/java/org/cbioportal/genome_nexus/web/AnnotationIntegrationTest.java
@@ -136,7 +136,30 @@ public class AnnotationIntegrationTest
 
     }
 
-    @Test
+    // THIS TEST HAS BEEN DISABLED. Several things need to be worked out here.
+    // - the format of this query is erroneous. HGVS format for deletions no longer recommend specifying the referene allele nucleotides,
+    //   and additionally our code base has been altered to convert these request into the recommended format before sending, so the request
+    //   will be sent simply as "11:g.4967810del" which is a single nucleotide deletion. Additionally, even if the request to the ensembl
+    //   rest endpoint did include the reference allele, the ensembl service itself is ignoring the reference allele and only annotates
+    //   based on the genomic start and stop positions. This can be seen by making requests such as :
+    //       - 11:g.4967810delT
+    //       - 11:g.4967810delTT
+    //       - 11:g.4967810delTTT
+    //   all of these come back annotated as a single nucleotide deletion. To annotate a long deletion, the end position must also be given
+    //   such as 11:g.4967810_4976423del for a 8614 nucleotide deletion. The reference allele *could* be specified in the (no longer
+    //   recommended) fully specified format.
+    // - if the format is adjusted to properly specify a 8614 nucleotide deletion, the ensembl vep annotation endpoint is failing to annotate
+    //   this long deletion. This request: https://rest.ensembl.org/vep/human/hgvs/11:g.4967810_4976423del?content-type=application/json
+    //   leads to this response : {"error":"Unable to parse HGVS notation '11:g.4967810_4976423del': Region requested must be smaller than 5kb"}
+    //   so this integration test cannot be passed using the ensembl rest api endpoint (unless we choose to adopt the expectation that requests
+    //   5kb or longer fail)
+    // - when genome-nexus is deployed using a local instance of the vep command line tool (from repo genome-nexus-vep), queries are first
+    //   converted to ensembl rest-like region format. So this query will be converted to "11:4967811-4976423:1/-". It has been verified that
+    //   the ensembl public vep region endpoint will respond appropriately to this query, and our local deployment of genome-nexus-vep
+    //   command line tool will also respond appropriately. However, there is currently a bug in the conversion code which instead converts
+    //   the request into a request which is a zero-lengh insert at the start position: "11:4967811-4967810:1/-", so this alternate mode for
+    //   querying a long deletion is not even possible.
+    //@Test
     public void testLongDeletion()
     {
         String[] variants = {


### PR DESCRIPTION
## Problem
When annotation api requests specify deleted nucleotides, genomenexus currently does not check whether those nucleotides match the content of the reference genome assembly which is in use by VEP to make variant effect predictions. This is because of simplification of the query format before passing the request to VEP.

When a genome nexus server uses the public Ensembl vep annotation endpoints for predictions, queries are submitted in the (standard simplified) HGVS format. This format no longer includes the nucleotides which are deleted, for example with this deletion-insertion variants: /annotation/genomic/5,138163255,138163256,CC,TT

the query which is made Ensembl does not mention the replaced "CC" nucleotides but is encoded like this:
5:g.138163255_138163256delinsTT
So a predicted effect is generated using the genome assembly available to VEP (which has sequence "TC" rather than "CC" at these positions.

When a genome nexus server uses a local deployment of the [VEP command line tool](https://github.com/genome-nexus/genome-nexus-vep) the query for the same case is formatted in a REST-style region format which also does not mention the deleted nucleotides:
5:138163255-138163256 :-/TT

There are subtle differences in output response between these two configured VEP service providers when invariant nucleotides are part of the "replacement". In other words, the results can differ if the query "replaces" a T with a T in the first position of a 2 NT delins where the second position is a genuine replacement (C>T).

To avoid these inconsistencies, we have decided to require that any query which specifies a reference allele must be validated to make sure the provided reference allele matches the genome assembly in use by VEP. During annotation of our own studies and variants we will provide the reference allele, increasing reliability and standardization in results.

## Strategy
Two services are available for providing annotation. One using HGVS format making requests to the Ensembl /annotation endpoint, One using REST-style region format to make requests to a locally deployed VEP web service. Calls to these services will be redirected to a higher level service which both makes the appropriate service call for annotation, and then verifies that the annotation returned from the service contains a reference genome sequence which matches the input Reference_Allele sequence. For some types of variants (SNV) this information will always be available and validation can be done with one request. For other types of variants (delins) the annotation returned from the service may not contain the full reference genome sequence if the extent of the variation has been reduced (as discussed above when part of the "replacement" is actually invariant). In those cases a subsequent request to the annotation service provider will be made for a full deletion of the coordinates covered by the Reference_Allele. Then the full reference genome sequence will be compared to the Reference_Allele. When it is not a match, the service will report a failure to annotate.
