### PR TITLE
Harmonize genomic location coordinates

### DIFF
--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
@@ -1,7 +1,5 @@
 package org.cbioportal.genome_nexus.component.annotation;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.cbioportal.genome_nexus.model.GenomicLocation;
 import org.cbioportal.genome_nexus.util.GenomicVariant;
 import org.cbioportal.genome_nexus.util.GenomicVariantUtil;
@@ -18,7 +16,6 @@ import java.util.Map;
 
 @Component
 public class NotationConverter {
-    private static final Log LOG = LogFactory.getLog(NotationConverter.class);
 
     public static final String DEFAULT_DELIMITER = ",";
 
@@ -133,9 +130,8 @@ public class NotationConverter {
                 nStart -= 1;
             }
             start = nStart;
-            LOG.info("Start position is changed from " + genomicLocation.getStart() + " to " + start + " for genomic location: " + genomicLocation.getChromosome() + "," + genomicLocation.getStart() + "," + genomicLocation.getEnd() + "," + genomicLocation.getReferenceAllele().trim() + "," + genomicLocation.getVariantAllele().trim() + ". Reason: remove common prefix alleles.");
         }
-        end = harmonizeGenomicLocationCoordinate(genomicLocation, chr, start, end, ref, var);
+        end = harmonizeGenomicLocationCoordinate(start, end, ref);
         normalizedGenomicLocation.setStart(start);
         normalizedGenomicLocation.setEnd(end);
         normalizedGenomicLocation.setReferenceAllele(ref);
@@ -143,20 +139,18 @@ public class NotationConverter {
         return normalizedGenomicLocation;
     }
 
