### PR TITLE
Change my variant info clinvar field name

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/MyVariantInfo.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/MyVariantInfo.java
@@ -35,7 +35,7 @@ public class MyVariantInfo
     private Cosmic cosmic;
 
     @Field(value = "clinvar")
-    private ClinVar clinVar;
+    private MyVariantInfoClinVar clinVar;
 
     @Field(value = "mutdb")
     private Mutdb mutdb;
@@ -110,11 +110,11 @@ public class MyVariantInfo
         this.cosmic = cosmic;
     }
 
-    public ClinVar getClinVar() {
+    public MyVariantInfoClinVar getClinVar() {
         return clinVar;
     }
 
-    public void setClinVar(ClinVar clinVar) {
+    public void setClinVar(MyVariantInfoClinVar clinVar) {
         this.clinVar = clinVar;
     }
 

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/MyVariantInfoClinVar.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/my_variant_info_model/MyVariantInfoClinVar.java
@@ -7,7 +7,7 @@ import org.springframework.data.mongodb.core.mapping.Field;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ClinVar
+public class MyVariantInfoClinVar
 {
     @Field(value = "_license")
     private String license;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/config/ExternalResourceObjectMapper.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/config/ExternalResourceObjectMapper.java
@@ -43,7 +43,7 @@ public class ExternalResourceObjectMapper extends ObjectMapper
         mixinMap.put(Alleles.class, AllelesMixin.class);
         mixinMap.put(Hg19.class, Hg19Mixin.class);
         mixinMap.put(Cosmic.class, CosmicMixin.class);
-        mixinMap.put(ClinVar.class, ClinVarMixin.class);
+        mixinMap.put(MyVariantInfoClinVar.class, MyVariantInfoClinVarMixin.class);
         mixinMap.put(Hg38.class, Hg38Mixin.class);
         mixinMap.put(Mutdb.class, MutdbMixin.class);
         mixinMap.put(Gnomad.class, GnomadMixin.class);

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/my_variant_info_mixin/MyVariantInfoClinVarMixin.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/my_variant_info_mixin/MyVariantInfoClinVarMixin.java
@@ -14,7 +14,7 @@ import org.cbioportal.genome_nexus.model.my_variant_info_model.Rcv;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 
-public class ClinVarMixin
+public class MyVariantInfoClinVarMixin
 {
     @JsonProperty(value = "_license", required = true)
     private String license;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/my_variant_info_mixin/MyVariantInfoMixin.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/my_variant_info_mixin/MyVariantInfoMixin.java
@@ -3,7 +3,7 @@ package org.cbioportal.genome_nexus.service.mixin.my_variant_info_mixin;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.cbioportal.genome_nexus.model.my_variant_info_model.ClinVar;
+import org.cbioportal.genome_nexus.model.my_variant_info_model.MyVariantInfoClinVar;
 import org.cbioportal.genome_nexus.model.my_variant_info_model.Cosmic;
 import org.cbioportal.genome_nexus.model.my_variant_info_model.Gnomad;
 import org.cbioportal.genome_nexus.model.my_variant_info_model.Mutdb;
@@ -36,7 +36,7 @@ public class MyVariantInfoMixin
     private Cosmic cosmic;
 
     @JsonProperty(value = "clinvar", required = true)
-    private ClinVar clinVar;
+    private MyVariantInfoClinVar clinVar;
 
     @JsonProperty(value = "mutdb", required = true)
     private Mutdb mutdb;

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/config/ApiObjectMapper.java
@@ -48,7 +48,7 @@ public class ApiObjectMapper extends ObjectMapper
         mixinMap.put(Alleles.class, AllelesMixin.class);
         mixinMap.put(Hg19.class, Hg19Mixin.class);
         mixinMap.put(Cosmic.class, CosmicMixin.class);
-        mixinMap.put(ClinVar.class, ClinVarMixin.class);
+        mixinMap.put(MyVariantInfoClinVar.class, MyVariantInfoClinVarMixin.class);
         mixinMap.put(Hg38.class, Hg38Mixin.class);
         mixinMap.put(Mutdb.class, MutdbMixin.class);
         mixinMap.put(Gnomad.class, GnomadMixin.class);

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/VariantAnnotationMixin.java
@@ -100,7 +100,7 @@ public class VariantAnnotationMixin {
     private MyVariantInfoAnnotation myVariantInfoAnnotation;
 
     @JsonProperty(value="clinvar", required = true)
-    @ApiModelProperty(value = "ClinVar", required = false)
+    @ApiModelProperty(value = "MyVariantInfoClinVar", required = false)
     private ClinvarAnnotation clinvarAnnotation;
 
     @JsonIgnore

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/my_variant_info_mixin/MyVariantInfoClinVarMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/my_variant_info_mixin/MyVariantInfoClinVarMixin.java
@@ -11,7 +11,7 @@ import org.cbioportal.genome_nexus.model.my_variant_info_model.Rcv;
 import io.swagger.annotations.ApiModelProperty;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ClinVarMixin
+public class MyVariantInfoClinVarMixin
 {
     @ApiModelProperty(value = "license", required = false)
     private String license;

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/my_variant_info_mixin/MyVariantInfoMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/my_variant_info_mixin/MyVariantInfoMixin.java
@@ -2,7 +2,7 @@ package org.cbioportal.genome_nexus.web.mixin.my_variant_info_mixin;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import org.cbioportal.genome_nexus.model.my_variant_info_model.ClinVar;
+import org.cbioportal.genome_nexus.model.my_variant_info_model.MyVariantInfoClinVar;
 import org.cbioportal.genome_nexus.model.my_variant_info_model.Cosmic;
 import org.cbioportal.genome_nexus.model.my_variant_info_model.Dbsnp;
 import org.cbioportal.genome_nexus.model.my_variant_info_model.Gnomad;
@@ -36,7 +36,7 @@ public class MyVariantInfoMixin
     private Cosmic cosmic;
 
     @ApiModelProperty(value = "clinvar", required = false)
-    private ClinVar clinVar;
+    private MyVariantInfoClinVar clinVar;
 
     @ApiModelProperty(value = "gnomad_exome", required = false)
     private Gnomad gnomadExome;


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/707
`Cinvar` is the model name for genome nexus clinvar.
`ClinVar` is the model name for my variant info clinvar.
Previously we get clinvar annotation from my variant info, but we switched to fetching clinvar annotation from genome nexus database now. 
Proposal: Probably ok to remove all my variant info `ClinVar`, not sure if it is used somewhere, so for now I keep the my variant info clinvar annotation and change name `ClinVar`  to `MyVariantInfoClinVar`. 