### PR TITLE
Fix failing my variant info tests

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/AlleleCount.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/AlleleCount.java
@@ -2,6 +2,9 @@ package org.cbioportal.genome_nexus.model.my_variant_info_model;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AlleleCount
 {
 

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/AlleleFrequency.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/AlleleFrequency.java
@@ -2,6 +2,9 @@ package org.cbioportal.genome_nexus.model.my_variant_info_model;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AlleleFrequency
 {
 

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/AlleleNumber.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/AlleleNumber.java
@@ -2,6 +2,9 @@ package org.cbioportal.genome_nexus.model.my_variant_info_model;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AlleleNumber
 {
 

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Alleles.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Alleles.java
@@ -2,6 +2,9 @@ package org.cbioportal.genome_nexus.model.my_variant_info_model;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Alleles
 {
 

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Ann.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Ann.java
@@ -2,6 +2,9 @@ package org.cbioportal.genome_nexus.model.my_variant_info_model;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Ann
 {
 

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/ClinVar.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/ClinVar.java
@@ -4,6 +4,9 @@ import java.util.List;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ClinVar
 {
     @Field(value = "_license")

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Cosmic.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Cosmic.java
@@ -2,6 +2,9 @@ package org.cbioportal.genome_nexus.model.my_variant_info_model;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Cosmic
 {
     @Field(value = "_license")

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Dbsnp.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Dbsnp.java
@@ -4,6 +4,9 @@ import java.util.List;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Dbsnp
 {
     @Field(value = "_license")

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Gene.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Gene.java
@@ -2,6 +2,9 @@ package org.cbioportal.genome_nexus.model.my_variant_info_model;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Gene
 {
 

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Gnomad.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Gnomad.java
@@ -2,6 +2,9 @@ package org.cbioportal.genome_nexus.model.my_variant_info_model;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Gnomad
 {
 

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Hg19.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Hg19.java
@@ -2,6 +2,9 @@ package org.cbioportal.genome_nexus.model.my_variant_info_model;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Hg19
 {
 

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Hg38.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Hg38.java
@@ -2,6 +2,9 @@ package org.cbioportal.genome_nexus.model.my_variant_info_model;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Hg38
 {
 

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Hgvs.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Hgvs.java
@@ -4,6 +4,9 @@ import java.util.List;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Hgvs
 {
 

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Homozygotes.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Homozygotes.java
@@ -2,6 +2,9 @@ package org.cbioportal.genome_nexus.model.my_variant_info_model;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Homozygotes
 {
 

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Mutdb.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Mutdb.java
@@ -2,6 +2,8 @@ package org.cbioportal.genome_nexus.model.my_variant_info_model;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Mutdb
 {
 

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/MyVariantInfo.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/MyVariantInfo.java
@@ -4,7 +4,10 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 @Document(collection = "my_variant_info.annotation")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class MyVariantInfo
 {
     @Id

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Rcv.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Rcv.java
@@ -2,6 +2,9 @@ package org.cbioportal.genome_nexus.model.my_variant_info_model;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Rcv
 {
 

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Snpeff.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Snpeff.java
@@ -2,6 +2,9 @@ package org.cbioportal.genome_nexus.model.my_variant_info_model;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Snpeff
 {
     @Field(value = "_license")

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Vcf.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/Vcf.java
@@ -2,6 +2,9 @@ package org.cbioportal.genome_nexus.model.my_variant_info_model;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Vcf
 {
 

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/cached/CachedMyVariantInfoFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/cached/CachedMyVariantInfoFetcher.java
@@ -1,6 +1,7 @@
 package org.cbioportal.genome_nexus.service.cached;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.mongodb.BasicDBList;
 import com.mongodb.DBObject;
 import org.apache.commons.logging.Log;
@@ -53,7 +54,9 @@ public class CachedMyVariantInfoFetcher extends BaseCachedExternalResourceFetche
 
         // instantiate a custom object mapper for normalizing purposes
         this.objectMapper = new ExternalResourceObjectMapper();
+        this.objectMapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
         this.objectMapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+        this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
     protected Object buildRequestBody(Set<String> ids)


### PR DESCRIPTION
There are some unrecognized new fields in my_variant_info response:
```
2023-06-22 05:11:16.617  WARN 572 --- [io-38892-exec-1] o.c.g.s.c.CachedMyVariantInfoFetcher     : chr17:g.7577570C>G: Unrecognized field "non-coding" (class org.cbioportal.genome_nexus.model.my_variant_info_model.Hgvs), not marked as ignorable (3 known properties: "genomic", "coding", "protein"])
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: org.cbioportal.genome_nexus.model.my_variant_info_model.MyVariantInfo["clinvar"]->org.cbioportal.genome_nexus.model.my_variant_info_model.ClinVar["hgvs"]->org.cbioportal.genome_nexus.model.my_variant_info_model.Hgvs["non-coding"])
2023-06-22 05:11:16.675  WARN 572 --- [io-38892-exec-1] o.c.g.s.c.CachedMyVariantInfoFetcher     : chr17:g.7577576_7577578del: Unrecognized field "non-coding" (class org.cbioportal.genome_nexus.model.my_variant_info_model.Hgvs), not marked as ignorable (3 known properties: "genomic", "coding", "protein"])
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: org.cbioportal.genome_nexus.model.my_variant_info_model.MyVariantInfo["clinvar"]->org.cbioportal.genome_nexus.model.my_variant_info_model.ClinVar["hgvs"]->org.cbioportal.genome_nexus.model.my_variant_info_model.Hgvs["non-coding"])
2023-06-22 05:11:17.168  INFO 572 --- [       Thread-1] o.s.b.a.mongo.embedded.EmbeddedMongo     : 2023-06-22T05:11:17.168+0000 I STORAGE  [conn2] createCollection: integration.my_variant_info.annotation with generated UUID: 023dc4a5-6013-4bc3-853e-73ed935e2ab3
2023-06-22 05:11:20.967  WARN 572 --- [io-38892-exec-1] o.c.g.s.c.CachedMyVariantInfoFetcher     : chr17:g.7578402G>T: Unrecognized field "non-coding" (class org.cbioportal.genome_nexus.model.my_variant_info_model.Hgvs), not marked as ignorable (3 known properties: "genomic", "coding", "protein"])
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: org.cbioportal.genome_nexus.model.my_variant_info_model.MyVariantInfo["clinvar"]->org.cbioportal.genome_nexus.model.my_variant_info_model.ClinVar["hgvs"]->org.cbioportal.genome_nexus.model.my_variant_info_model.Hgvs["non-coding"])
2023-06-22 05:11:20.974  WARN 572 --- [io-38892-exec-1] o.c.g.s.c.CachedMyVariantInfoFetcher     : chr17:g.7578413C>G: Unrecognized field "non-coding" (class org.cbioportal.genome_nexus.model.my_variant_info_model.Hgvs), not marked as ignorable (3 known properties: "genomic", "coding", "protein"])
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: org.cbioportal.genome_nexus.model.my_variant_info_model.MyVariantInfo["clinvar"]->org.cbioportal.genome_nexus.model.my_variant_info_model.ClinVar["hgvs"]->org.cbioportal.genome_nexus.model.my_variant_info_model.Hgvs["non-coding"])
2023-06-22 05:11:20.976  WARN 572 --- [io-38892-exec-1] o.c.g.s.c.CachedMyVariantInfoFetcher     : chr17:g.7578418T>C: Unrecognized field "non-coding" (class org.cbioportal.genome_nexus.model.my_variant_info_model.Hgvs), not marked as ignorable (3 known properties: "genomic", "coding", "protein"])
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: org.cbioportal.genome_nexus.model.my_variant_info_model.MyVariantInfo["clinvar"]->org.cbioportal.genome_nexus.model.my_variant_info_model.ClinVar["hgvs"]->org.cbioportal.genome_nexus.model.my_variant_info_model.Hgvs["non-coding"])
2023-06-22 05:11:23.168  WARN 572 --- [io-38892-exec-1] o.c.g.s.c.CachedMyVariantInfoFetcher     : chr17:g.7578492C>G: Unrecognized field "non-coding" (class org.cbioportal.genome_nexus.model.my_variant_info_model.Hgvs), not marked as ignorable (3 known properties: "genomic", "coding", "protein"])
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: org.cbioportal.genome_nexus.model.my_variant_info_model.MyVariantInfo["clinvar"]->org.cbioportal.genome_nexus.model.my_variant_info_model.ClinVar["hgvs"]->org.cbioportal.genome_nexus.model.my_variant_info_model.Hgvs["non-coding"])
2023-06-22 05:11:23.173  WARN 572 --- [io-38892-exec-1] o.c.g.s.c.CachedMyVariantInfoFetcher     : chr17:g.7578499T>C: Unrecognized field "non-coding" (class org.cbioportal.genome_nexus.model.my_variant_info_model.Hgvs), not marked as ignorable (3 known properties: "genomic", "coding", "protein"])
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: org.cbioportal.genome_nexus.model.my_variant_info_model.MyVariantInfo["clinvar"]->org.cbioportal.genome_nexus.model.my_variant_info_model.ClinVar["hgvs"]->org.cbioportal.genome_nexus.model.my_variant_info_model.Hgvs["non-coding"])
2023-06-22 05:11:23.212  WARN 572 --- [io-38892-exec-1] o.c.g.s.c.CachedMyVariantInfoFetcher     : chr17:g.7578524G>A: Unrecognized field "non-coding" (class org.cbioportal.genome_nexus.model.my_variant_info_model.Hgvs), not marked as ignorable (3 known properties: "genomic", "coding", "protein"])
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: org.cbioportal.genome_nexus.model.my_variant_info_model.MyVariantInfo["clinvar"]->org.cbioportal.genome_nexus.model.my_variant_info_model.ClinVar["hgvs"]->org.cbioportal.genome_nexus.model.my_variant_info_model.Hgvs["non-coding"])
```
Add `@JsonIgnoreProperties(ignoreUnknown = true)` to allow unrecognized fields