### PR TITLE
Fix AlphaMissense mixin

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/config/ExternalResourceObjectMapper.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/config/ExternalResourceObjectMapper.java
@@ -33,6 +33,7 @@ public class ExternalResourceObjectMapper extends ObjectMapper
         mixinMap.put(MutationAssessor.class, MutationAssessorMixin.class);
         mixinMap.put(NucleotideContext.class, NucleotideContextMixin.class);
         mixinMap.put(TranscriptConsequence.class, TranscriptConsequenceMixin.class);
+        mixinMap.put(AlphaMissense.class,AlphaMissenseMixin.class);
         mixinMap.put(VariantAnnotation.class, VariantAnnotationMixin.class);
         mixinMap.put(MyVariantInfo.class, MyVariantInfoMixin.class);
         mixinMap.put(Snpeff.class, SnpeffMixin.class);

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/AlphaMissenseMixin.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/AlphaMissenseMixin.java
@@ -1,0 +1,14 @@
+package org.cbioportal.genome_nexus.service.mixin;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AlphaMissenseMixin {
+
+    @JsonProperty(value = "am_class", required = true)
+    private String pathogenicity;
+
+    @JsonProperty(value = "am_pathogenicity", required = true)
+    private Double score;
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/TranscriptConsequenceMixin.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/mixin/TranscriptConsequenceMixin.java
@@ -1,6 +1,8 @@
 package org.cbioportal.genome_nexus.service.mixin;
 
 import com.fasterxml.jackson.annotation.*;
+import org.cbioportal.genome_nexus.model.AlphaMissense;
+
 import java.util.List;
 import java.util.Map;
 
@@ -69,6 +71,9 @@ public class TranscriptConsequenceMixin
 
     @JsonProperty(value="consequence_terms", required = true)
     private List<String> consequenceTerms;
+
+    @JsonProperty(value="alphamissense", required = true)
+    private AlphaMissense alphaMissense;
 
     @JsonIgnore
     private Map<String, Object> dynamicProps;


### PR DESCRIPTION
# Fix Issue with Initial Data Retrieval When Cache is Not Populated

## Description

This pull request fixes a bug where the first attempt to retrieve data fails if the data has not been cached previously. The issue was due to the system not handling cases where the cache was empty or uninitialized.

## Changes Made

- Implemented a check to handle scenarios where the cache is empty during the first data retrieval attempt.
- Modified the data retrieval logic to ensure that data is fetched correctly, even when the cache has not been populated.


## Issue Addressed

This fix ensures that the application can correctly retrieve data on the first attempt, even if the cache is empty or has not been populated yet.

