### PR TITLE
Explicitly set log4j2 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
 
     <properties>
       <java.version>1.8</java.version>
+      <log4j2.version>2.17.0</log4j2.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Fix #579

See https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot for details.