### PR TITLE
Replace reVUE map key

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
@@ -185,7 +185,7 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
             if (annotationSummary.getTranscriptConsequenceSummary() != null && 
                 annotationSummary.getTranscriptConsequenceSummary().getIsVue() != null && 
                 annotationSummary.getTranscriptConsequenceSummary().getIsVue() == true) {
-                annotationSummary.setVues(this.vuesMap.get(annotationSummary.getTranscriptConsequenceSummary().getTranscriptId()));
+                annotationSummary.setVues(this.vuesMap.get(annotationSummary.getTranscriptConsequenceSummary().getTranscriptId() + "-" + annotationSummary.getVariant()));
             }
         }
 


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/680
Key is changed to "transcript id + variant id", but `getAnnotationSummaryForCanonical` still uses "transcript id" as key. Replace to "transcript id + variant id".