### PR TITLE
Add transcript -> uniprot map into cache to increase query speed

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/EnsemblTranscript.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/EnsemblTranscript.java
@@ -1,6 +1,8 @@
 package org.cbioportal.genome_nexus.model;
 
 import java.util.List;
+
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -12,7 +14,8 @@ import org.springframework.data.mongodb.core.mapping.Field;
 public class EnsemblTranscript
 {
     public final static String TRANSCRIPT_ID_FIELD_NAME = "transcript_stable_id";
-
+    
+    @Indexed
     @Field(value=EnsemblTranscript.TRANSCRIPT_ID_FIELD_NAME)
     private String transcriptId;
 

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/EnsemblService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/EnsemblService.java
@@ -31,4 +31,5 @@ public interface EnsemblService
     String getHugoSymbolByEntrezGeneId(String entrezGeneId);
 
     Set<String> getCanonicalTranscriptIdsBySource(String isoformOverrideSource);
+    String getUniprotId(String transcript);
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
@@ -237,11 +237,11 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
             summary.setSiftScore(transcriptConsequence.getSiftScore());
             if (transcriptConsequence.getTranscriptId() != null) {
                 try {
-                    EnsemblTranscript transcript = this.ensemblService.getEnsemblTranscriptsByTranscriptId(transcriptConsequence.getTranscriptId());
-                    if (transcript != null) {
-                        summary.setUniprotId(transcript.getUniprotId());
+                    String uniprotId = this.ensemblService.getUniprotId(transcriptConsequence.getTranscriptId());
+                    if (uniprotId != null) {
+                        summary.setUniprotId(uniprotId);
                     }
-                } catch (EnsemblTranscriptNotFoundException e) {
+                } catch (Exception e) {
                     // TODO Auto-generated catch block
                     e.printStackTrace();
                 }


### PR DESCRIPTION
Fix: #502 

Create a map: HashMap<transcript_id, uniprot_id>, store map in cache, and enrich annotation summary `uniprotId` with map.

Test results:

- Build transcript to uniprot map: 11s
- Query 1400 variant with map: 10s(no significant increase, same as before adding uniprot)