### PR TITLE
Add the alphaMissense to transcript consequences

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/AlphaMissense.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/AlphaMissense.java
@@ -1,0 +1,28 @@
+package org.cbioportal.genome_nexus.model;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+public class AlphaMissense {
+
+    private Double score;
+
+    private String pathogenicity;
+
+    @Field("am_pathogenicity")
+    public Double getScore() {
+        return score;
+    }
+
+    public void setScore(Double score) {
+        this.score = score;
+    }
+
+    @Field("am_class")
+    public String getPathogenicity() {
+        return pathogenicity;
+    }
+
+    public void setPathogenicity(String pathogenicity) {
+        this.pathogenicity = pathogenicity;
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/TranscriptConsequence.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/TranscriptConsequence.java
@@ -70,6 +70,17 @@ public class TranscriptConsequence
 
     private Map<String, Object> dynamicProps;
 
+    private AlphaMissense alphaMissense;
+
+    @Field("alphamissense")
+    public AlphaMissense getAlphaMissense() {
+        return alphaMissense;
+    }
+
+    public void setAlphaMissense(AlphaMissense alphaMissense) {
+        this.alphaMissense = alphaMissense;
+    }
+
     public TranscriptConsequence()
     {
         this(null);
@@ -283,7 +294,7 @@ public class TranscriptConsequence
     }
 
     public void setUniprotId(String uniprotId) {
-        this.uniprotId = uniprotId; 
+        this.uniprotId = uniprotId;
     }
 
     @Field(value="refseq_transcript_ids")

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/TranscriptConsequenceSummary.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/TranscriptConsequenceSummary.java
@@ -1,5 +1,4 @@
 package org.cbioportal.genome_nexus.model;
-
 public class TranscriptConsequenceSummary
 {
     private String transcriptId;
@@ -23,6 +22,15 @@ public class TranscriptConsequenceSummary
     private String siftPrediction;
     private String uniprotId;
     private Boolean isVue;
+    private AlphaMissense alphaMissense;
+
+    public AlphaMissense getAlphaMissense() {
+        return alphaMissense;
+    }
+
+    public void setAlphaMissense(AlphaMissense alphaMissense) {
+        this.alphaMissense = alphaMissense;
+    }
 
     public String getTranscriptId() {
         return transcriptId;
@@ -149,7 +157,7 @@ public class TranscriptConsequenceSummary
     }
 
     public void setPolyphenScore(Double polyphenScore) {
-        this.polyphenScore = polyphenScore; 
+        this.polyphenScore = polyphenScore;
     }
 
     public String getPolyphenPrediction() {
@@ -157,7 +165,7 @@ public class TranscriptConsequenceSummary
     }
 
     public void setPolyphenPrediction(String polyphenPrediction) {
-        this.polyphenPrediction = polyphenPrediction; 
+        this.polyphenPrediction = polyphenPrediction;
     }
 
     public Double getSiftScore() {
@@ -165,7 +173,7 @@ public class TranscriptConsequenceSummary
     }
 
     public void setSiftScore(Double siftScore) {
-        this.siftScore = siftScore; 
+        this.siftScore = siftScore;
     }
 
     public String getSiftPrediction() {
@@ -173,7 +181,7 @@ public class TranscriptConsequenceSummary
     }
 
     public void setSiftPrediction(String siftPrediction) {
-        this.siftPrediction = siftPrediction; 
+        this.siftPrediction = siftPrediction;
     }
 
     public String getUniprotId() {
@@ -181,7 +189,7 @@ public class TranscriptConsequenceSummary
     }
 
     public void setUniprotId(String uniprotId) {
-        this.uniprotId = uniprotId; 
+        this.uniprotId = uniprotId;
     }
 
     public Boolean getIsVue() {

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotationSummary.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotationSummary.java
@@ -24,6 +24,16 @@ public class VariantAnnotationSummary
 
     private Vues vues;
 
+    private AlphaMissense alphaMissense;
+
+    public AlphaMissense getAlphaMissense() {
+        return alphaMissense;
+    }
+
+    public void setAlphaMissense(AlphaMissense alphaMissense) {
+        this.alphaMissense = alphaMissense;
+    }
+
     public String getVariant() {
         return variant;
     }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationSummaryServiceImpl.java
@@ -119,8 +119,8 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
             transcriptConsequences.add(annotationSummary.getTranscriptConsequenceSummary());
             annotationSummary.setTranscriptConsequences(transcriptConsequences);
             // if this variant is VUE, add Vues infomation
-            if (annotationSummary.getTranscriptConsequenceSummary() != null && 
-                annotationSummary.getTranscriptConsequenceSummary().getIsVue() != null && 
+            if (annotationSummary.getTranscriptConsequenceSummary() != null &&
+                annotationSummary.getTranscriptConsequenceSummary().getIsVue() != null &&
                 annotationSummary.getTranscriptConsequenceSummary().getIsVue() == true) {
                 annotationSummary.setVues(this.vuesMap.get(annotationSummary.getTranscriptConsequenceSummary().getTranscriptId()));
             }
@@ -187,8 +187,8 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
             annotationSummary.setTranscriptConsequences(summaries);
 
             // if this variant is VUE, add Vues infomation
-            if (annotationSummary.getTranscriptConsequenceSummary() != null && 
-                annotationSummary.getTranscriptConsequenceSummary().getIsVue() != null && 
+            if (annotationSummary.getTranscriptConsequenceSummary() != null &&
+                annotationSummary.getTranscriptConsequenceSummary().getIsVue() != null &&
                 annotationSummary.getTranscriptConsequenceSummary().getIsVue() == true) {
                 annotationSummary.setVues(this.vuesMap.get(annotationSummary.getTranscriptConsequenceSummary().getTranscriptId() + "-" + annotationSummary.getVariant()));
             }
@@ -285,6 +285,7 @@ public class VariantAnnotationSummaryServiceImpl implements VariantAnnotationSum
             summary.setRefSeq(this.refSeqResolver.resolve(transcriptConsequence));
             summary.setVariantClassification(this.variantClassificationResolver.resolve(annotation, transcriptConsequence));
             summary.setExon(this.exonResolver.resolve(transcriptConsequence));
+            summary.setAlphaMissense(transcriptConsequence.getAlphaMissense());
             summary.setPolyphenPrediction(transcriptConsequence.getPolyphenPrediction());
             summary.setPolyphenScore(transcriptConsequence.getPolyphenScore());
             summary.setSiftPrediction(transcriptConsequence.getSiftPrediction());

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/TranscriptConsequenceMixin.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/TranscriptConsequenceMixin.java
@@ -1,7 +1,6 @@
 package org.cbioportal.genome_nexus.service.mixin;
 
 import com.fasterxml.jackson.annotation.*;
-
 import java.util.List;
 import java.util.Map;
 


### PR DESCRIPTION
## Pull Request Description
This PR aims to update the `TranscriptConsequence` model to support `AlphaMissense` data and ensure that all related transcript consequence fields include `AlphaMissense` information. Specifically, this includes the following aspects:

### 1. Add `AlphaMissense`:
Include `AlphaMissense` in all relevant transcript consequence fields, including:
- `transcript_consequences`

### 2. Under `annotation_summary`:
- `transcriptConsequences`
- `transcriptConsequenceSummaries`
- `transcriptConsequenceSummary`

### Detailed Changes
[
<img width="319" alt="Screenshot 2024-07-17 at 12 09 27 PM" src="https://github.com/user-attachments/assets/1360760f-9789-4738-9e85-c6313ef0925b">
](url)

