### PR TITLE
Add error message in response for failing annotation

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotation.java
@@ -64,6 +64,7 @@ public class VariantAnnotation
     private List<IntergenicConsequences> intergenicConsequences;
     private List<TranscriptConsequence> transcriptConsequences;
     private Boolean successfullyAnnotated;
+    private String errorMessage;
 
     private MutationAssessorAnnotation mutationAssessorAnnotation;
     private NucleotideContextAnnotation nucleotideContextAnnotation;
@@ -362,5 +363,13 @@ public class VariantAnnotation
 
     public void setGenomicLocationExplanation(String genomicLocationExplanation) {
         this.genomicLocationExplanation = genomicLocationExplanation;
+    }
+    
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
     }
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/cached/BaseCachedVariantAnnotationFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/cached/BaseCachedVariantAnnotationFetcher.java
@@ -1,5 +1,6 @@
 package org.cbioportal.genome_nexus.service.cached;
 
+import com.google.gson.Gson;
 import com.mongodb.DBObject;
 import org.cbioportal.genome_nexus.model.VariantAnnotation;
 import org.cbioportal.genome_nexus.persistence.VariantAnnotationRepository;
@@ -73,7 +74,13 @@ public abstract class BaseCachedVariantAnnotationFetcher
             } else {
                 variantAnnotation.setSuccessfullyAnnotated(true);
             }
-        } catch (Exception e) {
+        }
+        catch (HttpClientErrorException e) {
+            variantAnnotation = new VariantAnnotation(id);
+            variantAnnotation.setErrorMessage(new Gson().fromJson(e.getResponseBodyAsString(), Map.class).getOrDefault("error", "Error from VEP").toString());
+            return variantAnnotation;
+        }
+        catch (Exception e) {
             return new VariantAnnotation(id);
         }
         return variantAnnotation;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VerifiedGenomicLocationAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VerifiedGenomicLocationAnnotationServiceImpl.java
@@ -158,6 +158,9 @@ public class VerifiedGenomicLocationAnnotationServiceImpl implements GenomicLoca
             return annotation;
         }
         // return annotation failure
+        if (annotation.getErrorMessage() == null) {
+            annotation.setErrorMessage( String.format("Reference allele extracted from response (%s) does not match given reference allele (%s)", responseReferenceAllele.length() == 0 ? "-" : responseReferenceAllele, providedReferenceAllele.length() == 0 ? "-" : providedReferenceAllele));
+        }
         return createFailedAnnotation(originalVariantQuery, originalVariant, annotation.getErrorMessage());
     }
 

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VerifiedGenomicLocationAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VerifiedGenomicLocationAnnotationServiceImpl.java
@@ -158,7 +158,7 @@ public class VerifiedGenomicLocationAnnotationServiceImpl implements GenomicLoca
             return annotation;
         }
         // return annotation failure
-        return createFailedAnnotation(originalVariantQuery, originalVariant);
+        return createFailedAnnotation(originalVariantQuery, originalVariant, annotation.getErrorMessage());
     }
 
     private Boolean needFollowUpQuery(String responseReferenceAllele, String providedReferenceAllele)
@@ -205,7 +205,7 @@ public class VerifiedGenomicLocationAnnotationServiceImpl implements GenomicLoca
 
     }
 
-    private VariantAnnotation createFailedAnnotation(String originalVariantQuery, String originalVariant)
+    private VariantAnnotation createFailedAnnotation(String originalVariantQuery, String originalVariant, String errorMessage)
     {
         VariantAnnotation annotation = new VariantAnnotation();
         if (originalVariantQuery != null && originalVariantQuery.length() > 0) {
@@ -215,6 +215,7 @@ public class VerifiedGenomicLocationAnnotationServiceImpl implements GenomicLoca
             annotation.setVariant(originalVariant);
         }
         annotation.setSuccessfullyAnnotated(false);
+        annotation.setErrorMessage(errorMessage);
         return annotation;
     }
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VerifiedHgvsVariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VerifiedHgvsVariantAnnotationService.java
@@ -133,6 +133,9 @@ public class VerifiedHgvsVariantAnnotationService implements VariantAnnotationSe
             return annotation;
         }
         // return annotation failure
