### PR TITLE
Use standard variant classification instead of revue classification in annotations

### DIFF
--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/VariantClassificationResolver.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/VariantClassificationResolver.java
@@ -132,6 +132,40 @@ public class VariantClassificationResolver
         return VARIANT_MAP.getOrDefault(variant, defaultValue);
     }
 
+    public String resolveRevueVariantClassification(String revueVariantClassification) {
+        if (revueVariantClassification == null) {
+            return null;
+        }
+        switch (revueVariantClassification) {
+            // Spilice exon skip:
+            case "Splice_Exon_Skip_In_Frame":
+                return "In_Frame_Del";
+            case "Splice_Exon_Skip_Out_Of_Frame":
+                return "Frame_Shift_Del";
+            case "Splice_Exon_Skip_Non_Start":
+                return "In_Frame_Del";
+            // Splice exon extension:
+            case "Splice_Exon_Extension_In_Frame":
+                return "In_Frame_Ins";
+            case "Splice_Exon_Extension_Out_Of_Frame":
+                return "Frame_Shift_Ins";
+            case "Splice_Exon_Extension_Nonsense":
+                return "In_Frame_Ins";
+            // Splice exon shortening:
+            case "Splice_Exon_Shortening_In_Frame":
+                return "In_Frame_Del";
+            case "Splice_Exon_Shortening_Out_Of_Frame":
+                return "Frame_Shift_Del";
+            // Splice intron retention:
+            case "Splice_Intron_Retention_In_Frame":
+                return "In_Frame_Ins";
+            case "Splice_Intron_Retention_Out_Of_Frame":
+                return "Frame_Shift_Ins";
+            default:
+                return null;
+        }
+    }
+
     private static Map<String, String> initVariantMap()
     {
         Map<String, String> variantMap = new HashMap<>();

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/RevisedProteinEffectJsonRecord.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/RevisedProteinEffectJsonRecord.java
@@ -1,5 +1,7 @@
 package org.cbioportal.genome_nexus.model;
 
+import java.util.List;
+
 public class RevisedProteinEffectJsonRecord {
     private String variant; 
     private String genomicLocation;
@@ -8,9 +10,17 @@ public class RevisedProteinEffectJsonRecord {
     private String vepPredictedVariantClassification;
     private String revisedProteinEffect;
     private String revisedVariantClassification;
-    private Integer pubmedId;
-    private String referenceText;
     private Boolean confirmed;
+    private String mutationOrigin;
+    private List<VueReference> references;
+
+    public List<VueReference> getReferences() {
+        return references;
+    }
+
+    public void setReferences(List<VueReference> references) {
+        this.references = references;
+    }
 
     public Boolean getConfirmed() {
         return confirmed;
@@ -75,22 +85,12 @@ public class RevisedProteinEffectJsonRecord {
     public void setVepPredictedVariantClassification(String vepPredictedVariantClassification) {
         this.vepPredictedVariantClassification = vepPredictedVariantClassification;
     }
-    
-    public Integer getPubmedId() {
-        return pubmedId;
+
+    public String getMutationOrigin() {
+        return mutationOrigin;
     }
 
-    public void setPubmedId(Integer pubmedId) {
-        this.pubmedId = pubmedId;
+    public void setMutationOrigin(String mutationOrigin) {
+        this.mutationOrigin = mutationOrigin;
     }
-
-    public String getReferenceText() {
-        return referenceText;
-    }
-
-    public void setReferenceText(String referenceText) {
-        this.referenceText = referenceText;
-    }
-
-
 }

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VueReference.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VueReference.java
@@ -1,0 +1,19 @@
+package org.cbioportal.genome_nexus.model;
+
+public class VueReference {
+    private Integer pubmedId;
+    private String referenceText;
+
+    public Integer getPubmedId() {
+        return pubmedId;
+    }
+    public void setPubmedId(Integer pubmedId) {
+        this.pubmedId = pubmedId;
+    }
+    public String getReferenceText() {
+        return referenceText;
+    }
+    public void setReferenceText(String referenceText) {
+        this.referenceText = referenceText;
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/Vues.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/Vues.java
@@ -12,7 +12,7 @@ public class Vues {
     private String transcriptId;
     private String revisedProteinEffect;
     private String revisedVariantClassification;
-    private String generalRevisedVariantClassification;
+    private String revisedVariantClassificationStandard;
     private String context;
     private String vepPredictedProteinEffect;
     private String vepPredictedVariantClassification;
@@ -105,11 +105,11 @@ public class Vues {
     public void setVepPredictedVariantClassification(String vepPredictedVariantClassification) {
         this.vepPredictedVariantClassification = vepPredictedVariantClassification;
     }
-    public String getGeneralRevisedVariantClassification() {
-        return generalRevisedVariantClassification;
+    public String getRevisedVariantClassificationStandard() {
+        return revisedVariantClassificationStandard;
     }
-    public void setGeneralRevisedVariantClassification(String generalRevisedVariantClassification) {
-        this.generalRevisedVariantClassification = generalRevisedVariantClassification;
+    public void setRevisedVariantClassificationStandard(String revisedVariantClassificationStandard) {
+        this.revisedVariantClassificationStandard = revisedVariantClassificationStandard;
     }
     public Boolean getConfirmed() {
         return confirmed;

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/Vues.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/Vues.java
@@ -7,16 +7,30 @@ public class Vues {
     private String genomicLocationDescription;
     private String defaultEffect;
     private String comment;
-    private Integer pubmedId;
-    private String referenceText;
     private String variant; 
     private String genomicLocation;
     private String transcriptId;
     private String revisedProteinEffect;
     private String revisedVariantClassification;
+    private String generalRevisedVariantClassification;
     private String context;
     private String vepPredictedProteinEffect;
     private String vepPredictedVariantClassification;
+    private String mutationOrigin;
+    private List<VueReference> references;
+    
+    public List<VueReference> getReferences() {
+        return references;
+    }
+    public void setReferences(List<VueReference> references) {
+        this.references = references;
+    }
+    public String getMutationOrigin() {
+        return mutationOrigin;
+    }
+    public void setMutationOrigin(String mutationOrigin) {
+        this.mutationOrigin = mutationOrigin;
+    }
     private Boolean confirmed;
 
     public String getHugoGeneSymbol() {
@@ -42,18 +56,6 @@ public class Vues {
     }
     public void setComment(String comment) {
         this.comment = comment;
-    }
-    public Integer getPubmedId() {
-        return pubmedId;
-    }
-    public void setPubmedId(Integer pubmedId) {
-        this.pubmedId = pubmedId;
-    }
-    public String getReferenceText() {
-        return referenceText;
-    }
-    public void setReferenceText(String referenceText) {
-        this.referenceText = referenceText;
     }
     public String getVariant() {
         return variant;
@@ -102,6 +104,12 @@ public class Vues {
     }
     public void setVepPredictedVariantClassification(String vepPredictedVariantClassification) {
         this.vepPredictedVariantClassification = vepPredictedVariantClassification;
+    }
+    public String getGeneralRevisedVariantClassification() {
+        return generalRevisedVariantClassification;
+    }
+    public void setGeneralRevisedVariantClassification(String generalRevisedVariantClassification) {
+        this.generalRevisedVariantClassification = generalRevisedVariantClassification;
     }
     public Boolean getConfirmed() {
         return confirmed;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
@@ -246,8 +246,8 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
                     vue.setDefaultEffect(vueRecord.getDefaultEffect());
                     vue.setComment(vueRecord.getComment());
                     vue.setContext(vueRecord.getContext());
-                    vue.setPubmedId(revisedProteinEffectJsonRecord.getPubmedId());
-                    vue.setReferenceText(revisedProteinEffectJsonRecord.getReferenceText());
+                    vue.setReferences(revisedProteinEffectJsonRecord.getReferences());
+                    vue.setGeneralRevisedVariantClassification(this.variantClassificationResolver.resolveRevueVariantClassification(revisedProteinEffectJsonRecord.getRevisedVariantClassification()));
                     vue.setRevisedVariantClassification(revisedProteinEffectJsonRecord.getRevisedVariantClassification());
                     vue.setRevisedProteinEffect(revisedProteinEffectJsonRecord.getRevisedProteinEffect());
                     vue.setVepPredictedVariantClassification(revisedProteinEffectJsonRecord.getVepPredictedVariantClassification());
@@ -296,7 +296,7 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
             Vues vue = vuesMap.get(transcriptConsequence.getTranscriptId() + "-" + annotation.getVariant());
             if (vue != null) {
                 if ((overwriteByConfirmedRevueOnly == true && vue.getConfirmed()== true) || overwriteByConfirmedRevueOnly == false) {
-                    summary.setVariantClassification(vue.getRevisedVariantClassification());
+                    summary.setVariantClassification(vue.getGeneralRevisedVariantClassification());
                     summary.setHgvspShort(vue.getRevisedProteinEffect());
                     summary.setProteinPosition(this.proteinPositionResolver.extractProteinPos(vue.getRevisedProteinEffect()));
                     summary.setIsVue(true);

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
@@ -247,7 +247,7 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
                     vue.setComment(vueRecord.getComment());
                     vue.setContext(vueRecord.getContext());
                     vue.setReferences(revisedProteinEffectJsonRecord.getReferences());
-                    vue.setGeneralRevisedVariantClassification(this.variantClassificationResolver.resolveRevueVariantClassification(revisedProteinEffectJsonRecord.getRevisedVariantClassification()));
+                    vue.setRevisedVariantClassificationStandard(this.variantClassificationResolver.resolveRevueVariantClassification(revisedProteinEffectJsonRecord.getRevisedVariantClassification()));
                     vue.setRevisedVariantClassification(revisedProteinEffectJsonRecord.getRevisedVariantClassification());
                     vue.setRevisedProteinEffect(revisedProteinEffectJsonRecord.getRevisedProteinEffect());
                     vue.setVepPredictedVariantClassification(revisedProteinEffectJsonRecord.getVepPredictedVariantClassification());
@@ -296,7 +296,7 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
             Vues vue = vuesMap.get(transcriptConsequence.getTranscriptId() + "-" + annotation.getVariant());
             if (vue != null) {
                 if ((overwriteByConfirmedRevueOnly == true && vue.getConfirmed()== true) || overwriteByConfirmedRevueOnly == false) {
-                    summary.setVariantClassification(vue.getGeneralRevisedVariantClassification());
+                    summary.setVariantClassification(vue.getRevisedVariantClassificationStandard());
                     summary.setHgvspShort(vue.getRevisedProteinEffect());
                     summary.setProteinPosition(this.proteinPositionResolver.extractProteinPos(vue.getRevisedProteinEffect()));
                     summary.setIsVue(true);


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/738
Changes in this PR:
- [x] Two separate fields, `revisedVariantClassification` and `revisedVariantClassificationStandard`. The standard classification will be used in annotation_summary and cbioportal
- [x] Make model changes to fit with current revue data (new revue variants could have multiple references)

Example response:
```
{
  "variant": "4:g.55593580_55593606del",
  "originalVariantQuery": "4:g.55593580_55593606del",
  "hgvsg": "4:g.55593580_55593606del",
  "id": "4:g.55593580_55593606del",
  "assembly_name": "GRCh37",
  "seq_region_name": "4",
  "start": 55593580,
  "end": 55593606,
  "allele_string": "AGAAACCCATGTATGAAGTACAGTGGA/-",
  "strand": 1,
  "most_severe_consequence": "splice_acceptor_variant",
...
    "transcriptConsequenceSummary": {
      "transcriptId": "ENST00000288135",
      "entrezGeneId": "3815",
      "consequenceTerms": "splice_acceptor_variant,coding_sequence_variant",
      "hugoGeneSymbol": "KIT",
      "hgvspShort": "p.K550_K558del",
      "hgvsc": "ENST00000288135.5:c.1648_1674del",
      "proteinPosition": {
        "start": 550,
        "end": 558
      },
      "refSeq": "NM_000222.2",
      "variantClassification": "In_Frame_Del",
      "exon": "11/21",
      "uniprotId": "P10721",
      "isVue": true
    },
    "vues": {
      "hugoGeneSymbol": "KIT",
      "genomicLocationDescription": "Deletions flanking intron 10 - exon 11 boundary (e.g. 4:55593576_55593606del)",
      "defaultEffect": "splice",
      "comment": "Changes splice donor site, cause inframe deletion in exon 11",
      "variant": "4:g.55593580_55593606del",
      "genomicLocation": "4,55593580,55593606,AGAAACCCATGTATGAAGTACAGTGGA,-",
      "transcriptId": "ENST00000288135",
      "revisedProteinEffect": "p.K550_K558del",
      "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
      "revisedVariantClassificationStandard": "In_Frame_Del",
      "context": "Actionable in GIST",
      "vepPredictedProteinEffect": "p.X550_splice",
      "vepPredictedVariantClassification": "Splice_Site",
      "mutationOrigin": null,
      "references": [
        {
          "pubmedId": 15507676,
          "referenceText": "Corless et al., 2004"
        }
      ],
      "confirmed": true
    }
  }
}
```