### PR TITLE
Fix cancer hotspots error when having identical variants in different representations

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
@@ -170,15 +170,15 @@ public class CancerHotspotServiceImpl implements CancerHotspotService
     {
         List<VariantAnnotation> variantAnnotations = this.genomicLocationAnnotationService.getAnnotations(genomicLocations);
 
-        Map<String, GenomicLocation> variantToGenomicLocation = genomicLocations.stream()
-            .collect(Collectors.toMap(genomicLocationAnnotationService::getVariantFormat, Function.identity()));
+        Map<String, GenomicLocation> originalInputVariantToGenomicLocation = genomicLocations.stream().distinct()
+            .collect(Collectors.toMap(GenomicLocation::getOriginalInput, Function.identity()));
         List<AggregatedHotspots> hotspots = new ArrayList<>();
         for (VariantAnnotation variantAnnotation : variantAnnotations)
         {
             AggregatedHotspots aggregatedHotspots = new AggregatedHotspots();
             aggregatedHotspots.setHotspots(this.getHotspotAnnotations(variantAnnotation));
             aggregatedHotspots.setVariant(variantAnnotation.getVariant());
-            aggregatedHotspots.setGenomicLocation(variantToGenomicLocation.get(variantAnnotation.getVariant()));
+            aggregatedHotspots.setGenomicLocation(originalInputVariantToGenomicLocation.get(variantAnnotation.getOriginalVariantQuery()));
             hotspots.add(aggregatedHotspots);
         }
 

--- a/web/src/test/java/org/cbioportal/genome_nexus/web/CancerHotspotsIntegrationTest.java
+++ b/web/src/test/java/org/cbioportal/genome_nexus/web/CancerHotspotsIntegrationTest.java
@@ -18,6 +18,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -381,5 +382,21 @@ public class CancerHotspotsIntegrationTest
         hotspots = this.fetchHotspotsByProteinLocationPOST(locations);
         assertEquals("The result should have one record no matter whether it is hotspot", 1, hotspots.length);
         assertEquals("This splice region is not a hotspot", 0, hotspots[0].getHotspots().size());
+    }
+
+    @Test
+    public void testIdenticalVariantsInDifferentRepresentations()
+    {
+        String[] genomicLocationString = {
+            "7,140453193,140453193,T,C",
+            "7,140453192,140453193,AT,AC", // identical variant as above
+        };
+        List<GenomicLocation> genomicLocationsList = Arrays.stream(genomicLocationString).map(
+            g -> this.notationConverter.parseGenomicLocation(g, ",")).collect(Collectors.toList());
+
+        AggregatedHotspots[] aggregatedHotspots = this.fetchHotspotsPOST(genomicLocationsList);
+        // If input variants are identical after normalization, but since the input is not the same, it still should return two annotations
+        assertEquals(genomicLocationString.length, aggregatedHotspots.length);
+        
     }
 }


### PR DESCRIPTION
Fix: https://github.com/cBioPortal/cbioportal/issues/9831

For example,
**Input**
```
[{
    "chromosome": "7",
    "start": 55242467,
    "end": 55242486,
    "referenceAllele": "AATTAAGAGAAGCAACATCT",
    "variantAllele": "AT"
},
{
    "chromosome": "7",
    "start": 55242468,
    "end": 55242486,
    "referenceAllele": "ATTAAGAGAAGCAACATCT",
    "variantAllele": "T"
}]
```

**output:**
```
[
  {
    "genomicLocation": {
      "chromosome": "7",
      "start": 55242468,
      "end": 55242486,
      "referenceAllele": "ATTAAGAGAAGCAACATCT",
      "variantAllele": "T"
    },
    "variant": "7:g.55242468_55242486delinsT",
    "hotspots": [
      {
        "hugoSymbol": "EGFR",
        "transcriptId": "ENST00000275493",
        "residue": "745-759",
        "tumorCount": 155,
        "type": "in-frame indel",
        "missenseCount": 0,
        "truncatingCount": 0,
        "inframeCount": 155,
        "spliceCount": 0
      }
    ]
  },
  {
    "genomicLocation": {
      "chromosome": "7",
      "start": 55242467,
      "end": 55242486,
      "referenceAllele": "AATTAAGAGAAGCAACATCT",
      "variantAllele": "AT"
    },
    "variant": "7:g.55242468_55242486delinsT",
    "hotspots": [
      {
        "hugoSymbol": "EGFR",
        "transcriptId": "ENST00000275493",
        "residue": "745-759",
        "tumorCount": 155,
        "type": "in-frame indel",
        "missenseCount": 0,
        "truncatingCount": 0,
        "inframeCount": 155,
        "spliceCount": 0
      }
    ]
  }
]
```