+        if (annotation.getErrorMessage() == null) {
+            annotation.setErrorMessage( String.format("Reference allele extracted from response (%s) does not match given reference allele (%s)", responseReferenceAllele.length() == 0 ? "-" : responseReferenceAllele, providedReferenceAllele.length() == 0 ? "-" : providedReferenceAllele));
+        }
         return createFailedAnnotation(originalVariantQuery, originalVariant, annotation.getErrorMessage());
     }
 

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VerifiedHgvsVariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VerifiedHgvsVariantAnnotationService.java
@@ -133,7 +133,7 @@ public class VerifiedHgvsVariantAnnotationService implements VariantAnnotationSe
             return annotation;
         }
         // return annotation failure
-        return createFailedAnnotation(originalVariantQuery, originalVariant);
+        return createFailedAnnotation(originalVariantQuery, originalVariant, annotation.getErrorMessage());
     }
 
     private String constructFollowUpQuery(String originalQuery)
@@ -162,7 +162,7 @@ public class VerifiedHgvsVariantAnnotationService implements VariantAnnotationSe
 
     }
 
-    private VariantAnnotation createFailedAnnotation(String originalVariantQuery, String originalVariant)
+    private VariantAnnotation createFailedAnnotation(String originalVariantQuery, String originalVariant, String errorMessage)
     {
         VariantAnnotation annotation = new VariantAnnotation();
         if (originalVariantQuery != null && originalVariantQuery.length() > 0) {
@@ -172,6 +172,7 @@ public class VerifiedHgvsVariantAnnotationService implements VariantAnnotationSe
             annotation.setVariant(originalVariant);
         }
         annotation.setSuccessfullyAnnotated(false);
+        annotation.setErrorMessage(errorMessage);
         return annotation;
     }
 

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VerifiedGenomicLocationAnnotationServiceTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VerifiedGenomicLocationAnnotationServiceTest.java
@@ -80,6 +80,7 @@ public class VerifiedGenomicLocationAnnotationServiceTest
         public boolean expectedGnSuccessfullyAnnotated;
         public String expectedGnAlleleString;
         public String description;
+        public String errorMessage;
         public VariantTestCase(
                 String originalVariantQuery,
                 boolean expectedGnSuccessfullyAnnotated,
@@ -89,6 +90,18 @@ public class VerifiedGenomicLocationAnnotationServiceTest
             this.expectedGnSuccessfullyAnnotated = expectedGnSuccessfullyAnnotated;
             this.expectedGnAlleleString = expectedGnAlleleString;
             this.description = description;
+        }
+        public VariantTestCase(
+                String originalVariantQuery,
+                boolean expectedGnSuccessfullyAnnotated,
+                String expectedGnAlleleString,
+                String description,
+                String errorMessage) {
+            this.originalVariantQuery =  originalVariantQuery;
+            this.expectedGnSuccessfullyAnnotated = expectedGnSuccessfullyAnnotated;
+            this.expectedGnAlleleString = expectedGnAlleleString;
+            this.description = description;
+            this.errorMessage = errorMessage;
         }
     }
 
