### PR TITLE
Fix converting dels using region converter

### DIFF
--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
@@ -221,6 +221,18 @@ public class NotationConverter {
         // Ensembl uses a one-based coordinate system
         if (start < 1) {
             region = null;
+        // If the var allele is "-", then it is a deletion
+        // A ref allele of "-" could be an insertion or deletion, so this check should come first.
+        } else if (var.equals("-") || var.length() == 0) {
+            /*
+            Process Deletion
+            Example deletion: 1 206811015 206811016  AC -
+            Example output:   1:206811015-206811016:1/-
+
+            Example deletion: 11 2133018 2133018 - -
+            Example output: 11:2133018-2133018:1/-
+            */
+            region = chr + ":" + start + "-" + end + ":1/-";
         } else if (ref.equals("-") || ref.length() == 0 || ref.equals("NA") || ref.contains("--")) {
             /*
             Process Insertion
@@ -233,13 +245,6 @@ public class NotationConverter {
             catch (NumberFormatException e) {
                 return null;
             }
-        } else if (var.equals("-") || var.length() == 0) {
-            /*
-            Process Deletion
-            Example deletion: 1 206811015 206811016  AC -
-            Example output:   1:206811015-206811016:1/-
-            */
-            region = chr + ":" + start + "-" + end + ":1/-";
         } else if (ref.length() > 1 || var.length() > 1) {
             /*
             Process ONP

--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
@@ -240,6 +240,8 @@ public class NotationConverter {
             Example output: 17:36002278-36002277:1/A
             */
             try {
+                // We follow the rule for insertions described here: https://useast.ensembl.org/info/docs/tools/vep/vep_formats.html#default
+                // The VEP differentiates between ins and delins by swapping the start and end positions for insertions.
                 region = chr + ":" + String.valueOf(start + 1) + "-" + start  + ":1/" + var;
             }
             catch (NumberFormatException e) {

--- a/component/src/test/java/org/cbioportal/genome_nexus/util/GenomicVariantUtilTest.java
+++ b/component/src/test/java/org/cbioportal/genome_nexus/util/GenomicVariantUtilTest.java
@@ -138,6 +138,20 @@ public class GenomicVariantUtilTest {
         assertEquals("5:140533-140532:1/C", GenomicVariantUtil.toRegion(variant));
     }
 
+    @Test
+    public void testGenomicVariantDelToRegion() {
+        GenomicVariant variant = new GenomicVariant("5", GenomicVariant.RefType.GENOMIC, 140532, 140532, GenomicVariant.Type.DELETION, "-", "-");
+
+        assertEquals("5:140532-140532:1/-", GenomicVariantUtil.toRegion(variant));
+    }
+
+    @Test
+    public void testGenomicVariantDelWithRefAlleleToRegion() {
+        GenomicVariant variant = new GenomicVariant("10", GenomicVariant.RefType.GENOMIC, 89624230, 89624231, GenomicVariant.Type.DELETION, "AC", "-");
+
+        assertEquals("10:89624230-89624231:1/-", GenomicVariantUtil.toRegion(variant));
+    }
+
     // TODO: add conversion test cases from hgvs delete and indel (maybe dup?)
 
     @Test
@@ -152,6 +166,13 @@ public class GenomicVariantUtilTest {
         String region = GenomicVariantUtil.toRegion(GenomicVariantUtil.fromHgvs("12:g.25398285_25398286insA"));
 
         assertEquals("12:25398286-25398285:1/A", region);
+    }
+
+    @Test
+    public void testHgvsDelToGenomicVariantToRegion() {
+        String region = GenomicVariantUtil.toRegion(GenomicVariantUtil.fromHgvs("11:g.2133018del"));
+
+        assertEquals("11:2133018-2133018:1/-", region);
     }
 
     // TODO: add conversion test cases from hgvs delete and indel (maybe dup?)

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/SelectedAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/SelectedAnnotationServiceImpl.java
@@ -30,12 +30,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package org.cbioportal.genome_nexus.service;
+package org.cbioportal.genome_nexus.service.internal;
 
 import org.cbioportal.genome_nexus.component.annotation.NotationConverter;
 import org.cbioportal.genome_nexus.model.GenomicLocation;
 import org.cbioportal.genome_nexus.model.VariantAnnotation;
 import org.cbioportal.genome_nexus.service.GenomicLocationAnnotationService;
+import org.cbioportal.genome_nexus.service.SelectedAnnotationService;
+import org.cbioportal.genome_nexus.service.VariantAnnotationService;
 import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
 import org.cbioportal.genome_nexus.service.exception.VariantAnnotationQueryMixedFormatException;
 import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
@@ -56,7 +58,7 @@ public class SelectedAnnotationServiceImpl implements SelectedAnnotationService 
     private final NotationConverter notationConverter;
     private final Boolean isRegionAnnotationEnabled;
 
-private static final Log LOG = LogFactory.getLog(SelectedAnnotationServiceImpl.class);
+    private static final Log LOG = LogFactory.getLog(SelectedAnnotationServiceImpl.class);
 
     @Autowired
     public SelectedAnnotationServiceImpl(


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb-pipeline/issues/143

### Issue:
When GN is setup using a local VEP, the variants need to be converted to VEP's region format. 
GN converts `11:g.2133018del` to genomic location `11,2133018,2133018,-,-` Then the genomic location is converted to region format `11:2133019_2133018:1/-`, which is wrong.

The reason is genomic location with ref allele "-" are treated as an ins

### Changes:
- Check that the variant allele is "-" before checking that reference allele is "-". In the original code, the HGVSg del was treated as an insertion because the ref allele was "-".
- The package definition for `SelectedAnnotationServiceImpl.java` was fixed