### PR TITLE
Add Cancer Hotspots v3 support with opt-in API parameter

### DIFF
--- a/model/src/main/java/org/cbioportal/genome_nexus/model/Hotspot.java
+++ b/model/src/main/java/org/cbioportal/genome_nexus/model/Hotspot.java
@@ -76,6 +76,10 @@ public class Hotspot
     @Field(value="splice_count")
     private Integer spliceCount;
 
+    @Indexed
+    @Field(value="version")
+    private String version;
+
     public String getHugoSymbol() {
         return hugoSymbol;
     }
@@ -162,6 +166,14 @@ public class Hotspot
 
     public void setSpliceCount(Integer spliceCount) {
         this.spliceCount = spliceCount;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
     }
 
     @Override

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/CancerHotspotService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/CancerHotspotService.java
@@ -55,4 +55,15 @@ public interface CancerHotspotService
     List<Hotspot> getHotspotAnnotationsByGenomicLocation(String genomicLocation)
         throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException, CancerHotspotsWebServiceException;
     List<AggregatedHotspots> getHotspotAnnotationsByProteinLocations(List<ProteinLocation> proteinLocations) throws CancerHotspotsWebServiceException;
+
+    // v3-aware overloads: when includeV3 is true, v3 hotspots are included in results
+    List<Hotspot> getHotspots(String transcriptId, boolean includeV3) throws CancerHotspotsWebServiceException;
+    List<AggregatedHotspots> getHotspotsByTranscriptIds(List<String> transcriptIds, boolean includeV3) throws CancerHotspotsWebServiceException;
+    List<Hotspot> getHotspotAnnotationsByVariant(String variant, boolean includeV3)
+        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException, CancerHotspotsWebServiceException;
+    List<AggregatedHotspots> getHotspotAnnotationsByVariants(List<String> variants, boolean includeV3) throws CancerHotspotsWebServiceException;
+    List<Hotspot> getHotspotAnnotationsByGenomicLocation(String genomicLocation, boolean includeV3)
+        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException, CancerHotspotsWebServiceException;
+    List<AggregatedHotspots> getHotspotAnnotationsByGenomicLocations(List<GenomicLocation> genomicLocations, boolean includeV3) throws CancerHotspotsWebServiceException;
+    List<AggregatedHotspots> getHotspotAnnotationsByProteinLocations(List<ProteinLocation> proteinLocations, boolean includeV3) throws CancerHotspotsWebServiceException;
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/CancerHotspotServiceImpl.java
@@ -71,10 +71,25 @@ public class CancerHotspotServiceImpl implements CancerHotspotService
         this.notationConverter = notationConverter;
     }
 
+    private List<Hotspot> filterByVersion(List<Hotspot> hotspots, boolean includeV3) {
+        if (includeV3) {
+            return hotspots;
+        }
+        return hotspots.stream()
+            .filter(h -> !"v3".equals(h.getVersion()))
+            .collect(Collectors.toList());
+    }
+
     @Override
     public List<Hotspot> getHotspots(String transcriptId) throws CancerHotspotsWebServiceException
     {
-        return this.hotspotRepository.findByTranscriptId(transcriptId);
+        return this.getHotspots(transcriptId, false);
+    }
+
+    @Override
+    public List<Hotspot> getHotspots(String transcriptId, boolean includeV3) throws CancerHotspotsWebServiceException
+    {
+        return this.filterByVersion(this.hotspotRepository.findByTranscriptId(transcriptId), includeV3);
     }
 
     @Override
