### PR TITLE
Add error message for VEP error on POST requests

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/cached/BaseCachedVariantAnnotationFetcher.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/cached/BaseCachedVariantAnnotationFetcher.java
@@ -93,6 +93,7 @@ public abstract class BaseCachedVariantAnnotationFetcher
         for (String variantId : variantResponse.keySet()) {
             if (variantResponse.get(variantId) == null) {
                 VariantAnnotation variantAnnotation = new VariantAnnotation(variantId);
+                variantAnnotation.setErrorMessage("Error from VEP for: " + variantId);
                 variantResponse.put(variantId, variantAnnotation);
             } else {
                 variantResponse.get(variantId).setSuccessfullyAnnotated(true);


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/708
When sending POST request to VEP, if one of the variant can be annotated successfully, the whole query returns 200 instead of 400, and no error message is returned. In those cases the annotation of failing variant will be null, and will fail in annotation verification, because the response ref allele will always be `-`, which can't match the provided ref allele. But the error message will take `-` as reference (e.g. Reference allele extracted from response (C) does not match given reference allele (-)), so this is not correct.
This PR updates error message for POST requests to indicate the error is from VEP.
Would be good if we could include more details about the error.