### PR TITLE
move genome-nexus-importer env to build args

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,9 @@ services:
 
   db:
     build: https://github.com/genome-nexus/genome-nexus-importer.git
-    environment:
-      - REF_ENSEMBL_VERSION=${REF_ENSEMBL_VERSION}
-      - SPECIES=${SPECIES}
+      args:
+        - REF_ENSEMBL_VERSION=${REF_ENSEMBL_VERSION:-grch37_ensembl92}
+        - SPECIES=${SPECIES:-homo_sapiens}
     restart: always
 
   vep:


### PR DESCRIPTION
this comes along together with https://github.com/genome-nexus/genome-nexus-importer/pull/53 which now depends on setting the environment variables during build