@@ -212,6 +227,58 @@ public class CancerHotspotServiceImpl implements CancerHotspotService
     public List<AggregatedHotspots> getHotspotAnnotationsByProteinLocations(List<ProteinLocation> proteinLocations)
         throws CancerHotspotsWebServiceException
     {
+        return this.getHotspotAnnotationsByProteinLocations(proteinLocations, false);
+    }
+
+    // --- v3-aware overloads ---
+
+    private List<AggregatedHotspots> filterAggregatedByVersion(List<AggregatedHotspots> aggregated, boolean includeV3) {
+        if (includeV3) {
+            return aggregated;
+        }
+        for (AggregatedHotspots agg : aggregated) {
+            agg.setHotspots(this.filterByVersion(agg.getHotspots(), includeV3));
+        }
+        return aggregated;
+    }
+
+    @Override
+    public List<AggregatedHotspots> getHotspotsByTranscriptIds(List<String> transcriptIds, boolean includeV3) throws CancerHotspotsWebServiceException
+    {
+        return this.filterAggregatedByVersion(this.getHotspotsByTranscriptIds(transcriptIds), includeV3);
+    }
+
+    @Override
+    public List<Hotspot> getHotspotAnnotationsByVariant(String variant, boolean includeV3)
+        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException,
+        CancerHotspotsWebServiceException
+    {
+        return this.filterByVersion(this.getHotspotAnnotationsByVariant(variant), includeV3);
+    }
+
+    @Override
+    public List<AggregatedHotspots> getHotspotAnnotationsByVariants(List<String> variants, boolean includeV3) throws CancerHotspotsWebServiceException
+    {
+        return this.filterAggregatedByVersion(this.getHotspotAnnotationsByVariants(variants), includeV3);
+    }
+
+    @Override
+    public List<Hotspot> getHotspotAnnotationsByGenomicLocation(String genomicLocation, boolean includeV3)
+        throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException,
+        CancerHotspotsWebServiceException
+    {
+        return this.filterByVersion(this.getHotspotAnnotationsByGenomicLocation(genomicLocation), includeV3);
+    }
+
+    @Override
+    public List<AggregatedHotspots> getHotspotAnnotationsByGenomicLocations(List<GenomicLocation> genomicLocations, boolean includeV3) throws CancerHotspotsWebServiceException
+    {
+        return this.filterAggregatedByVersion(this.getHotspotAnnotationsByGenomicLocations(genomicLocations), includeV3);
+    }
+
+    @Override
+    public List<AggregatedHotspots> getHotspotAnnotationsByProteinLocations(List<ProteinLocation> proteinLocations, boolean includeV3) throws CancerHotspotsWebServiceException
+    {
         List<AggregatedHotspots> hotspots = new ArrayList<>();
         for (ProteinLocation proteinLocation : proteinLocations)
         {
@@ -221,7 +288,7 @@ public class CancerHotspotServiceImpl implements CancerHotspotService
             aggregatedHotspots.setProteinLocation(proteinLocation);
 
             // query hotspots service by protein location
-            aggregatedHotspots.setHotspots(hotspotFilter.proteinLocationHotspotsFilter(this.getHotspots(proteinLocation.getTranscriptId()), proteinLocation));
+            aggregatedHotspots.setHotspots(hotspotFilter.proteinLocationHotspotsFilter(this.getHotspots(proteinLocation.getTranscriptId(), includeV3), proteinLocation));
             hotspots.add(aggregatedHotspots);
         }
 

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/CancerHotspotsController.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/CancerHotspotsController.java
@@ -24,6 +24,9 @@ import java.util.List;
 @Api(tags = "cancer-hotspots-controller", description = "Cancer Hotspots Controller")
 public class CancerHotspotsController
 {
+    private static final String INCLUDE_V3_DESC =
+        "When true, include Cancer Hotspots v3 hotspots in the response. Default: false (v2 only, backwards compatible).";
+
     private final CancerHotspotService hotspotService;
 
     @Autowired
@@ -41,11 +44,13 @@ public class CancerHotspotsController
         @ApiParam(value="A variant. For example 7:g.140453136A>T",
             required = true,
             allowMultiple = true)
-        @PathVariable String variant)
+        @PathVariable String variant,
+        @ApiParam(value = INCLUDE_V3_DESC)
+        @RequestParam(required = false, defaultValue = "false") boolean includeV3)
         throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException,
         CancerHotspotsWebServiceException
     {
-        return this.hotspotService.getHotspotAnnotationsByVariant(variant);
+        return this.hotspotService.getHotspotAnnotationsByVariant(variant, includeV3);
     }
 
     @ApiOperation(value = "Retrieves hotspot annotations for the provided list of variants",
@@ -57,9 +62,11 @@ public class CancerHotspotsController
         @ApiParam(value="List of variants. For example [\"7:g.140453136A>T\",\"12:g.25398285C>A\"]",
             required = true,
             allowMultiple = true)
-        @RequestBody List<String> variants) throws CancerHotspotsWebServiceException
+        @RequestBody List<String> variants,
+        @ApiParam(value = INCLUDE_V3_DESC)
+        @RequestParam(required = false, defaultValue = "false") boolean includeV3) throws CancerHotspotsWebServiceException
     {
-        return this.hotspotService.getHotspotAnnotationsByVariants(variants);
+        return this.hotspotService.getHotspotAnnotationsByVariants(variants, includeV3);
     }
 
     @ApiOperation(value = "Retrieves hotspot annotations for a specific genomic location",
@@ -71,11 +78,13 @@ public class CancerHotspotsController
         @ApiParam(value="A genomic location. For example 7,140453136,140453136,A,T",
             required = true,
             allowMultiple = true)
-        @PathVariable String genomicLocation)
+        @PathVariable String genomicLocation,
+        @ApiParam(value = INCLUDE_V3_DESC)
+        @RequestParam(required = false, defaultValue = "false") boolean includeV3)
         throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException,
         CancerHotspotsWebServiceException
     {
-        return this.hotspotService.getHotspotAnnotationsByGenomicLocation(genomicLocation);
+        return this.hotspotService.getHotspotAnnotationsByGenomicLocation(genomicLocation, includeV3);
     }
 
     @ApiOperation(value = "Retrieves hotspot annotations for the provided list of genomic locations",
@@ -87,9 +96,11 @@ public class CancerHotspotsController
         @ApiParam(value="List of genomic locations.",
             required = true,
             allowMultiple = true)
-        @RequestBody List<GenomicLocation> genomicLocations) throws CancerHotspotsWebServiceException
+        @RequestBody List<GenomicLocation> genomicLocations,
+        @ApiParam(value = INCLUDE_V3_DESC)
+        @RequestParam(required = false, defaultValue = "false") boolean includeV3) throws CancerHotspotsWebServiceException
     {
-        return this.hotspotService.getHotspotAnnotationsByGenomicLocations(genomicLocations);
+        return this.hotspotService.getHotspotAnnotationsByGenomicLocations(genomicLocations, includeV3);
     }
 
     @ApiOperation(value = "Retrieves hotspot annotations for the provided transcript ID",
@@ -101,11 +112,13 @@ public class CancerHotspotsController
         @ApiParam(value="A Transcript Id. For example ENST00000288602",
             required = true,
             allowMultiple = true)
-        @PathVariable String transcriptId)
+        @PathVariable String transcriptId,
+        @ApiParam(value = INCLUDE_V3_DESC)
+        @RequestParam(required = false, defaultValue = "false") boolean includeV3)
         throws VariantAnnotationNotFoundException, VariantAnnotationWebServiceException,
         CancerHotspotsWebServiceException
     {
-        return this.hotspotService.getHotspots(transcriptId);
+        return this.hotspotService.getHotspots(transcriptId, includeV3);
     }
 
     @ApiOperation(value = "Retrieves hotspot annotations for the provided list of transcript ID",
@@ -117,10 +130,12 @@ public class CancerHotspotsController
         @ApiParam(value="List of transcript Id. For example [\"ENST00000288602\",\"ENST00000256078\"]",
             required = true,
             allowMultiple = true)
-        @RequestBody List<String> transcriptIds)
+        @RequestBody List<String> transcriptIds,
+        @ApiParam(value = INCLUDE_V3_DESC)
+        @RequestParam(required = false, defaultValue = "false") boolean includeV3)
         throws CancerHotspotsWebServiceException
     {
-        return this.hotspotService.getHotspotsByTranscriptIds(transcriptIds);
+        return this.hotspotService.getHotspotsByTranscriptIds(transcriptIds, includeV3);
     }
 
     @ApiOperation(value = "Retrieves hotspot annotations for the provided list of transcript id, protein location and mutation type",
@@ -129,11 +144,13 @@ public class CancerHotspotsController
         method = RequestMethod.POST,
         produces = "application/json")
     public List<AggregatedHotspots> fetchHotspotAnnotationByProteinLocationsPOST(
-        @ApiParam(value="List of transcript id, protein start location, protein end location, mutation type. The mutation types are limited to 'Missense_Mutation', 'In_Frame_Ins', 'In_Frame_Del', 'Splice_Site', and 'Splice_Region'",
+        @ApiParam(value="List of transcript id, protein start location, protein end location, mutation type. The mutation types are limited to 'Missense_Mutation', 'In_Frame_Ins', 'In_Frame_Del', 'Splice_Site', and 'Splice_Region'",
             required = true,
             allowMultiple = true)
-        @RequestBody List<ProteinLocation> proteinLocations) throws CancerHotspotsWebServiceException
+        @RequestBody List<ProteinLocation> proteinLocations,
+        @ApiParam(value = INCLUDE_V3_DESC)
+        @RequestParam(required = false, defaultValue = "false") boolean includeV3) throws CancerHotspotsWebServiceException
     {
-        return this.hotspotService.getHotspotAnnotationsByProteinLocations(proteinLocations);
+        return this.hotspotService.getHotspotAnnotationsByProteinLocations(proteinLocations, includeV3);
     }
 }

