### PR TITLE
Add intergenicConsequnceSummaries and variant classification in annotationSummary

### DIFF
--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/VariantClassificationResolver.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/VariantClassificationResolver.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 public class VariantClassificationResolver
@@ -45,6 +46,21 @@ public class VariantClassificationResolver
             variantClassification = this.resolveVariantClassification(
                 this.consequencePrioritizer.pickHighestPriorityConsequence(transcriptConsequence.getConsequenceTerms()),
                     variantType, isInframe);
+        }
+        // if variant has no transcript and has intergenicConsequences instead, try to resolve the variant classification from intergenicConsequences
+        else if (variantAnnotation != null && variantAnnotation.getIntergenicConsequences() != null && !variantAnnotation.getIntergenicConsequences().isEmpty()) {
+            // pick the highest priority consequence from the intergenic consequences
+            // get every getConsequenceTerms() from each intergenic consequence and put in a list
+            variantClassification = this.resolveVariantClassification(
+                this.consequencePrioritizer.pickHighestPriorityConsequence(
+                    variantAnnotation.getIntergenicConsequences()
+                    .stream()
+                    .flatMap(consequence -> consequence.getConsequenceTerms()
+                    .stream())
+                    .collect(Collectors.toList())),
+                    variantType,
+                    isInframe
+            );
         }
         // use the most severe consequence to resolve the variant classification
         else if (variantAnnotation != null)
@@ -186,9 +202,13 @@ public class VariantClassificationResolver
         variantMap.put("missense_variant",              "Missense_Mutation");
         variantMap.put("protein_altering_variant",      "Missense_Mutation"); // Not always correct, resolveVariantClassification handles the exceptions
         variantMap.put("coding_sequence_variant",       "Missense_Mutation"); // Not always correct, resolveVariantClassification handles the exceptions
+        variantMap.put("coding_transcript_variant",       "Missense_Mutation"); // Not always correct, resolveVariantClassification handles the exceptions
         variantMap.put("conservative_missense_variant", "Missense_Mutation");
         variantMap.put("rare_amino_acid_variant",       "Missense_Mutation");
         variantMap.put("transcript_amplification",      "Intron");
+        variantMap.put("feature_elongation",      "Feature_Elongation");
+        variantMap.put("feature_truncation",      "Feature_Elongation");
+        variantMap.put("sequence_variant",      "Sequence_Variant");
         variantMap.put("splice_region_variant",         "Splice_Region");
         variantMap.put("splice_donor_region_variant",         "Splice_Region");
         variantMap.put("splice_polypyrimidine_tract_variant",         "Splice_Region");
@@ -216,6 +236,7 @@ public class VariantClassificationResolver
         variantMap.put("regulatory_region_variant",     "IGR");
         variantMap.put("regulatory_region_amplification",     "IGR");
         variantMap.put("regulatory_region",             "IGR");
+        variantMap.put("regulatory_region_ablation",             "IGR");
         variantMap.put("intergenic_variant",            "IGR");
         variantMap.put("intergenic_region",             "IGR");
         variantMap.put("upstream_gene_variant",         "5'Flank");

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/IntergenicConsequenceSummary.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/IntergenicConsequenceSummary.java
@@ -1,0 +1,53 @@
+package org.cbioportal.genome_nexus.model;
+
+import java.util.List;
+
+public class IntergenicConsequenceSummary {
+    private String impact;
+
+    public String getImpact()
+    {
+        return impact;
+    }
+
+    public void setImpact(String impact)
+    {
+        this.impact = impact;
+    }
+
+    private String variantAllele;
+
+    public String getVariantAllele()
+    {
+        return variantAllele;
+    }
+
+    public void setVariantAllele(String variantAllele)
+    {
+        this.variantAllele = variantAllele;
+    }
+
+    private List<String> consequenceTerms;
+
+    public List<String> getConsequenceTerms()
+    {
+        return consequenceTerms;
+    }
+
+    public void setConsequenceTerms(List<String> consequenceTerms)
+    {
+        this.consequenceTerms = consequenceTerms;
+    }
+
+    private String variantClassification;
+
+    public String getVariantClassification()
+    {
+        return variantClassification;
+    }
+
+    public void setVariantClassification(String variantClassification)
+    {
+        this.variantClassification = variantClassification;
+    }
+}

