### PR TITLE
Return separate annotations for identical variant in different representations

### DIFF
--- a/web/src/test/java/org/cbioportal/genome_nexus/web/AnnotationIntegrationTest.java
+++ b/web/src/test/java/org/cbioportal/genome_nexus/web/AnnotationIntegrationTest.java
@@ -291,6 +291,17 @@ public class AnnotationIntegrationTest
     }
 
     @Test
+    public void testIdenticalGenomicLocationsPOST() {
+        List<GenomicLocation> genomicLocations = new ArrayList<>();
+        // If input has two identical genomic locations but in different representations
+        // Return should have two objects too
+        genomicLocations.add(genomicLocationStringToGenomicLocation("12,25398284,25398284,C,A"));
+        genomicLocations.add(genomicLocationStringToGenomicLocation("12,25398283,25398284,AC,AA"));
+        List<Map<String, Object>> response = this.fetchVariantAnnotationByGenomicLocationPOST(genomicLocations.toArray(new GenomicLocation[0]));
+        assertEquals(2, response.size());
+    }
+
+    @Test
     public void testVariantAnnotationOriginalQuery() {
         String expectedConvertedVariant = "4:g.55152096_55152107del";
         String genomicLocationString = "4,55152095,55152107,ATCATGCATGATT,A";


### PR DESCRIPTION
Fix: https://github.com/cBioPortal/cbioportal/issues/9517
See comment: https://github.com/cBioPortal/cbioportal/issues/9517#issuecomment-1175370011
For example:
```
[
  {
    "chromosome": "12",
    "start": 25398284,
    "end": 25398284,
    "referenceAllele": "C",
    "variantAllele": "A"
  },
  {
    "chromosome": "12",
    "start": 25398283,
    "end": 25398284,
    "referenceAllele": "AC",
    "variantAllele": "AA"
  }
]
```
This example case is from [GENIE](https://genie.cbioportal.org/results/mutations?cancer_study_list=genie_public&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&profileFilter=mutations&case_set_id=genie_public_all&gene_list=KRAS&geneset_list=%20&tab_index=tab_visualize&Action=Submit) 
Ideally the second variant should be normalized to the first variant, so technically they are identical. But if for any reason users query these two variants, genome nexus should return annotation for both variants. Because otherwise we probably have some variants that couldn't find a matching annotation in return, so the number of input variant should equal to number of output annotation. In this example, two annotations should be the same, but one has `"originalVariantQuery": "12,25398284,25398284,C,A"`, the other has `"originalVariantQuery": "12,25398283,25398284,AC,AA"`. 

### Example:
#### Input
```
[
  {
    "chromosome": "12",
    "start": 25398284,
    "end": 25398284,
    "referenceAllele": "C",
    "variantAllele": "A"
  },
  {
    "chromosome": "12",
    "start": 25398283,
    "end": 25398284,
    "referenceAllele": "AC",
    "variantAllele": "AA"
  }
]
```
#### Before
Example return:
```
[
  {
    "variant": "12:g.25398284C>A",
    ...
    ...
    "originalVariantQuery": "12,25398283,25398284,AC,AA",
  }
]
```

#### After
Example return:
```
[
  {
    "variant": "12:g.25398284C>A",
    ...
    ...
    "originalVariantQuery": "12,25398284,25398284,C,A",
  },
  {
    "variant": "12:g.25398284C>A",
    ...
    ...
    "originalVariantQuery": "12,25398283,25398284,AC,AA",
  }
]
```