### PR TITLE
Version Support

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/AggregateSourceInfo.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/AggregateSourceInfo.java
@@ -1,0 +1,28 @@
+package org.cbioportal.genome_nexus.model;
+
+public class AggregateSourceInfo {
+
+    private GenomeNexusInfo genomeNexus;
+    private VEPInfo vep;
+
+    public AggregateSourceInfo(GenomeNexusInfo genomeNexusInfo, VEPInfo vepInfo) {
+        this.genomeNexus = genomeNexusInfo;
+        this.vep = vepInfo;
+    }
+
+    public GenomeNexusInfo getGenomeNexus() {
+        return genomeNexus;
+    }
+
+    public void setGenomeNexus(GenomeNexusInfo genomeNexusInfo) {
+        this.genomeNexus = genomeNexusInfo;
+    }
+
+    public VEPInfo getVep() {
+        return vep;
+    }
+
+    public void setVep(VEPInfo vepInfo) {
+        this.vep = vepInfo;
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/GenomeNexusInfo.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/GenomeNexusInfo.java
@@ -1,0 +1,12 @@
+package org.cbioportal.genome_nexus.model;
+
+public class GenomeNexusInfo {
+
+    public Version server;
+    public Version database;
+
+    public GenomeNexusInfo(String genomeNexusServerVersion, String genomeNexusDatabaseVersion) {
+        this.server = new Version(genomeNexusServerVersion, true);
+        this.database = new Version(genomeNexusDatabaseVersion, true);
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VEPInfo.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VEPInfo.java
@@ -1,0 +1,25 @@
+package org.cbioportal.genome_nexus.model;
+
+public class VEPInfo {
+
+    private final String NA_STRING = "NA";
+    private final String COMMENT = "VEP annotations are currently externally sourced from ENSEMBL. Results are subject to change without notice.";
+
+    // server corresponds to genome nexus VEP code release
+    // cache corresponds to downloaded FASTA cache
+    // comment is an additional disclaimer in the event we are using ENSEMBL VEP
+    public Version server;
+    public Version cache;
+    public String comment;
+
+    public VEPInfo(String vepServerVersion, String vepCacheVersion, String vepRegionURL) {
+        if (vepRegionURL != null && !vepRegionURL.isEmpty()) {
+            this.server = new Version(vepServerVersion, true);
+            this.cache = new Version(vepCacheVersion, true);
+        } else {
+            this.server = new Version(NA_STRING, false);
+            this.cache = new Version(NA_STRING, false);
+            this.comment = COMMENT;
+        }
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/Version.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/Version.java
@@ -1,0 +1,28 @@
+package org.cbioportal.genome_nexus.model;
+
+public class Version {
+
+    private String version;
+    private boolean isStatic;
+
+    public Version(String version, boolean isStatic) {
+        this.version = version;
+        this.isStatic = isStatic;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public boolean isStatic() {
+        return isStatic;
+    }
+
+    public void setStatic(boolean isStatic) {
+        this.isStatic = isStatic;
+    }
+}

--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/internal/SourceInfoRepository.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/internal/SourceInfoRepository.java
@@ -1,0 +1,41 @@
+package org.cbioportal.genome_nexus.persistence.internal;
+
+import org.cbioportal.genome_nexus.model.AggregateSourceInfo;
+import org.cbioportal.genome_nexus.model.GenomeNexusInfo;
+import org.cbioportal.genome_nexus.model.VEPInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class SourceInfoRepository {
+
+    @Autowired
+    private GenomeNexusInfo genomeNexusInfo;
+
+    @Autowired
+    private VEPInfo vepInfo;
+
+    @Autowired
+    private AggregateSourceInfo aggregateSourceInfo;
+
+    @Bean
+    public GenomeNexusInfo genomeNexusInfo(@Value("${genomenexus.server.version:NA}") String serverVersion, @Value("${spring.mongodb.embedded.version:NA}") String dbVersion) {
+        return new GenomeNexusInfo(serverVersion, dbVersion);
+    }
+
+    @Bean
+    public VEPInfo vepInfo(@Value("${gn_vep.server.version:NA}") String serverVersion, @Value("${gn_vep.cache.version:NA}") String cacheVersion, @Value("${gn_vep.region.url:}") String vepRegionURL) {
+        return new VEPInfo(serverVersion, cacheVersion, vepRegionURL);
+    }
+
+    @Bean
+    public AggregateSourceInfo aggregateSourceInfo() {
+        return new AggregateSourceInfo(genomeNexusInfo, vepInfo);
+    }
+
+    public AggregateSourceInfo getAggregateSourceInfo() {
+        return aggregateSourceInfo;
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/InfoServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/InfoServiceImpl.java
@@ -1,36 +1,24 @@
 package org.cbioportal.genome_nexus.service.internal;
 
+import org.cbioportal.genome_nexus.model.AggregateSourceInfo;
+import org.cbioportal.genome_nexus.model.GenomeNexusInfo;
+import org.cbioportal.genome_nexus.model.VEPInfo;
+import org.cbioportal.genome_nexus.persistence.internal.SourceInfoRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
 
 @Configuration
 @PropertySource("classpath:/maven.properties")
 @Service
 public class InfoServiceImpl {
+
     @Autowired
-    private Version version;
+    private SourceInfoRepository sourceInfoRepository;
 
-    public Version getVersion() {
-        return this.version;
-    }
-
-    @Component
-    public static class Version {
-        private String version;
-
-        @Autowired
-        Version(@Value("${project.version}") final String version) {
-            this.version = version;
-        }
-
-        public String getVersion() {
-            return this.version;
-        }
+    public AggregateSourceInfo getAggregateSourceInfo() {
+        return sourceInfoRepository.getAggregateSourceInfo();
     }
 
 }

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/InfoController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/InfoController.java
@@ -2,6 +2,7 @@ package org.cbioportal.genome_nexus.web;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import org.cbioportal.genome_nexus.model.AggregateSourceInfo;
 import org.cbioportal.genome_nexus.web.config.PublicApi;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,9 +28,9 @@ public class InfoController
         method = RequestMethod.GET,
         produces = "application/json")
     @ResponseBody
-    public InfoServiceImpl.Version fetchVersionGET()
+    public AggregateSourceInfo fetchVersionGET()
     {
-        return infoService.getVersion();
+        return infoService.getAggregateSourceInfo();
     }
 
 }

--- a/web/src/main/resources/application.properties.EXAMPLE
+++ b/web/src/main/resources/application.properties.EXAMPLE
@@ -14,6 +14,8 @@ vep.max_page_size=200
 # This is only the VEP part of the Ensembl REST API.
 # e.g. when running on port 6060:
 # gn_vep.region.url=http://localhost:6060/vep/human/region/VARIANT
+# gn_vep.cache.version=
+# gn_vep.server.version=
 # Note that this overrides vep.url
 # To get the full advantage of running your own VEP, several optimizations are
 # required, please read documentation in
@@ -44,6 +46,7 @@ spring.data.mongodb.uri=mongodb://127.0.0.1:27017/annotator
 # Server port number for the embedded tomcat. This property is required only when building
 # a jar file, and ignored when building a war file.
 server.port=38080
+genomenexus.server.version=1.0.2
 
 # For testing use same embeded mongo version as genome-nexus-importer
 # https://github.com/genome-nexus/genome-nexus-importer/blob/master/Dockerfile#L1


### PR DESCRIPTION
Changes include
- New models (3 levels including version, source-specific info, aggregate info returned by endpoint)
- Repository layer (autowires all info related to versioning)
- New properties to specify versions

Currently supports versioning for Genome Nexus (server/codebase and mongo) and VEP (server/codebase and cache)

Example in Swagger
```
{
  "genomeNexus": {
    "database": {
      "static": true,
      "version": "string"
    },
    "server": {
      "static": true,
      "version": "string"
    }
  },
  "vep": {
    "cache": {
      "static": true,
      "version": "string"
    },
    "comment": "string",
    "server": {
      "static": true,
      "version": "string"
    }
  }
}
```