--- a/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/HotspotMixin.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/mixin/HotspotMixin.java
@@ -39,4 +39,7 @@ public class HotspotMixin
 
     @ApiModelProperty(value="Splice mutation count")
     private Integer spliceCount;
+
+    @ApiModelProperty(value = "Cancer Hotspots data version: 'v2' (legacy) or 'v3'")
+    private String version;
 }

--- a/web/src/test/java/org/cbioportal/genome_nexus/web/CancerHotspotsIntegrationTest.java
+++ b/web/src/test/java/org/cbioportal/genome_nexus/web/CancerHotspotsIntegrationTest.java
@@ -385,6 +385,55 @@ public class CancerHotspotsIntegrationTest
     }
 
     @Test
+    public void testV3HotspotOptIn()
+    {
+        // V3_TEST_GENE has two hotspots in the test DB: R100 (v2) and R200 (v3).
+        // The default endpoint (no includeV3) must only return the v2 hotspot.
+        // Passing includeV3=true must return both.
+        String transcriptId = "ENST99999999901";
+        String baseTranscriptUrl = "http://localhost:38888/cancer_hotspots/transcript/" + transcriptId;
+
+        // default — v3 excluded
+        Hotspot[] defaultHotspots = this.restTemplate.getForObject(baseTranscriptUrl, Hotspot[].class);
+        assertEquals("default endpoint should exclude v3 hotspots", 1, defaultHotspots.length);
+        assertEquals("R100", defaultHotspots[0].getResidue());
+        assertEquals("v2", defaultHotspots[0].getVersion());
+
+        // explicit includeV3=false — same as default
+        Hotspot[] excludedHotspots = this.restTemplate.getForObject(
+            baseTranscriptUrl + "?includeV3=false", Hotspot[].class);
+        assertEquals(1, excludedHotspots.length);
+        assertEquals("R100", excludedHotspots[0].getResidue());
+
+        // includeV3=true — both returned
+        Hotspot[] includedHotspots = this.restTemplate.getForObject(
+            baseTranscriptUrl + "?includeV3=true", Hotspot[].class);
+        assertEquals("includeV3=true should return v2 and v3 hotspots", 2, includedHotspots.length);
+
+        // verify version field is populated for both
+        List<String> versions = Arrays.stream(includedHotspots).map(Hotspot::getVersion).sorted().collect(Collectors.toList());
+        assertEquals(Arrays.asList("v2", "v3"), versions);
+
+        // POST /transcript — same opt-in semantics
+        AggregatedHotspots[] defaultPost = this.restTemplate.postForObject(
+            "http://localhost:38888/cancer_hotspots/transcript",
+            Arrays.asList(transcriptId), AggregatedHotspots[].class);
+        assertEquals(1, defaultPost.length);
+        assertEquals("POST default should exclude v3", 1, defaultPost[0].getHotspots().size());
+
+        AggregatedHotspots[] includedPost = this.restTemplate.postForObject(
+            "http://localhost:38888/cancer_hotspots/transcript?includeV3=true",
+            Arrays.asList(transcriptId), AggregatedHotspots[].class);
+        assertEquals(1, includedPost.length);
+        assertEquals("POST includeV3=true should include v3", 2, includedPost[0].getHotspots().size());
+
+        // legacy hotspots without a version field (stored as null) must still pass the default filter —
+        // backwards compatibility with pre-v3 data. Verified implicitly: testTranscriptIdHotspots
+        // loads BRAF/ENST00000288602 hotspots that have no version field and they still return under
+        // the default endpoint.
+    }
+
+    @Test
     public void testIdenticalVariantsInDifferentRepresentations()
     {
         String[] genomicLocationString = {

--- a/web/src/test/resources/hotspot/hotspots_integration_test.json
+++ b/web/src/test/resources/hotspot/hotspots_integration_test.json
@@ -163,5 +163,29 @@
         "truncating_count": 1,
         "inframe_count": 0,
         "splice_count": 0
+    },
+    {
+        "hugo_symbol": "V3_TEST_GENE",
+        "transcript_id": "ENST99999999901",
+        "residue": "R100",
+        "tumor_count": 10,
+        "type": "single residue",
+        "missense_count": 10,
+        "truncating_count": 0,
+        "inframe_count": 0,
+        "splice_count": 0,
+        "version": "v2"
+    },
+    {
+        "hugo_symbol": "V3_TEST_GENE",
+        "transcript_id": "ENST99999999901",
+        "residue": "R200",
+        "tumor_count": 5,
+        "type": "single residue",
+        "missense_count": 5,
+        "truncating_count": 0,
+        "inframe_count": 0,
+        "splice_count": 0,
+        "version": "v3"
     }
 ]


