### PR TITLE
Fix the allele order for reversed strand

### DIFF
--- a/component/src/main/java/org/cbioportal/genome_nexus/util/GenomicLocationUtil.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/util/GenomicLocationUtil.java
@@ -45,6 +45,6 @@ public class GenomicLocationUtil {
                 sb.append(nucleotide);
             } 
         }
-        return sb.toString();
+        return sb.reverse().toString();
     }
 }

--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationService.java
@@ -439,7 +439,18 @@ public class VariantAnnotationService
 
     private void normalizeStrand(VariantAnnotation variantAnnotation) {
         if (variantAnnotation.getStrand() != null && variantAnnotation.getStrand() == -1) {
-            variantAnnotation.setAlleleString(GenomicLocationUtil.getReverseStrandAllele(variantAnnotation.getAlleleString()));
+            String alleleString = variantAnnotation.getAlleleString();
+            if (alleleString != null) {
+                String[] parts = alleleString.split("/");
+                StringBuilder result = new StringBuilder();
+                for (int i = 0; i < parts.length; i++) {
+                    if (i > 0) {
+                        result.append("/");
+                    }
+                    result.append(GenomicLocationUtil.getReverseStrandAllele(parts[i]));
+                }
+                variantAnnotation.setAlleleString(result.toString());
+            }
         }
     }
 


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/847
To implement a proper reverse complement: first complement each nucleotide (A <-> T, C <-> G, already fixed in https://github.com/genome-nexus/genome-nexus/pull/806), then reverse the order. For example:

 - AG - complement to TC - reverse to CT
 - ATG - complement to TAC - reverse to CAT
