### PR TITLE
Fix missing CDKN2A canonical transcript

### DIFF
--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/internal/EnsemblRepositoryImpl.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/internal/EnsemblRepositoryImpl.java
@@ -171,9 +171,17 @@ public class EnsemblRepositoryImpl implements EnsemblRepositoryCustom
         List<EnsemblCanonical> transcripts = mongoTemplate.findAll(
             EnsemblCanonical.class, CANONICAL_TRANSCRIPTS_COLLECTION);
 
-        return transcripts
+        Set<String> canonicalTranscriptIds = transcripts
             .stream()
             .map(t -> t.getCanonicalTranscriptId(isoformOverrideSource))
             .collect(Collectors.toSet());
+
+        // CDKN2A is a special case where it has two canonical transcripts
+        // by default the first canonical transcript ENST00000304494 is returned
+        // if the isoform override source is mskcc then the second canonical transcript ENST00000361445 should be added as well
+        if ("mskcc".equalsIgnoreCase(isoformOverrideSource)) {
+            canonicalTranscriptIds.add("ENST00000361570");
+        }
+        return canonicalTranscriptIds;
     }
 }


### PR DESCRIPTION
We have two canonical transcript for `mskcc` isoform override - ENST00000428597 and ENST00000361570, but because ENST00000428597 is the first transcript and we only choose one transcript per gene, so we store this transcript in the database and missed the ENST00000361570. 
This PR add `ENST00000361570` when pulling `mskcc` isoform override canonical transcript id list, so the matching transcript will be selected as canonical.

Example: 9:g.21993799_21993800del
This variant has ENST00000428597 (CDKN2B-AS1) as canonical transcript previously, now it has ENST00000361570 (CDKN2A) as canonical transcript
