### PR TITLE
Deserialise VariantAnnotation.colocatedVariants on first hit

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/ColocatedVariant.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/ColocatedVariant.java
@@ -32,8 +32,11 @@
 
 package org.cbioportal.genome_nexus.model;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.springframework.data.mongodb.core.mapping.Field;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ColocatedVariant
 {
     private String gnomad_nfe_maf;
@@ -114,6 +117,7 @@ public class ColocatedVariant
         this.gnomad_eas_allele = gnomad_eas_allele;
     }
 
+    @JsonAlias("id")
     private String dbSnpId;
 
     @Field(value="id")

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/VariantAnnotationMixin.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/VariantAnnotationMixin.java
@@ -2,6 +2,7 @@ package org.cbioportal.genome_nexus.service.mixin;
 
 import com.fasterxml.jackson.annotation.*;
 
+import org.cbioportal.genome_nexus.model.ColocatedVariant;
 import org.cbioportal.genome_nexus.model.IntergenicConsequences;
 import org.cbioportal.genome_nexus.model.TranscriptConsequence;
 
@@ -53,6 +54,9 @@ public class VariantAnnotationMixin
 
     @JsonProperty(value="transcript_consequences", required = true)
     private List<TranscriptConsequence> transcriptConsequences;
+
+    @JsonAlias("colocated_variants")
+    private List<ColocatedVariant> colocatedVariants;
 
     @JsonIgnore
     private Map<String, Object> dynamicProps;

--- a/web/src/test/java/org/cbioportal/genome_nexus/web/AnnotationIntegrationTest.java
+++ b/web/src/test/java/org/cbioportal/genome_nexus/web/AnnotationIntegrationTest.java
@@ -10,6 +10,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.client.RestTemplate;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -322,5 +324,18 @@ public class AnnotationIntegrationTest
             setVariantAllele(genomicLocation.split(",")[4]);
             setOriginalInput(genomicLocation);
         }};
+    }
+
+    @Test
+    public void testColocatedVariantDbSnpId() {
+        String genomicLocationString = "4,55152095,55152107,ATCATGCATGATT,A";
+        GenomicLocation[] genomicLocations = {
+            genomicLocationStringToGenomicLocation(genomicLocationString)
+        };
+
+        List<Map<String, Object>> response = this.fetchVariantAnnotationByGenomicLocationPOST(genomicLocations);
+
+        List<Map<String, Object>> colocatedVariants = (List<Map<String, Object>>) response.get(0).get("colocatedVariants");
+        assertThat(colocatedVariants, hasItem(hasEntry("dbSnpId", (Object) "rs121913268")));
     }
 }


### PR DESCRIPTION
Fix filling of the colocated variants field when the variant annotation is not in the cache yet. e.g. fetched for such genomic locations for the first time.

The issue is described in more details here https://github.com/genome-nexus/genome-nexus/issues/644