--- a/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotationSummary.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/VariantAnnotationSummary.java
@@ -21,8 +21,8 @@ public class VariantAnnotationSummary
     // most impactful canonical annotation, when looking to pick a single
     // annotation
     private TranscriptConsequenceSummary transcriptConsequenceSummary;
-
     private Vues vues;
+    private List<IntergenicConsequenceSummary> intergenicConsequenceSummaries;
 
     private AlphaMissense alphaMissense;
 
@@ -112,5 +112,13 @@ public class VariantAnnotationSummary
 
     public void setVues(Vues vues) {
         this.vues = vues;
+    }
+
+    public List<IntergenicConsequenceSummary> getIntergenicConsequenceSummaries() {
+        return intergenicConsequenceSummaries;
+    }
+
+    public void setIntergenicConsequenceSummaries(List<IntergenicConsequenceSummary> intergenicConsequenceSummaries) {
+        this.intergenicConsequenceSummaries = intergenicConsequenceSummaries;
     }
 }


### PR DESCRIPTION
Fix:https://github.com/genome-nexus/genome-nexus/issues/725
**Background**: Intergenic_variant has no transcript so it returns empty in genome-nexus-annotation-pipeline annotation, and they are not supposed to be imported into cbioportal. 
The variant classification is resolved from transcript consequence terms. So when variants don't have transcripts, the variant classification is empty. And if variant classification is empty, the variant gets imported into cbioportal because we filter variants by variant classification == IGR / etc...
- [x] Intergenic_variant should be filtered out when importing into cbioportal, so we need to set 'IGR' variant classification for those variants.
    - [x] Add a dew field `intergenicConsequenceSummaries` in annotationSummary
    - [x] Add `variantClassification` in `intergenicConsequenceSummary`

- [x] Update transcript consequence list (https://useast.ensembl.org/info/genome/variation/prediction/predicted_data.html) and their variant classification

Example 1:g.69918522A>T:
Previous:
```
"annotation_summary": {
    "variant": "1:g.69918522A>T",
    "genomicLocation": {
      "chromosome": "1",
      "start": 69918522,
      "end": 69918522,
      "referenceAllele": "A",
      "variantAllele": "T"
    },
    "strandSign": "+",
    "variantType": "SNP",
    "assemblyName": "GRCh37",
    "transcriptConsequences": [],
    "transcriptConsequenceSummaries": []
  }
```
New
```
"annotation_summary": {
    "variant": "1:g.69918522A>T",
    "genomicLocation": {
      "chromosome": "1",
      "start": 69918522,
      "end": 69918522,
      "referenceAllele": "A",
      "variantAllele": "T"
    },
    "strandSign": "+",
    "variantType": "SNP",
    "assemblyName": "GRCh37",
    "transcriptConsequences": [],
    "transcriptConsequenceSummaries": [],
    "intergenicConsequenceSummaries": [
      {
        "impact": "MODIFIER",
        "variantAllele": "T",
        "consequenceTerms": [
          "intergenic_variant"
        ],
        "variantClassification": "IGR"
      }
    ]
  }
```

Discussion:
1. Do we want to use the same order of severity from Ensembl? (According Ensembl: This ordering is necessarily subjective and API and VEP users can always get the full set of consequences for each allele and make their own severity judgement. ) For example, in Genome nexus xx is higher than xx, but the Ensembl takes xx lower than xx

We will keep our original order as long as it's in the same impact group (high, moderate, low, modifier)

2. Does manually adding `consequenceTerms` and `variantClassification` make sense?  Because the variant doesn't have transcript, but the two fields are under transcriptConsequenceSummary. Should we directly fix this in genome nexus annotation pipeline instead?

We decide to add intergenic_consequences_summary inside annotation_summary

3. Variant classification (especially "Feature_mutation" and "Sequence_mutation") for missing transcript consequence terms

We decide to use the original terms for variant classification, in the future if we have a better name we can replace it