### PR TITLE
Fix search box when there are duplicated records

### DIFF
--- a/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/IndexRepository.java
+++ b/persistence/src/main/java/org/cbioportal/genome_nexus/persistence/IndexRepository.java
@@ -6,7 +6,7 @@ import org.cbioportal.genome_nexus.model.Index;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface IndexRepository extends MongoRepository<Index, String>, GenericMongoRepository {
-    Index findByVariant(String Variant);
+    Index findFirstByVariant(String Variant);
     List<Index> findByHugoSymbolAndHgvspShort(String hugoSymbol, String hgvspShort);
     List<Index> findByHugoSymbolAndHgvsp(String hugoSymbol, String hgvsp);
     List<Index> findByHugoSymbolAndCdna(String hugoSymbol, String cdna);

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/IndexSearchServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/IndexSearchServiceImpl.java
@@ -3,6 +3,7 @@ package org.cbioportal.genome_nexus.service.internal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.cbioportal.genome_nexus.model.Index;
@@ -77,7 +78,7 @@ public class IndexSearchServiceImpl implements IndexSearchService{
     private List<IndexSearch> searchByVariant(
         String queryString
     ) {
-        Index index = this.indexRepository.findByVariant(queryString);
+        Index index = this.indexRepository.findFirstByVariant(queryString);
         IndexSearch query = new IndexSearch();
         query.setQueryType(IndexSearchType.HGVSG);
         query.setResults(Arrays.asList(index));


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/776
There are duplicated records in database, e.g. `7:g.140453136A>T` and `chr7:g.140453136A>T`, they have identical normalized variant id `7:g.140453136A>T`. Only one record should be returned, so in this pr the return is changed to find by the first match.