-    public Integer harmonizeGenomicLocationCoordinate(GenomicLocation genomicLocation, String chr, Integer start, Integer end, String ref, String var) {
+    public Integer harmonizeGenomicLocationCoordinate(Integer start, Integer end, String ref) {
         if (ref.equals("-") || ref.length() == 0 || ref.equals("NA") || ref.contains("--")) {
             // insertion variants: end = start + 1
             if (end != start + 1) {
                 end = start + 1;
-                LOG.info("End position is changed from " + genomicLocation.getEnd() + " to " + end + " for genomic location: " + genomicLocation.getChromosome() + "," + genomicLocation.getStart() + "," + genomicLocation.getEnd() + "," + genomicLocation.getReferenceAllele().trim() + "," + genomicLocation.getVariantAllele().trim() + ". Reason: wrong coordinates, insersion variants' end position should be start + 1.");
             }
         }
         else {
             // all deletion, delins, and SNV
-            // for single allele delins and SNV, ref.length() = 1, so end = start
+            // for single alleledel, delins and SNV, ref.length() = 1, so end = start
             if (end != start + ref.length() - 1) {
                 end = start + ref.length() - 1;
-                LOG.info("End position is changed from " + genomicLocation.getEnd() + " to " + end + " for genomic location: " + genomicLocation.getChromosome() + "," + genomicLocation.getStart() + "," + genomicLocation.getEnd() + "," + genomicLocation.getReferenceAllele().trim() + "," + genomicLocation.getVariantAllele().trim() + ". Reason: wrong coordinates, end position should be the range of nucleotides deleted/affected.");
             }
         }
         return end;

--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
@@ -16,7 +16,6 @@ import java.util.Map;
 
 @Component
 public class NotationConverter {
-
     public static final String DEFAULT_DELIMITER = ",";
 
     public String hgvsNormalizer(String hgvs) {
@@ -114,7 +113,6 @@ public class NotationConverter {
         String ref = genomicLocation.getReferenceAllele().trim();
         String var = genomicLocation.getVariantAllele().trim();
 
-
         String prefix = "";
 
         if (!ref.equals(var)) {
@@ -200,7 +198,6 @@ public class NotationConverter {
                 */
                 hgvs = chr + ":g." + start + "_" + end + "del";
             } 
-            
         } else if (ref.length() > 1 && var.length() >= 1) {
             /*
             Process ONP (multiple deletion insertion)

--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/NotationConverter.java
@@ -164,6 +164,10 @@ public class NotationConverter {
                 return null;
             }
         } else if (var.equals("-") || var.length() == 0 || var.equals("NA") || var.contains("--")) {
+            if (end < start) {
+                // If end position is less than start position, change it to correct number
+                end = start + ref.length() - 1;
+            }
             if (ref.length() == 1) {
                 /*
                 Process Deletion (single positon)
@@ -180,6 +184,7 @@ public class NotationConverter {
                 */
                 hgvs = chr + ":g." + start + "_" + end + "del";
             } 
+            
         } else if (ref.length() > 1 && var.length() >= 1) {
             /*
             Process ONP (multiple deletion insertion)

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
@@ -76,6 +76,7 @@ public class VariantAnnotation
     private SignalAnnotation signalAnnotation;
     private String originalVariantQuery;
     private Map<String, Object> dynamicProps;
+    private String genomicLocationExplanation;
 
     public VariantAnnotation()
     {
@@ -353,5 +354,13 @@ public class VariantAnnotation
     public Map<String, Object> getDynamicProps()
     {
         return this.dynamicProps;
+    }
+
+    public String getGenomicLocationExplanation() {
+        return genomicLocationExplanation;
+    }
+
+    public void setGenomicLocationExplanation(String genomicLocationExplanation) {
+        this.genomicLocationExplanation = genomicLocationExplanation;
     }
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/GenomicLocationAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/GenomicLocationAnnotationServiceImpl.java
@@ -47,6 +47,7 @@ import com.google.gson.Gson;
 import org.springframework.beans.factory.annotation.*;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class GenomicLocationAnnotationServiceImpl implements GenomicLocationAnnotationService
@@ -58,7 +59,6 @@ public class GenomicLocationAnnotationServiceImpl implements GenomicLocationAnno
     private final VariantAnnotationService variantAnnotationService;
     private final GenomicLocationToVariantFormat genomicLocationToVariantFormat;
     private final GenomicLocationStringToVariantFormat genomicLocationStringToVariantFormat;
-
     private final GenomicLocationsToVariantFormats genomicLocationsToVariantFormats;
 
     @Autowired
@@ -82,7 +82,6 @@ public class GenomicLocationAnnotationServiceImpl implements GenomicLocationAnno
             this.genomicLocationToVariantFormat = notationConverter::genomicToHgvs;
             this.genomicLocationStringToVariantFormat = notationConverter::genomicToHgvs;
             this.genomicLocationsToVariantFormats = notationConverter::genomicToHgvs;
-
         }
     }
 
@@ -93,6 +92,7 @@ public class GenomicLocationAnnotationServiceImpl implements GenomicLocationAnno
         VariantAnnotation variantAnnotation = this.variantAnnotationService.getAnnotation(this.genomicLocationToVariantFormat.convert(genomicLocation));
         genomicLocation.setOriginalInput(genomicLocation.toString());
         variantAnnotation.setOriginalVariantQuery(genomicLocation.getOriginalInput());
+        variantAnnotation.setGenomicLocationExplanation(this.notationConverter.getGenomicLocationExplanation(genomicLocation));
         return variantAnnotation;
     }
 
@@ -130,6 +130,10 @@ public class GenomicLocationAnnotationServiceImpl implements GenomicLocationAnno
                 }
             }
         });
+        variantAnnotations.stream().map((VariantAnnotation variantAnnotation) -> {
+            variantAnnotation.setGenomicLocationExplanation(this.notationConverter.getGenomicLocationExplanation(variantAnnotation.getOriginalVariantQuery()));
+            return variantAnnotation;
+        }).collect(Collectors.toList());
         return variantAnnotations;
     }
 
@@ -146,6 +150,7 @@ public class GenomicLocationAnnotationServiceImpl implements GenomicLocationAnno
                 token,
                 fields);
         variantAnnotation.setOriginalVariantQuery(genomicLocation);
+        variantAnnotation.setGenomicLocationExplanation(this.notationConverter.getGenomicLocationExplanation(genomicLocation));
         return variantAnnotation;
     }
 
@@ -180,6 +185,10 @@ public class GenomicLocationAnnotationServiceImpl implements GenomicLocationAnno
                 }
             }
         });
+        variantAnnotations.stream().map((VariantAnnotation variantAnnotation) -> {
+            variantAnnotation.setGenomicLocationExplanation(this.notationConverter.getGenomicLocationExplanation(variantAnnotation.getOriginalVariantQuery()));
+            return variantAnnotation;
+        }).collect(Collectors.toList());
         return variantAnnotations;
     }
 


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/702
This PR can also fix some failing variants from: https://github.com/genome-nexus/annotation-tools/issues/57 
And some failing variants on GENIE genome nexus: https://github.com/genome-nexus/genome-nexus-annotation-pipeline/issues/260

Harmonize end position for some of the variants that have
- no end position
- end position < start position
- start - end does not equal to length of reference allele

Todo:
- [x] Harmonize genomic location coordinates
- [x] Return a brief reason of genomic location harmonization