### PR TITLE
Prioritize oncokb gene on selecting canonical transcript

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/OncokbService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/OncokbService.java
@@ -1,6 +1,7 @@
 package org.cbioportal.genome_nexus.service;
 
 import java.util.List;
+import java.util.Set;
 
 import org.cbioportal.genome_nexus.model.Alteration;
 import org.oncokb.client.CancerGene;
@@ -14,4 +15,5 @@ public interface OncokbService
     IndicatorQueryResp getOncokb(Alteration alteration, String token)
         throws OncokbNotFoundException, OncokbWebServiceException;
     List<CancerGene>  getOncokbCancerGenesList();
+    Set<String> getOncokbGeneSymbolList();
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/BaseVariantAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/BaseVariantAnnotationServiceImpl.java
@@ -287,7 +287,7 @@ public abstract class BaseVariantAnnotationServiceImpl implements VariantAnnotat
         // always register an isoform override enricher
         // if the source is invalid we will use the default override source
         postEnrichmentService.registerEnricher(
-            new IsoformAnnotationEnricher(isoformOverrideSource, isoformOverrideSource, ensemblService)
+            new IsoformAnnotationEnricher(isoformOverrideSource, isoformOverrideSource, ensemblService, oncokbService)
         );
 
         if (fields == null || fields.isEmpty()) {

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/OncokbServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/OncokbServiceImpl.java
@@ -1,8 +1,10 @@
 package org.cbioportal.genome_nexus.service.internal;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -27,11 +29,15 @@ public class OncokbServiceImpl implements OncokbService {
 
     private final OncokbDataFetcher oncokbDataFetcher;
     private final OncokbCancerGenesListRepository oncokbCancerGenesListRepository;
+    private Set<String> oncokbGeneSymbolList = new HashSet();
 
     @Autowired
     public OncokbServiceImpl(OncokbDataFetcher oncokbDataFetcher, OncokbCancerGenesListRepository oncokbCancerGenesListRepository) {
         this.oncokbDataFetcher = oncokbDataFetcher;
         this.oncokbCancerGenesListRepository = oncokbCancerGenesListRepository;
+        LOG.info("Building OncoKB gene list");
+        this.oncokbGeneSymbolList = this.buildList();
+        LOG.info("Finished building OncoKB gene list");
     }
 
     public IndicatorQueryResp getOncokbByProteinChange(Alteration alteration, String token) throws OncokbNotFoundException, OncokbWebServiceException {
@@ -105,5 +111,20 @@ public class OncokbServiceImpl implements OncokbService {
 
     public List<CancerGene> getOncokbCancerGenesList() {
         return this.oncokbCancerGenesListRepository.getOncokbCancerGenesList();
+    }
+
+    private Set<String> buildList() {
+        List<CancerGene> cancerGenes = this.getOncokbCancerGenesList();
+        Set<String> geneSymbolList = new HashSet();
+        for (CancerGene cancerGene : cancerGenes) {
+            geneSymbolList.add(cancerGene.getHugoSymbol());
+        }
+        return geneSymbolList;
+    }
+
+    @Override
+    public Set<String> getOncokbGeneSymbolList()
+    {
+        return this.oncokbGeneSymbolList;
     }
 }

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/enricher/IsoformAnnotationEnricherTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/enricher/IsoformAnnotationEnricherTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import org.cbioportal.genome_nexus.model.TranscriptConsequence;
 import org.cbioportal.genome_nexus.model.VariantAnnotation;
 import org.cbioportal.genome_nexus.service.EnsemblService;
+import org.cbioportal.genome_nexus.service.OncokbService;
 import org.cbioportal.genome_nexus.service.mock.VariantAnnotationMockData;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,6 +26,7 @@ public class IsoformAnnotationEnricherTest
 {
     @Mock
     EnsemblService ensemblService;
+    OncokbService  oncokbService;
 
     private final VariantAnnotationMockData variantAnnotationMockData = new VariantAnnotationMockData();
 
@@ -34,7 +36,7 @@ public class IsoformAnnotationEnricherTest
         Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
 
         IsoformAnnotationEnricher enricher = new IsoformAnnotationEnricher(
-            "genome_nexus", "genome_nexus", this.ensemblService
+            "genome_nexus", "genome_nexus", this.ensemblService, null
         );
 
         // override canonical transcripts with no one matching transcript
@@ -69,7 +71,7 @@ public class IsoformAnnotationEnricherTest
         Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
 
         IsoformAnnotationEnricher enricher = new IsoformAnnotationEnricher(
-            "uniprot", "uniprot", this.ensemblService
+            "uniprot", "uniprot", this.ensemblService, null
         );
 
         // override canonical transcripts with just one matching transcript
@@ -105,7 +107,7 @@ public class IsoformAnnotationEnricherTest
         Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
 
         IsoformAnnotationEnricher enricher = new IsoformAnnotationEnricher(
-            "mskcc", "mskcc", this.ensemblService
+            "mskcc", "mskcc", this.ensemblService, this.oncokbService
         );
 
         // override canonical transcripts with just one matching transcript

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/enricher/IsoformAnnotationEnricherTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/enricher/IsoformAnnotationEnricherTest.java
@@ -26,6 +26,7 @@ public class IsoformAnnotationEnricherTest
 {
     @Mock
     EnsemblService ensemblService;
+    @Mock
     OncokbService  oncokbService;
 
     private final VariantAnnotationMockData variantAnnotationMockData = new VariantAnnotationMockData();
@@ -69,9 +70,9 @@ public class IsoformAnnotationEnricherTest
     public void enrichAnnotationWithSingleOverride() throws IOException
     {
         Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
-
+        this.mockOncokbServiceMethods();
         IsoformAnnotationEnricher enricher = new IsoformAnnotationEnricher(
-            "uniprot", "uniprot", this.ensemblService, null
+            "uniprot", "uniprot", this.ensemblService, this.oncokbService
         );
 
         // override canonical transcripts with just one matching transcript
@@ -105,7 +106,7 @@ public class IsoformAnnotationEnricherTest
     public void enrichAnnotationWithMultipleOverride() throws IOException
     {
         Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
-
+        this.mockOncokbServiceMethods();
         IsoformAnnotationEnricher enricher = new IsoformAnnotationEnricher(
             "mskcc", "mskcc", this.ensemblService, this.oncokbService
         );
@@ -147,5 +148,12 @@ public class IsoformAnnotationEnricherTest
             "ENST00000532924",
             canonicalTranscripts.get(2).getTranscriptId()
         );
+    }
+
+    private void mockOncokbServiceMethods()
+    {
+        Set<String> oncokbGeneSymbolList = new HashSet<>();
+        oncokbGeneSymbolList.add("TPRXL");
+        Mockito.when(this.oncokbService.getOncokbGeneSymbolList()).thenReturn(oncokbGeneSymbolList);
     }
 }

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantAnnotationMockData.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/mock/VariantAnnotationMockData.java
@@ -79,6 +79,7 @@ public class VariantAnnotationMockData implements MockData<VariantAnnotation>
             this.objectMapper.readVariantAnnotation("13_g.48954120_48954122delinsAAA.json"));
         mockData.put("10:g.8100129_8100132delinsAACT",
             this.objectMapper.readVariantAnnotation("10_g.8100129_8100132delinsAACT.json"));
+        mockData.put("11:g.118392020_118392034delinsTTAC", this.objectMapper.readVariantAnnotation("11_g.118392020_118392034delinsTTAC.json"));
         return mockData;
     }
 }

--- a/service/src/test/resources/variant/11_g.118392020_118392034delinsTTAC.json
+++ b/service/src/test/resources/variant/11_g.118392020_118392034delinsTTAC.json
@@ -1,0 +1,51 @@
+{
+    "variant": "11:g.118392020_118392034delinsTTAC",
+    "originalVariantQuery": "11:g.118392020_118392034delinsTTAC",
+    "hgvsg": "11:g.118392020_118392034delinsTTAC",
+    "id": "11:g.118392020_118392034delinsTTAC",
+    "assembly_name": "GRCh37",
+    "seq_region_name": "11",
+    "start": 118392020,
+    "end": 118392034,
+    "allele_string": "GGGGTCTTTTCTGTA/TTAC",
+    "strand": 1,
+    "most_severe_consequence": "splice_acceptor_variant",
+    "transcript_consequences": [
+      {
+        "exon": "35/36",
+        "transcript_id": "ENST00000534358",
+        "hgvsp": "ENSP00000436786.1:p.Arg3844LeufsTer6",
+        "hgvsc": "ENST00000534358.1:c.11531_11545delinsTTAC",
+        "variant_allele": "TTAC",
+        "codons": "cGGGGTCTTTTCTGTAag/cTTACag",
+        "protein_id": "ENSP00000436786",
+        "protein_start": 3844,
+        "protein_end": 3849,
+        "gene_symbol": "KMT2A",
+        "gene_id": "ENSG00000118058",
+        "amino_acids": "RGLFCK/LTX",
+        "hgnc_id": "7132",
+        "canonical": "1",
+        "refseq_transcript_ids": [
+          "NM_005933.3",
+          "NM_001197104.1"
+        ],
+        "consequence_terms": [
+          "frameshift_variant"
+        ]
+      },
+      {
+        "exon": "2/3",
+        "transcript_id": "ENST00000554407",
+        "hgvsc": "ENST00000554407.1:n.273-5_282delinsGTAA",
+        "variant_allele": "TTAC",
+        "gene_symbol": "RP11-770J1.3",
+        "gene_id": "ENSG00000255435",
+        "consequence_terms": [
+          "splice_acceptor_variant",
+          "non_coding_transcript_exon_variant",
+          "intron_variant"
+        ]
+      }
+    ]
+}


### PR DESCRIPTION
**Background**
When choosing canonical transcript, Genome Nexus finds all transcripts and select some of the transcripts to be "canonical transcript candidates". Usually, we choose transcript candidates by finding transcripts with `getCanonical() == 1` or transcripts id in the canonical transcript list. 

**Changes**
This pr prioritizes OncoKB genes when selecting transcript candidates:
- When there is only one `getCanonical() == 1` transcript, that means this is the only "canonical" transcript from Ensembl, we add this transcript to the candidate list, and don't look for other transcripts or override this transcript to other oncokb transcripts.
- When there are more than one `getCanonical() == 1` transcripts, that means there are multiple "canonical" like transcripts, so we prioritize Oncokb genes and only add Oncokb gene transcripts into candidate list.
- If it ends up with multiple canonical transcript candidates, we will choose by the most severe consequences.
