### PR TITLE
Fix Outdated cBioPortal Swagger Endpoint in Notebook Example

### DIFF
--- a/notebooks/genome_nexus_python_example.ipynb
+++ b/notebooks/genome_nexus_python_example.ipynb
@@ -223,8 +223,8 @@
     }
    ],
    "source": [
-    "cbioportal = SwaggerClient.from_url('https://www.cbioportal.org/api/api-docs',\n",
-    "                                config={\"validate_requests\":False,\"validate_responses\":False})\n",
+    "cbioportal = SwaggerClient.from_url('https://www.cbioportal.org/api/v2/api-docs',\n",
+    "                                config={\"validate_requests\":False,\"validate_responses\":False,\"validate_swagger_spec\":False})\n",
     "print(cbioportal)"
    ]
   },


### PR DESCRIPTION
I tried to run this notebook and it failed at this point, maybe this will help someone in the future.

ref: https://docs.cbioportal.org/web-api-and-clients/