### PR DESCRIPTION
## Summary

Adds support for Cancer Hotspots v3 data as an **opt-in** feature. Existing API consumers see no change unless they pass \`includeV3=true\`. Companion PR: genome-nexus/genome-nexus-importer#124 (adds the \`version\` column to imported hotspot data).

### What changed

- **\`model/Hotspot.java\`** — new \`@Indexed @Field(\"version\")\` string field.
- **\`web/mixin/HotspotMixin.java\`** — exposes \`version\` in JSON with Swagger docs.
- **\`service/CancerHotspotService.java\`** and **\`service/internal/CancerHotspotServiceImpl.java\`** — v3-aware overloads for all seven hotspot methods. Filtering lives in a single \`filterByVersion\` helper in the service impl. No-arg overloads are preserved and delegate to the \`includeV3=false\` path so no existing caller needs to change.
- **\`web/CancerHotspotsController.java\`** — all seven endpoints accept an optional \`?includeV3=true|false\` query parameter (default \`false\`).

### API surface

All existing endpoints are unchanged on the happy path; the new parameter is additive:

| Method | Path | New parameter |
|---|---|---|
| GET | \`/cancer_hotspots/hgvs/{variant}\` | \`?includeV3\` |
| POST | \`/cancer_hotspots/hgvs\` | \`?includeV3\` |
| GET | \`/cancer_hotspots/genomic/{genomicLocation}\` | \`?includeV3\` |
| POST | \`/cancer_hotspots/genomic\` | \`?includeV3\` |
| GET | \`/cancer_hotspots/transcript/{transcriptId}\` | \`?includeV3\` |
| POST | \`/cancer_hotspots/transcript\` | \`?includeV3\` |
| POST | \`/cancer_hotspots/proteinLocations\` | \`?includeV3\` |

### Backwards compatibility

- Default behavior (no \`includeV3\`) filters out records where \`version == \"v3\"\`. v2 records and records with a **null** \`version\` (legacy pre-v3 data) pass the filter unchanged.
- \`HotspotAnnotationEnricher\` (used in the standard variant annotation pipeline) calls \`hotspotService.getHotspots(transcript, annotation)\`, which cascades through the default path and sees v2-only data.
- \`Hotspot.equals/hashCode\` is intentionally keyed on \`hugoSymbol + residue + type + tumorCount\` and does **not** include \`version\`. If a v3 record ever collides with a v2 record on those four fields, \`Set<Hotspot>\` dedup would merge them — only matters on the \`includeV3=true\` path.

### Deploy ordering

**This PR first, importer second.** The genome-nexus-importer PR reimports the \`hotspot.mutation\` collection with 6910 v2 + 164 v3 records. If the importer runs while the old API is still live, callers would start seeing v3 records by default — breaking the contract. Once this PR is deployed, the API tolerates both the old (no-\`version\`) and new (with-\`version\`) Mongo schemas.

### Testing

Added \`testV3HotspotOptIn\` to \`CancerHotspotsIntegrationTest\`:

- Seeds two test hotspots on a dedicated transcript \`ENST99999999901\` — \`R100\` (\`version=v2\`) and \`R200\` (\`version=v3\`).
- Verifies \`GET /cancer_hotspots/transcript/{id}\` returns only R100 by default and with \`?includeV3=false\`.
- Verifies \`?includeV3=true\` returns both, with the \`version\` field populated on each.
- Verifies the same semantics on \`POST /cancer_hotspots/transcript\`.
- Backwards compatibility for null-version legacy data is covered implicitly by the existing tests (\`testTranscriptIdHotspots\` etc. use fixture records with no \`version\` field and still pass under the default endpoint).

> ⚠️ **Not locally compiled.** The development environment for this branch did not have Java/Maven available. CI compile + test is the verification gate; please do not mark ready-for-review until CI is green.

## Test plan

- [ ] CI compiles cleanly
- [ ] \`CancerHotspotsIntegrationTest\` passes, including the new \`testV3HotspotOptIn\`
- [ ] Manual smoke test against a Mongo populated by genome-nexus/genome-nexus-importer#124:
  - [ ] \`GET /cancer_hotspots/transcript/ENST00000288602\` returns the same records as today
  - [ ] \`GET /cancer_hotspots/transcript/ENST00000288602?includeV3=true\` returns the same or more records, all with \`version\` populated
  - [ ] Variant annotation (\`/annotation\` with \`fields=hotspots\`) still returns v2-only hotspots on the enricher path

🤖 Generated with [Claude Code](https://claude.com/claude-code)