@@ -113,13 +126,13 @@ public class VerifiedGenomicLocationAnnotationServiceTest
         if (glSubstitutions == null) {
             glSubstitutions = new ArrayList<VariantTestCase>();
             glSubstitutions.add(new VariantTestCase("5,138163256,138163256,C,T", true, "C/T", "valid substitution"));
-            glSubstitutions.add(new VariantTestCase("5,138163256,138163256,A,T", false, null, "discrepant RefAllele"));
+            glSubstitutions.add(new VariantTestCase("5,138163256,138163256,A,T", false, null, "discrepant RefAllele", "Reference allele extracted from response (C) does not match given reference allele (A)"));
             glDeletions = new ArrayList<VariantTestCase>();
             glDeletions.add(new VariantTestCase("5,138163256,138163256,C,-", true, "C/-", "1nt deletion with RefAllele"));
-            glDeletions.add(new VariantTestCase("5,138163256,138163256,A,-", false, null, "1nt deletion with discrepant RefAllele"));
+            glDeletions.add(new VariantTestCase("5,138163256,138163256,A,-", false, null, "1nt deletion with discrepant RefAllele", "Reference allele extracted from response (C) does not match given reference allele (A)"));
             glDeletions.add(new VariantTestCase("5,138163255,138163256,TC,-", true, "TC/-", "2nt deletion with RefAllele"));
-            glDeletions.add(new VariantTestCase("5,138163255,138163256,CC,-", false, null, "2nt deletion with discrepant RefAllele"));
-            glDeletions.add(new VariantTestCase("5,138163255,138163256,CCCC,-", false, null, "2nt deletion with invalid RefAllele"));
+            glDeletions.add(new VariantTestCase("5,138163255,138163256,CC,-", false, null, "2nt deletion with discrepant RefAllele", "Reference allele extracted from response (TC) does not match given reference allele (CC)"));
+            glDeletions.add(new VariantTestCase("5,138163255,138163256,CCCC,-", false, null, "2nt deletion with invalid RefAllele", "Reference allele extracted from response (TC) does not match given reference allele (CCCC)"));
             glInsertions = new ArrayList<VariantTestCase>();
             glInsertions.add(new VariantTestCase("5,138163255,138163256,-,T", true, "-/T", "1nt insertion"));
             glInsertions.add(new VariantTestCase("5,138163255,138163256,-,TT", true, "-/TT", "2nt insertion"));
@@ -128,18 +141,18 @@ public class VerifiedGenomicLocationAnnotationServiceTest
             glInsertions.add(new VariantTestCase("5,138163255,138163256,TC,TCA", true, "-/A", "2nt deletion with RefAllele, 3nt insertion, partial change"));
             glInsertionDeletions = new ArrayList<VariantTestCase>();
             glInsertionDeletions.add(new VariantTestCase("5,138163256,138163256,C,T", true, "C/T", "1nt deletion with RefAllele, 1nt insertion"));
-            glInsertionDeletions.add(new VariantTestCase("5,138163256,138163256,A,T", false, null, "1nt deletion with discrepant RefAllele, 1nt insertion"));
+            glInsertionDeletions.add(new VariantTestCase("5,138163256,138163256,A,T", false, null, "1nt deletion with discrepant RefAllele, 1nt insertion", "Reference allele extracted from response (C) does not match given reference allele (A)"));
             glInsertionDeletions.add(new VariantTestCase("5,138163256,138163256,C,TT", true, "C/TT", "1nt deletion with RefAllele, 2nt insertion"));
-            glInsertionDeletions.add(new VariantTestCase("5,138163256,138163256,A,TT", false, null, "1nt deletion with discrepant RefAllele, 2nt insertion"));
+            glInsertionDeletions.add(new VariantTestCase("5,138163256,138163256,A,TT", false, null, "1nt deletion with discrepant RefAllele, 2nt insertion", "Reference allele extracted from response (C) does not match given reference allele (A)"));
             glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,TC,A", true, "TC/A", "2nt deletion with RefAllele, 1nt insertion"));
-            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,TA,G", false, null, "2nt deletion with discrepant RefAllele, 1nt insertion"));
+            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,TA,G", false, null, "2nt deletion with discrepant RefAllele, 1nt insertion", "Reference allele extracted from response (TC) does not match given reference allele (TA)"));
             glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,TC,TC", true, "TC/TC", "2nt deletion with RefAllele, 2nt insertion no change")); // note : different result than ensembl
             glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,TC,TT", true, "C/T", "2nt deletion with RefAllele, 2nt insertion, partial change"));
             glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,TC,GG", true, "TC/GG", "2nt deletion with RefAllele, 2nt insertion, full change"));
-            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,CC,TC", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion no change")); // note : different result than ensembl
-            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,CC,TT", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion, partial change"));
-            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,CC,GG", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion, full change"));
-            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,CCCC,TT", false, null, "2nt deletion with invalid RefAllele, 2nt insertion"));
+            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,CC,TC", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion no change", "Reference allele extracted from response (TC) does not match given reference allele (CC)")); // note : different result than ensembl
+            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,CC,TT", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion, partial change", "Reference allele extracted from response (TC) does not match given reference allele (CC)"));
+            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,CC,GG", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion, full change", "Reference allele extracted from response (TC) does not match given reference allele (CC)"));
+            glInsertionDeletions.add(new VariantTestCase("5,138163255,138163256,CCCC,TT", false, null, "2nt deletion with invalid RefAllele, 2nt insertion", "Reference allele extracted from response (TC) does not match given reference allele (CCCC)"));
         }
     }
 
