### PR TITLE
Make prioritizing cancer gene transcripts configurable

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/config/AppConfig.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/config/AppConfig.java
@@ -1,0 +1,15 @@
+package org.cbioportal.genome_nexus.service.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AppConfig {
+
+    @Value("${prioritize_oncokb_gene_transcripts:false}")
+    private String prioritizeOncokbGeneTranscripts;
+
+    public String getPrioritizeOncokbGeneTranscripts() {
+        return prioritizeOncokbGeneTranscripts;
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/config/AppConfig.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/config/AppConfig.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class AppConfig {
 
-    @Value("${prioritize_oncokb_gene_transcripts:false}")
+    @Value("${prioritize_cancer_gene_transcripts:true}")
     private String prioritizeOncokbGeneTranscripts;
 
     public String getPrioritizeOncokbGeneTranscripts() {

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/factory/IsoformAnnotationEnricherFactory.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/factory/IsoformAnnotationEnricherFactory.java
@@ -1,0 +1,34 @@
+package org.cbioportal.genome_nexus.service.factory;
+
+import org.cbioportal.genome_nexus.service.config.AppConfig;
+import org.cbioportal.genome_nexus.service.EnsemblService;
+import org.cbioportal.genome_nexus.service.OncokbService;
+import org.cbioportal.genome_nexus.service.enricher.IsoformAnnotationEnricher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IsoformAnnotationEnricherFactory {
+    private final EnsemblService ensemblService;
+    private final OncokbService oncokbService;
+    private final AppConfig properties;
+
+    public IsoformAnnotationEnricherFactory(
+        EnsemblService ensemblService,
+        OncokbService oncokbService,
+        AppConfig properties
+    ) {
+        this.ensemblService = ensemblService;
+        this.oncokbService = oncokbService;
+        this.properties = properties;
+    }
+
+    public IsoformAnnotationEnricher create(String isoformOverrideSource) {
+        return new IsoformAnnotationEnricher(
+            isoformOverrideSource,
+            isoformOverrideSource,
+            ensemblService,
+            oncokbService,
+            properties.getPrioritizeOncokbGeneTranscripts()
+        );
+    }
+}

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/BaseVariantAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/BaseVariantAnnotationServiceImpl.java
@@ -48,6 +48,7 @@ import org.cbioportal.genome_nexus.service.exception.ResourceMappingException;
 import org.cbioportal.genome_nexus.service.exception.VariantAnnotationNotFoundException;
 import org.cbioportal.genome_nexus.service.exception.VariantAnnotationWebServiceException;
 import org.springframework.beans.factory.annotation.Value;
+import org.cbioportal.genome_nexus.service.factory.IsoformAnnotationEnricherFactory;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.ResourceAccessException;
 
@@ -77,6 +78,7 @@ public abstract class BaseVariantAnnotationServiceImpl implements VariantAnnotat
     private final HugoGeneSymbolResolver hugoGeneSymbolResolver;
     @Value("${cache.enabled:true}")
     private boolean cacheEnabled;
+    private final IsoformAnnotationEnricherFactory enricherFactory;
 
     public BaseVariantAnnotationServiceImpl(
         BaseCachedExternalResourceFetcher<VariantAnnotation, VariantAnnotationRepository> resourceFetcher,
@@ -92,7 +94,8 @@ public abstract class BaseVariantAnnotationServiceImpl implements VariantAnnotat
         ClinvarVariantAnnotationService clinvarVariantAnnotationService,
         IndexRepository indexRepository,
         ProteinChangeResolver proteinChangeResolver,
-        HugoGeneSymbolResolver hugoGeneSymbolResolver
+        HugoGeneSymbolResolver hugoGeneSymbolResolver,
+        IsoformAnnotationEnricherFactory enricherFactory
     ) {
         this.resourceFetcher = resourceFetcher;
         this.ensemblService = ensemblService;
@@ -108,6 +111,7 @@ public abstract class BaseVariantAnnotationServiceImpl implements VariantAnnotat
         this.indexRepository = indexRepository;
         this.proteinChangeResolver = proteinChangeResolver;
         this.hugoGeneSymbolResolver = hugoGeneSymbolResolver;
+        this.enricherFactory = enricherFactory;
     }
 
     // Needs to be overridden to support normalizing variants
@@ -294,7 +298,7 @@ public abstract class BaseVariantAnnotationServiceImpl implements VariantAnnotat
         // always register an isoform override enricher
         // if the source is invalid we will use the default override source
         postEnrichmentService.registerEnricher(
-            new IsoformAnnotationEnricher(isoformOverrideSource, isoformOverrideSource, ensemblService, oncokbService)
+            enricherFactory.create(isoformOverrideSource)
         );
 
         if (fields == null || fields.isEmpty()) {

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/DbsnpVariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/DbsnpVariantAnnotationService.java
@@ -40,6 +40,7 @@ import org.cbioportal.genome_nexus.persistence.IndexRepository;
 import org.cbioportal.genome_nexus.service.*;
 
 import org.cbioportal.genome_nexus.service.cached.CachedVariantIdAnnotationFetcher;
+import org.cbioportal.genome_nexus.service.factory.IsoformAnnotationEnricherFactory;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.*;
@@ -66,7 +67,8 @@ public class DbsnpVariantAnnotationService extends BaseVariantAnnotationServiceI
         @Lazy ClinvarVariantAnnotationService clinvarVariantAnnotationService,
         IndexRepository indexRepository,
         ProteinChangeResolver proteinChangeResolver,
-        HugoGeneSymbolResolver hugoGeneSymbolResolver
+        HugoGeneSymbolResolver hugoGeneSymbolResolver,
+        IsoformAnnotationEnricherFactory isoformAnnotationEnricherFactory
     ) {
         super(
             cachedVariantIdAnnotationFetcher,
@@ -82,7 +84,8 @@ public class DbsnpVariantAnnotationService extends BaseVariantAnnotationServiceI
             clinvarVariantAnnotationService,
             indexRepository,
             proteinChangeResolver,
-            hugoGeneSymbolResolver
+            hugoGeneSymbolResolver,
+            isoformAnnotationEnricherFactory
         );
     }
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HgvsVariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/HgvsVariantAnnotationService.java
@@ -40,6 +40,7 @@ import org.cbioportal.genome_nexus.component.annotation.NotationConverter;
 import org.cbioportal.genome_nexus.component.annotation.ProteinChangeResolver;
 import org.cbioportal.genome_nexus.persistence.IndexRepository;
 import org.cbioportal.genome_nexus.service.cached.CachedVariantAnnotationFetcher;
+import org.cbioportal.genome_nexus.service.factory.IsoformAnnotationEnricherFactory;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.*;
@@ -68,7 +69,8 @@ public class HgvsVariantAnnotationService extends BaseVariantAnnotationServiceIm
         @Lazy ClinvarVariantAnnotationService clinvarVariantAnnotationService,
         IndexRepository indexRepository,
         ProteinChangeResolver proteinChangeResolver,
-        HugoGeneSymbolResolver hugoGeneSymbolResolver
+        HugoGeneSymbolResolver hugoGeneSymbolResolver,
+        IsoformAnnotationEnricherFactory isoformAnnotationEnricherFactory
     ) {
         super(
             cachedVariantAnnotationFetcher,
@@ -84,7 +86,8 @@ public class HgvsVariantAnnotationService extends BaseVariantAnnotationServiceIm
             clinvarVariantAnnotationService,
             indexRepository,
             proteinChangeResolver,
-            hugoGeneSymbolResolver
+            hugoGeneSymbolResolver,
+            isoformAnnotationEnricherFactory
         );
 
         this.notationConverter = notationConverter;

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/RegionVariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/RegionVariantAnnotationService.java
@@ -40,6 +40,7 @@ import org.cbioportal.genome_nexus.persistence.IndexRepository;
 import org.cbioportal.genome_nexus.service.*;
 
 import org.cbioportal.genome_nexus.service.cached.CachedVariantRegionAnnotationFetcher;
+import org.cbioportal.genome_nexus.service.factory.IsoformAnnotationEnricherFactory;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.*;
@@ -66,7 +67,8 @@ public class RegionVariantAnnotationService extends BaseVariantAnnotationService
         @Lazy ClinvarVariantAnnotationService clinvarVariantAnnotationService,
         IndexRepository indexRepository,
         ProteinChangeResolver proteinChangeResolver,
-        HugoGeneSymbolResolver hugoGeneSymbolResolver
+        HugoGeneSymbolResolver hugoGeneSymbolResolver,
+        IsoformAnnotationEnricherFactory isoformAnnotationEnricherFactory
     ) {
         super(
             cachedVariantRegionAnnotationFetcher,
@@ -82,7 +84,8 @@ public class RegionVariantAnnotationService extends BaseVariantAnnotationService
             clinvarVariantAnnotationService,
             indexRepository,
             proteinChangeResolver,
-            hugoGeneSymbolResolver
+            hugoGeneSymbolResolver,
+            isoformAnnotationEnricherFactory
         );
     }
 }

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/enricher/IsoformAnnotationEnricherTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/enricher/IsoformAnnotationEnricherTest.java
@@ -37,7 +37,7 @@ public class IsoformAnnotationEnricherTest
         Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
 
         IsoformAnnotationEnricher enricher = new IsoformAnnotationEnricher(
-            "genome_nexus", "genome_nexus", this.ensemblService, null
+            "genome_nexus", "genome_nexus", this.ensemblService, null, "yes"
         );
 
         // override canonical transcripts with no one matching transcript
@@ -72,7 +72,7 @@ public class IsoformAnnotationEnricherTest
         Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
         this.mockOncokbServiceMethods();
         IsoformAnnotationEnricher enricher = new IsoformAnnotationEnricher(
-            "uniprot", "uniprot", this.ensemblService, this.oncokbService
+            "uniprot", "uniprot", this.ensemblService, this.oncokbService, "true"
         );
 
         // override canonical transcripts with just one matching transcript
@@ -108,7 +108,7 @@ public class IsoformAnnotationEnricherTest
         Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
         this.mockOncokbServiceMethods();
         IsoformAnnotationEnricher enricher = new IsoformAnnotationEnricher(
-            "mskcc", "mskcc", this.ensemblService, this.oncokbService
+            "mskcc", "mskcc", this.ensemblService, this.oncokbService, "true"
         );
 
         // override canonical transcripts with just one matching transcript

--- a/service/src/test/java/org/cbioportal/genome_nexus/service/enricher/IsoformAnnotationEnricherTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/service/enricher/IsoformAnnotationEnricherTest.java
@@ -37,7 +37,7 @@ public class IsoformAnnotationEnricherTest
         Map<String, VariantAnnotation> variantMockData = this.variantAnnotationMockData.generateData();
 
         IsoformAnnotationEnricher enricher = new IsoformAnnotationEnricher(
-            "genome_nexus", "genome_nexus", this.ensemblService, null, "yes"
+            "genome_nexus", "genome_nexus", this.ensemblService, null, "true"
         );
 
         // override canonical transcripts with no one matching transcript

--- a/web/src/main/resources/application.properties.EXAMPLE
+++ b/web/src/main/resources/application.properties.EXAMPLE
@@ -72,6 +72,10 @@ revue.url=https://raw.githubusercontent.com/knowledgesystems/reVUE-data/refs/hea
 # If overwrite_by_confirmed_revue_only=false, overwrite variant annotation by both confirmed and unconfirmed VUE ("confirmed=true" and "confirmed=false")
 overwrite_by_confirmed_revue_only=true
 
+
+# prioritize cancer gene transcripts (oncokb gene transcripts) when selecting canonical transcript
+prioritize_cancer_gene_transcripts=true
+
 # cache.enabled - Enables or disables caching for annotation sources such as vep.annotation, index, my_variant_info.annotation.
 # Default: true
 # When set to false, queries bypass the cache and make direct calls to the web service, not saving any data to the database.


### PR DESCRIPTION
Genome Nexus prioritizes cancer gene transcripts (oncokb transcripts) when picking canonical transcript, if people prefer to not include this prioritizer, it can be disabled in the application.properties