### PR TITLE
Fix missing id in error object from VEP

### DIFF
--- a/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/genome_nexus/service/internal/VariantAnnotationService.java
@@ -279,9 +279,14 @@ public class VariantAnnotationService
             }
             for (VariantAnnotation variantAnnotation : variantAnnotations) {
                 // add new annotation to index 
+                // For successful VEP responses, match by variantId ("id" field).
+                // For VEP error objects, "id" is absent so variantId is null; fall back to
+                // variant ("input" field) which VEP echoes back as the normalized HGVS string.
                 Optional<String[]> normalizedToOriginal = normalizedVariantToOriginalVariant
                     .stream()
-                    .filter((normToOrig) -> normToOrig[0].equals(variantAnnotation.getVariantId()))
+                    .filter((normToOrig) -> normToOrig[0].equals(variantAnnotation.getVariantId())
+                        || (variantAnnotation.getVariantId() == null
+                            && normToOrig[0].equals(variantAnnotation.getVariant())))
                     .findFirst();
                 if (normalizedToOriginal.isPresent()) {
                     variantAnnotation.setVariant(normalizedToOriginal.get()[0]);


### PR DESCRIPTION
Extended the lookup filter in fetchAnnotationsExternally to also match on getVariant() when getVariantId() is null.
The error annotation was correctly deserialized but originalVariantQuery was never set, because the lookup at line 284 filtered by variantAnnotation.getVariantId() which is always null for VEP error objects. Without originalVariantQuery, genome-nexus can't include the error in the correct position in the batch response, and the annotation pipeline (genome-nexus-annotation-pipeline) can't match the failed variant back to the input record — so it silently falls through to a bare unannotated record instead of being correctly marked ANNOTATION_STATUS="FAILED" with the actual VEP error message.