@@ -254,6 +267,7 @@ public class VerifiedGenomicLocationAnnotationServiceTest
                 Assert.assertTrue(testCase.originalVariantQuery + " : expected successful annotation", testResponse.isSuccessfullyAnnotated());
             } else {
                 Assert.assertFalse(testCase.originalVariantQuery + " : expected failed annotation", testResponse.isSuccessfullyAnnotated());
+                Assert.assertEquals(testCase.originalVariantQuery + " : expected error message", testCase.errorMessage, testResponse.getErrorMessage());
             }
             if (testResponse.isSuccessfullyAnnotated()) {
                 Assert.assertEquals(testCase.originalVariantQuery + " : Variant Allele comparison", testCase.expectedGnAlleleString, testResponse.getAlleleString());
@@ -273,6 +287,7 @@ public class VerifiedGenomicLocationAnnotationServiceTest
                 Assert.assertTrue(genomicLocation.toString() + " : expected successful annotation", testResponse.isSuccessfullyAnnotated());
             } else {
                 Assert.assertFalse(genomicLocation.toString() + " : expected failed annotation", testResponse.isSuccessfullyAnnotated());
+                Assert.assertEquals(testCase.originalVariantQuery + " : expected error message", testCase.errorMessage, testResponse.getErrorMessage());
             }
             if (testResponse.isSuccessfullyAnnotated()) {
                 Assert.assertEquals(genomicLocation.toString() + " : Variant Allele comparison", testCase.expectedGnAlleleString, testResponse.getAlleleString());
@@ -307,6 +322,7 @@ public class VerifiedGenomicLocationAnnotationServiceTest
                 Assert.assertTrue(testCase.originalVariantQuery + " : expected successful annotation", testResponse.isSuccessfullyAnnotated());
             } else {
                 Assert.assertFalse(testCase.originalVariantQuery + " : expected failed annotation", testResponse.isSuccessfullyAnnotated());
+                Assert.assertEquals(testCase.originalVariantQuery + " : expected error message", testCase.errorMessage, testResponse.getErrorMessage());
             }
             if (testResponse.isSuccessfullyAnnotated()) {
                 Assert.assertEquals(testCase.originalVariantQuery + " : Variant Allele comparison", testCase.expectedGnAlleleString, testResponse.getAlleleString());

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VerifiedHgvsVariantAnnotationServiceTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/internal/VerifiedHgvsVariantAnnotationServiceTest.java
@@ -76,6 +76,7 @@ public class VerifiedHgvsVariantAnnotationServiceTest
         public boolean expectedGnSuccessfullyAnnotated;
         public String expectedGnAlleleString;
         public String description;
+        public String errorMessage;
         public VariantTestCase(
                 String originalVariantQuery,
                 boolean expectedGnSuccessfullyAnnotated,
@@ -85,6 +86,18 @@ public class VerifiedHgvsVariantAnnotationServiceTest
             this.expectedGnSuccessfullyAnnotated = expectedGnSuccessfullyAnnotated;
             this.expectedGnAlleleString = expectedGnAlleleString;
             this.description = description;
+        }
+        public VariantTestCase(
+                String originalVariantQuery,
+                boolean expectedGnSuccessfullyAnnotated,
+                String expectedGnAlleleString,
+                String description,
+                String errorMessage) {
+            this.originalVariantQuery =  originalVariantQuery;
+            this.expectedGnSuccessfullyAnnotated = expectedGnSuccessfullyAnnotated;
+            this.expectedGnAlleleString = expectedGnAlleleString;
+            this.description = description;
+            this.errorMessage = errorMessage;
         }
     }
 
