### PR TITLE
Fix protein position resolver on intergenic and splice region mutations

### DIFF
--- a/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/ProteinPositionResolver.java
+++ b/component/src/main/java/org/cbioportal/genome_nexus/component/annotation/ProteinPositionResolver.java
@@ -1,5 +1,7 @@
 package org.cbioportal.genome_nexus.component.annotation;
 
+import java.util.List;
+
 import org.cbioportal.genome_nexus.model.IntegerRange;
 import org.cbioportal.genome_nexus.model.TranscriptConsequence;
 import org.cbioportal.genome_nexus.model.VariantAnnotation;
@@ -7,8 +9,6 @@ import org.cbioportal.genome_nexus.util.Numerical;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 public class ProteinPositionResolver
@@ -36,6 +36,15 @@ public class ProteinPositionResolver
         // special case for splice
         if (proteinChange != null &&
             proteinChange.toLowerCase().contains("x"))
+        {
+            proteinPos = this.extractProteinPos(proteinChange);
+        }
+        // special case for splice region variants (e.g. p.*963*, p.*963fs*)
+        // VEP does not provide protein_start for splice_region_variant intronic positions,
+        // so we extract the position from the computed hgvspShort string
+        if (proteinPos == null &&
+            proteinChange != null &&
+            proteinChange.matches("p\\.\\*\\d+.*"))
         {
             proteinPos = this.extractProteinPos(proteinChange);
         }

--- a/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/ProteinPositionResolverTest.java
+++ b/service/src/test/java/org/cbioportal/genome_nexus/component/annotation/ProteinPositionResolverTest.java
@@ -92,4 +92,32 @@ public class ProteinPositionResolverTest
         assertEquals("Protein end position should be derived from protein change for splice sites",
             proteinPos.getEnd(), new Integer(307));
     }
+
+    @Test
+    public void resolveProteinChangeForStopCodonPosition()
+    {
+        VariantAnnotation annotation = new VariantAnnotation();
+        annotation.setVariantId("7:g.116411872_116411900del");
+
+        // VEP provides no protein_start for splice_region_variant intronic positions
+        TranscriptConsequence transcriptNoProteinPos = new TranscriptConsequence();
+
+        Mockito.when(this.proteinChangeResolver.resolveHgvspShort(annotation, transcriptNoProteinPos)).thenReturn("p.*963*");
+
+        IntegerRange proteinPos = proteinPositionResolver.resolve(annotation, transcriptNoProteinPos);
+
+        assertEquals("Protein start position should be extracted from p.*963* hgvspShort",
+            proteinPos.getStart(), new Integer(963));
+
+        assertEquals("Protein end position should be extracted from p.*963* hgvspShort",
+            proteinPos.getEnd(), new Integer(963));
+
+        // frameshift variant of same pattern
+        Mockito.when(this.proteinChangeResolver.resolveHgvspShort(annotation, transcriptNoProteinPos)).thenReturn("p.*963fs*");
+
+        proteinPos = proteinPositionResolver.resolve(annotation, transcriptNoProteinPos);
+
+        assertEquals("Protein start position should be extracted from p.*963fs* hgvspShort",
+            proteinPos.getStart(), new Integer(963));
+    }
 }


### PR DESCRIPTION
#### Problem:

  For splice_region_variant intronic variants (e.g. MET chr7:116411872-116411900del), Genome Nexus computes hgvspShort as p.*963* — but returns proteinPosition as null. This is
  because VEP does not provide protein_start for purely intronic positions, and the existing fallback logic in ProteinPositionResolver only handled two patterns: dup and x (for
  p.X{N}_splice). The p.*{N}* pattern was missed.

  As a result, the annotation pipeline received a null proteinPosition from the server and left the Protein_position MAF column empty.

  Note: splice_acceptor_variant / splice_donor_variant are unaffected — VEP provides protein_start for those because they carry coding_sequence_variant in their consequence terms.

  #### Root cause:

  ProteinPositionResolver.resolve() had no case for the p.*{N}* / p.*{N}fs* pattern. The extractProteinPos() helper already handles it correctly (it uses
  Numerical.extractPositiveIntegers), it just wasn't being called.

  #### Fix:

  Added a new special case in ProteinPositionResolver.resolve() — when hgvspShort matches p.*\d+.* and no position was resolved from the other cases or from VEP, extract the protein
   position from the hgvspShort string directly.