### PR TITLE
Fix 404s

### DIFF
--- a/web/src/main/java/org/cbioportal/genome_nexus/GenomeNexusAnnotation.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/GenomeNexusAnnotation.java
@@ -41,9 +41,11 @@ import org.springframework.boot.web.servlet.support.SpringBootServletInitializer
 import org.springframework.boot.web.servlet.error.ErrorController;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import springfox.documentation.builders.ApiInfoBuilder;
@@ -128,6 +130,7 @@ public class GenomeNexusAnnotation extends SpringBootServletInitializer implemen
     private static final String PATH = "/error";
 
     @RequestMapping(value = PATH)
+    @ResponseStatus(HttpStatus.OK)
     public String error() {
         return "forward:/";
     }


### PR DESCRIPTION
Used to give 404 on frontend only pages:

```
curl --verbose 'http://localhost:38080/variant/7:g.140453136A%3ET'
< HTTP/1.1 404
```

This fixes it to instead show 200:
```
curl --verbose 'http://localhost:38080/variant/7:g.140453136A%3ET'
< HTTP/1.1 200
```

However this means 404s should now be handled in the frontend.
See for instance:

```
curl --verbose 'http://localhost:38080/api/random'
< HTTP/1.1 200
```

For cBioPortal's API it seems that `/api/error` is handled by API but other routes like `/asddasd/` are handled by frontend, which might be a cleaner solution.