@@ -109,15 +122,15 @@ public class VerifiedHgvsVariantAnnotationServiceTest
         if (hgvsSubstitutions == null) {
             hgvsSubstitutions = new ArrayList<VariantTestCase>();
             hgvsSubstitutions.add(new VariantTestCase("5:g.138163256C>T", true, "C/T", "valid substitution"));
-            hgvsSubstitutions.add(new VariantTestCase("5:g.138163256A>T", false, null, "discrepant RefAllele"));
-            hgvsSubstitutions.add(new VariantTestCase("5:g.138163256>T", false, null, "missing RefAllele"));
+            hgvsSubstitutions.add(new VariantTestCase("5:g.138163256A>T", false, null, "discrepant RefAllele", "Reference allele extracted from response (-) does not match given reference allele (A)"));
+            hgvsSubstitutions.add(new VariantTestCase("5:g.138163256>T", false, null, "missing RefAllele", "Line 1 skipped (5:g.138163256>T): Invalid allele string / or possible parsing error"));
             hgvsDeletions = new ArrayList<VariantTestCase>();
             hgvsDeletions.add(new VariantTestCase("5:g.138163256delC", true, "C/-", "1nt deletion with RefAllele"));
-            hgvsDeletions.add(new VariantTestCase("5:g.138163256delA", false, null, "1nt deletion with discrepant RefAllele"));
+            hgvsDeletions.add(new VariantTestCase("5:g.138163256delA", false, null, "1nt deletion with discrepant RefAllele", "Reference allele extracted from response (C) does not match given reference allele (A)"));
             hgvsDeletions.add(new VariantTestCase("5:g.138163256del", true, "C/-", "1nt deletion missing RefAllele"));
             hgvsDeletions.add(new VariantTestCase("5:g.138163255_138163256delTC", true, "TC/-", "2nt deletion with RefAllele"));
-            hgvsDeletions.add(new VariantTestCase("5:g.138163255_138163256delCC", false, null, "2nt deletion with discrepant RefAllele"));
-            hgvsDeletions.add(new VariantTestCase("5:g.138163255_138163256delCCCC", false, null, "2nt deletion with invalid RefAllele"));
+            hgvsDeletions.add(new VariantTestCase("5:g.138163255_138163256delCC", false, null, "2nt deletion with discrepant RefAllele", "Reference allele extracted from response (TC) does not match given reference allele (CC)"));
+            hgvsDeletions.add(new VariantTestCase("5:g.138163255_138163256delCCCC", false, null, "2nt deletion with invalid RefAllele", "Reference allele extracted from response (TC) does not match given reference allele (CCCC)"));
             hgvsDeletions.add(new VariantTestCase("5:g.138163255_138163256del", true, "TC/-", "2nt deletion missing RefAllele"));
             hgvsInsertions = new ArrayList<VariantTestCase>();
             hgvsInsertions.add(new VariantTestCase("5:g.138163255_138163256insT", true, "-/T", "1nt insertion"));
@@ -126,24 +139,24 @@ public class VerifiedHgvsVariantAnnotationServiceTest
             hgvsInsertionDeletions = new ArrayList<VariantTestCase>();
             hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163256delinsT", true, "C/T", "1nt deletion without RefAllele, 1nt insertion"));
             hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163256delCinsT", true, "C/T", "1nt deletion with RefAllele, 1nt insertion"));
-            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163256delAinsT", false, null, "1nt deletion with discrepant RefAllele, 1nt insertion"));
-            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163256delinsC", false, null, "1nt deletion without RefAllele, 1nt insertion no change"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163256delAinsT", false, null, "1nt deletion with discrepant RefAllele, 1nt insertion", "Reference allele extracted from response (C) does not match given reference allele (A)"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163256delinsC", false, null, "1nt deletion without RefAllele, 1nt insertion no change", "Unable to parse HGVS notation '5:g.138163256delinsC': Reference allele extracted from 5:138163257-138163256 (C) matches alt allele given by HGVS notation 5:g.138163256delinsC (-)"));
             hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163256delinsTT", true, "C/TT", "1nt deletion without RefAllele, 2nt insertion"));
             hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163256delCinsTT", true, "C/TT", "1nt deletion with RefAllele, 2nt insertion"));
-            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163256delAinsTT", false, null, "1nt deletion with discrepant RefAllele, 2nt insertion"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163256delAinsTT", false, null, "1nt deletion with discrepant RefAllele, 2nt insertion", "Reference allele extracted from response (C) does not match given reference allele (A)"));
             hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delinsG", true, "TC/G", "2nt deletion without RefAllele, 1nt insertion"));
             hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delTCinsA", true, "TC/A", "2nt deletion with RefAllele, 1nt insertion"));
-            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delTAinsG", false, null, "2nt deletion with discrepant RefAllele, 1nt insertion"));
-            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delTCinsTC", false, null, "2nt deletion with RefAllele, 2nt insertion no change"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delTAinsG", false, null, "2nt deletion with discrepant RefAllele, 1nt insertion", "Reference allele extracted from response (TC) does not match given reference allele (TA)"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delTCinsTC", false, null, "2nt deletion with RefAllele, 2nt insertion no change", "Unable to parse HGVS notation '5:g.138163255_138163256delTCinsTC': Reference allele extracted from 5:138163257-138163256 (TC) matches alt allele given by HGVS notation 5:g.138163255_138163256delTCinsTC (-)"));
             hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delTCinsTT", true, "C/T", "2nt deletion with RefAllele, 2nt insertion, partial change"));
             hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delTCinsGG", true, "TC/GG", "2nt deletion with RefAllele, 2nt insertion, full change"));
