### PR TITLE
In follow up query, convert genomic location to hgvsg or region based on whether region annotation is enabled 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,4 +27,4 @@ services:
     ports:
       - "6060:8080"
     volumes:
-      - ${VEP_CACHE}:/opt/vep/.vep/:ro
+      - ${VEP_CACHE}:/opt/vep/.vep/

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/GenomicLocationAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/GenomicLocationAnnotationServiceImpl.java
@@ -88,7 +88,7 @@ public class GenomicLocationAnnotationServiceImpl implements GenomicLocationAnno
     public VariantAnnotation getAnnotation(GenomicLocation genomicLocation)
         throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException
     {
-        VariantAnnotation variantAnnotation = this.variantAnnotationService.getAnnotation(this.notationConverter.genomicToEnsemblRestRegion(genomicLocation));
+        VariantAnnotation variantAnnotation = this.variantAnnotationService.getAnnotation(this.genomicLocationToVariantFormat.convert(genomicLocation));
         genomicLocation.setOriginalInput(genomicLocation.toString());
         variantAnnotation.setOriginalVariantQuery(genomicLocation.getOriginalInput());
         return variantAnnotation;
@@ -109,7 +109,7 @@ public class GenomicLocationAnnotationServiceImpl implements GenomicLocationAnno
         Map<String, String> convertedVarsToOrigVarQueryMap = mapConvertedVarsToOrigVarQuery(genomicLocations);
         List<VariantAnnotation> variantAnnotations = new ArrayList<>();
         this.variantAnnotationService.getAnnotations(
-                this.notationConverter.genomicToEnsemblRestRegion(genomicLocations)
+                this.genomicLocationsToVariantFormats.convert(genomicLocations)
         ).stream().map((a) -> {
             a.setOriginalVariantQuery(convertedVarsToOrigVarQueryMap.get(a.getVariant()));
             return a;


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/550

If region annotation is enabled: convert genomic location to region.
If region annotation is not enabled: convert genomic location to hgvs.

Test query:
7,55242467,55242486,AATTAAGAGAAGCAACATCT,AGCAA