-            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delCCinsTC", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion no change"));
-            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delCCinsTT", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion, partial change"));
-            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delCCinsGG", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion, full change"));
-            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delinsTC", false, null, "2nt deletion without RefAllele, 2nt insertion no change"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delCCinsTC", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion no change", "Reference allele extracted from response (TC) does not match given reference allele (CC)"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delCCinsTT", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion, partial change", "Reference allele extracted from response (TC) does not match given reference allele (CC)"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delCCinsGG", false, null, "2nt deletion with discrepant RefAllele, 2nt insertion, full change", "Reference allele extracted from response (TC) does not match given reference allele (CC)"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delinsTC", false, null, "2nt deletion without RefAllele, 2nt insertion no change", "Unable to parse HGVS notation '5:g.138163255_138163256delinsTC': Reference allele extracted from 5:138163257-138163256 (TC) matches alt allele given by HGVS notation 5:g.138163255_138163256delinsTC (-)"));
             hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delinsTT", true, "C/T", "2nt deletion without RefAllele, 2nt insertion, partial change"));
             hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delinsGG", true, "TC/GG", "2nt deletion without RefAllele, 2nt insertion, full change"));
-            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delCCCCinsTT", false, null, "2nt deletion with invalid RefAllele, 2nt insertion"));
+            hgvsInsertionDeletions.add(new VariantTestCase("5:g.138163255_138163256delCCCCinsTT", false, null, "2nt deletion with invalid RefAllele, 2nt insertion", "Reference allele extracted from response (TC) does not match given reference allele (CCCC)"));
             hgvsInversions = new ArrayList<VariantTestCase>();
             hgvsInversions.add(new VariantTestCase("5:g.138163255_138163256inv", true, "TC/GA", "inversions not supported - but will run as passthrough"));
             hgvsInversions.add(new VariantTestCase("5:g.138163255_138163256invTC", false, null, "inversion format does not allow specification of RefAllele"));
@@ -271,6 +284,7 @@ public class VerifiedHgvsVariantAnnotationServiceTest
                 Assert.assertTrue(testCase.originalVariantQuery + " : expected successful annotation", testResponse.isSuccessfullyAnnotated());
             } else {
                 Assert.assertFalse(testCase.originalVariantQuery + " : expected failed annotation", testResponse.isSuccessfullyAnnotated());
+                Assert.assertEquals(testCase.originalVariantQuery + " : expected error message", testCase.errorMessage, testResponse.getErrorMessage());
             }
             if (testResponse.isSuccessfullyAnnotated()) {
                 Assert.assertEquals(testCase.originalVariantQuery + " : Variant Allele comparison", testCase.expectedGnAlleleString, testResponse.getAlleleString());
@@ -305,6 +319,7 @@ public class VerifiedHgvsVariantAnnotationServiceTest
                 Assert.assertTrue(testCase.originalVariantQuery + " : expected successful annotation", testResponse.isSuccessfullyAnnotated());
             } else {
                 Assert.assertFalse(testCase.originalVariantQuery + " : expected failed annotation", testResponse.isSuccessfullyAnnotated());
+                Assert.assertEquals(testCase.originalVariantQuery + " : expected error message", testCase.errorMessage, testResponse.getErrorMessage());
             }
             if (testResponse.isSuccessfullyAnnotated()) {
                 Assert.assertEquals(testCase.originalVariantQuery + " : Variant Allele comparison", testCase.expectedGnAlleleString, testResponse.getAlleleString());


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/653
Return error message in response:
Example: 12,58142319,58142319,A,C
```
{
  "variant": "12:g.58142319A>C",
  "errorMessage": "Unable to parse HGVS notation '12:g.58142319A>C': Reference allele extracted from 12:58142319-58142319 (T) does not match reference allele given by HGVS notation 12:g.58142319A>C (A)",
  "originalVariantQuery": "12,58142319,58142319,A,C",
  "successfully_annotated": false
}
```
```
{
  "variant": "GL000199.1:98962-98962:1/G",
  "errorMessage": "Reference allele extracted from response (-) does not match given reference allele (C)",
  "originalVariantQuery": "GL000199.1,98962,98962,C,G",
  "successfully_annotated": false
}
```